### PR TITLE
fix: shorten MCP registry description to the 100-char limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@
 
 * pin release-please initial version to 0.1.0 ([491e60a](https://github.com/BeppeTemp/cartographer/commit/491e60ae86c622e9282626de18b3e34e62db64e4))
 
-## Changelog
-
 > Public versioning starts at v0.1.0. Earlier version numbers (the v2.x line)
 > belonged to the internal pre-open-source development history and were retired
 > when versioning was reset to reflect the project's beta status

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.beppetemp/cartographer",
   "title": "Cartographer",
-  "description": "MCP governance server for agent-maintained knowledge bases: OKF concepts, git-backed writes, search, lint and provisioning.",
+  "description": "Governance MCP server for agent-maintained knowledge bases (OKF): git-backed writes, search, lint.",
   "repository": {
     "url": "https://github.com/BeppeTemp/cartographer",
     "source": "github"


### PR DESCRIPTION
The v0.1.0 release pipeline succeeded except for the `mcp-registry` job: the registry rejected the publish with a 422 because `server.json`'s `description` was 122 characters (limit: 100). Shortened to 98 chars. Re-running the job wouldn't help — it checks out the tag — so this lands on `main` and the next release (v0.1.1) will carry the first registry publish.

Also removes a stray `## Changelog` heading release-please left when prepending the 0.1.0 entry above the reset note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7YiXF11C4zdbFdBxzV61t

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7YiXF11C4zdbFdBxzV61t)_