### PR TITLE
fix: match MCP registry server name casing to the GitHub account

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ COPY --from=dist /dist /
 # Final stage (default): server runtime image.
 FROM alpine:3.21
 # Ownership verification for the MCP Registry (must match server.json's name).
-LABEL io.modelcontextprotocol.server.name="io.github.beppetemp/cartographer"
+LABEL io.modelcontextprotocol.server.name="io.github.BeppeTemp/cartographer"
 RUN apk add --no-cache git sops age openssh-client
 COPY --from=builder /cartographer /usr/local/bin/cartographer
 RUN adduser -D -h /home/cartographer cartographer

--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.beppetemp/cartographer",
+  "name": "io.github.BeppeTemp/cartographer",
   "title": "Cartographer",
   "description": "Governance MCP server for agent-maintained knowledge bases (OKF): git-backed writes, search, lint.",
   "repository": {


### PR DESCRIPTION
Second and last blocker for the registry publish: v0.1.1 got past the description-length 422 but hit a 403 — GitHub OIDC authorizes `io.github.BeppeTemp/*` (exact account casing) while `server.json` declared `io.github.beppetemp/cartographer`. Aligns the `name` in `server.json` and the `io.modelcontextprotocol.server.name` LABEL in the Dockerfile. The `ghcr.io/beppetemp/cartographer` image identifier stays lowercase (OCI requirement).

The next release (v0.1.2) should complete the first registry publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7YiXF11C4zdbFdBxzV61t

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7YiXF11C4zdbFdBxzV61t)_