### PR TITLE
chore: mark GitHub releases as pre-release until 1.0 (D82)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,9 @@ contributions — CI runs `make vet && make test`.
   write is the changelog line users will read.
 - The project is in **beta** (pre-1.0): breaking changes bump the **minor**
   version (release-please `bump-minor-pre-major`), so any 0.x minor release
-  may break compatibility. 1.0.0 will be tagged once the MCP tool surface and
-  the CLI stabilize.
+  may break compatibility. GitHub releases are marked as **pre-releases**
+  until 1.0.0, which will be tagged once the MCP tool surface and the CLI
+  stabilize.
 - **Documentation moves with the code in the same PR** — it's a project rule:
   any change touching interfaces, behavior, configuration, or architecture
   updates the corresponding `docs/` pages (see `docs/index.md` §Maintenance

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 > MCP governance server in **Go** for the *Agentic Wiki* — knowledge that **composes**, not that you query.
 
 [![CI](https://github.com/BeppeTemp/cartographer/actions/workflows/ci.yml/badge.svg)](https://github.com/BeppeTemp/cartographer/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/BeppeTemp/cartographer)](https://github.com/BeppeTemp/cartographer/releases/latest)
+[![Release](https://img.shields.io/github/v/release/BeppeTemp/cartographer?include_prereleases)](https://github.com/BeppeTemp/cartographer/releases)
 [![Go Report Card](https://goreportcard.com/badge/github.com/BeppeTemp/cartographer)](https://goreportcard.com/report/github.com/BeppeTemp/cartographer)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Go](https://img.shields.io/badge/Go-1.26+-00ADD8?logo=go)](https://go.dev/)

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1373,6 +1373,16 @@ b) **Plans move from `docs/plans/` files to GitHub issues** (label `plan`, templ
 
 **Rationale.** Issues give the handoff artifact first-class linkage to the PR, an archive that survives consumption, zero service commits in the public history, and readability from any agent with `gh` — the file-based flow had none of these once `main` became protected.
 
+## D82 — Beta marking via GitHub pre-release flag, not `-beta` version suffix
+
+**Status: implemented (2026-07-20).**
+
+**Context.** Until 1.0 the beta phase should be visible on the releases themselves, not only in the README disclaimer. Candidate mechanisms: a `-beta` semver suffix in the tags, or the GitHub pre-release flag on the releases.
+
+**Decision.** `"prerelease": true` in `release-please-config.json`: every GitHub release is marked **Pre-release** until 1.0, tags stay plain `v0.x.y`. The already-published `v0.1.x` releases were retro-marked for consistency (operator action). The README release badge uses `?include_prereleases` and links to `/releases` (with every release a pre-release, `releases/latest` would freeze on the last stable one). At 1.0.0 the flag is removed and the badge reverted.
+
+**Rationale.** A `-beta` suffix in the tags would re-break `go install @latest` (Go considers prereleases only when no release version exists, and stable `v0.1.x` tags already do — the exact invisibility D80 fixed) and is redundant with 0.x semantics, which already declare instability. The pre-release flag gives the visible marker at zero tooling cost: Go reads tags, not GitHub release metadata.
+
 ## Known deviations from the specification
 
 - TUI configurator: implemented (D35), opt-in via `--tui`.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "go",
   "include-component-in-tag": false,
+  "prerelease": true,
   "bump-minor-pre-major": true,
   "initial-version": "0.1.0",
   "packages": {


### PR DESCRIPTION
Makes the beta phase visible on the releases themselves without touching the version tags.

- `"prerelease": true` in `release-please-config.json`: every release is marked **Pre-release** on GitHub until 1.0; tags stay plain `v0.x.y`, so `go install @latest` keeps working (a `-beta` tag suffix would re-introduce the invisibility D80 fixed, since Go ignores prereleases once stable `v0.1.x` tags exist).
- README release badge switched to `?include_prereleases` and linked to `/releases` (`releases/latest` freezes once every release is a pre-release).
- Pre-1.0 policy in `CONTRIBUTING.md` updated; **D82** entry with the rationale.
- Existing `v0.1.x` releases retro-marked as pre-release (operator action, outside this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)