### PR TITLE
docs: multi-plan programs — cross-plan order and amendment rules in plan workflow

### DIFF
--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -21,6 +21,11 @@ Claude-side glue.
    structure, then:
    `gh issue create --title "Plan: <title> (D<n>)" --label plan --body-file <file>`.
 4. Apply the self-sufficiency test from `CONTRIBUTING.md` before submitting.
+5. One analysis, several plans → every issue states the cross-plan execution
+   order and which sibling plans touch the same files (those land strictly
+   sequentially, never in parallel). Amend a plan by editing the issue body
+   while nothing is implemented yet; once implementation starts, amend via
+   comments only.
 
 ## Consuming a plan (implementing session)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,10 @@ only the issue and the repo must be able to implement without asking questions.
 - Expected errors and edge cases are listed with the desired behavior.
 - **No code in the plan**: exact semantics plus real `file:line` pointers,
   derived from the code before writing — not paraphrases of it.
+- A single analysis may yield **several plan issues**: each one states the
+  cross-plan execution order and which sibling plans touch the same files
+  (those land sequentially, never in parallel). Amendments made before
+  implementation starts go in the issue body; later ones in comments.
 
 The implementation PR references the issue (`Closes #<n>`), executes the work
 packages in order (`make vet && make test` green after each), updates the docs


### PR DESCRIPTION
Lesson from the D83–D91 planning session: when one analysis yields several plan issues, the ordering and same-file constraints must live in the issues themselves, and there must be a rule for where amendments go.

- `CONTRIBUTING.md` §Plan issues: new bullet — each issue in a multi-plan program states the cross-plan execution order and which sibling plans touch the same files (sequential landing); amendments before implementation → issue body, after → comments.
- `.claude/skills/plan/SKILL.md`: same rule as step 5 of "Writing a plan" (Claude-side glue).

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)