### PR TITLE
fix(okf): ignore headings inside code fences

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1443,6 +1443,22 @@ it; `/ready` gives `readinessProbe` a signal that actually reflects usability. P
 the gap between what D53 already documented as "the name used everywhere" and what the HTTP layer
 actually accepted.
 
+## D87 — Fence-aware heading detection: shared line iterator for `ListHeadings`/`ExtractSection`/`SectionHashes`
+
+**Status: implemented (2026-07-23).**
+
+**Context.** `ListHeadings`, `ExtractSection` and `SectionHashes` (`internal/okf/okf.go`) each scanned body lines independently, calling `parseHeading` with no code-fence state. A `#` line inside a fenced code block (e.g. a bash comment `# Usage: ...` inside a ```` ```bash ```` fence) was parsed as a real heading, surfacing as a spurious entry in the `concept_read` outline (`internal/mcpserver/tools_read.go`) and potentially splitting sections/hashes mid-fence.
+
+**Decision.** A shared helper (`headingEligibleLines`) computes, once per body, which lines are eligible for heading parsing; all three functions consult it before calling `parseHeading`, so they stay mutually consistent by construction. Fence rules (pragmatic CommonMark subset, not the full spec):
+
+- a line whose trimmed content starts with ` ``` ` or `~~~` opens a fence (an info string after the marker, e.g. `bash`, is ignored);
+- the fence closes on the next line whose trimmed content starts with the **same** marker; markers do not cross-close (a ` ``` ` fence is not closed by `~~~`);
+- an **unclosed fence extends to the end of the document** — the rest of the body is treated as fenced content, not as a fallback to normal heading parsing. This is a deliberate simplification: a malformed/unclosed fence is far more likely in a document that also has trailing garbage than one that "resumes" cleanly, and erring toward under-detection (fewer headings) is safer for section extraction than guessing where the fence should have closed.
+
+**Ripple.** The D78 size-guard outline counts headings; documents with fenced `#` lines now report a smaller (correct) heading count — the changed count is the fix, not a regression.
+
+**Rationale.** A single shared iterator, rather than three ad-hoc fence-aware loops, is what actually guarantees the outline/section/hash consumers agree — duplicating fence-tracking logic three times would only move the risk of drift from "no fence awareness" to "three subtly different fence-aware implementations."
+
 ## Known deviations from the specification
 
 - TUI configurator: implemented (D35), opt-in via `--tui`.

--- a/internal/okf/okf.go
+++ b/internal/okf/okf.go
@@ -128,9 +128,14 @@ func ExtractSection(body string, heading string) (string, bool) {
 		targetTitle = strings.TrimSpace(heading[targetLevel:])
 	}
 
+	headingEligible := headingEligibleLines(lines)
+
 	startIdx := -1
 	foundLevel := 0
 	for i, line := range lines {
+		if !headingEligible[i] {
+			continue
+		}
 		level, title := parseHeading(line)
 		if level == 0 {
 			continue
@@ -183,8 +188,13 @@ func ListHeadings(body string) []Heading {
 		title    string
 		startIdx int // index into lines right after the heading line
 	}
+	headingEligible := headingEligibleLines(lines)
+
 	var raws []raw
 	for i, line := range lines {
+		if !headingEligible[i] {
+			continue
+		}
 		level, title := parseHeading(line)
 		if level == 0 {
 			continue
@@ -209,6 +219,49 @@ func ListHeadings(body string) []Heading {
 		})
 	}
 	return headings
+}
+
+// fenceMarkers are the recognized code-fence delimiters (pragmatic CommonMark subset).
+var fenceMarkers = [...]string{"```", "~~~"}
+
+// headingEligibleLines returns, for each line, whether it may be parsed as a heading.
+// Shared by ListHeadings, ExtractSection and SectionHashes so the three consumers agree
+// on section boundaries. A line whose trimmed content starts with one of fenceMarkers
+// toggles fence state: the opening line (which may carry an info string) and every line
+// up to and including the matching closing fence (same marker) are ineligible. An
+// unclosed fence extends to the end of the document — the rest of the body is treated
+// as fenced content rather than falling back to heading parsing.
+func headingEligibleLines(lines []string) []bool {
+	eligible := make([]bool, len(lines))
+	inFence := false
+	fenceMarker := ""
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if inFence {
+			if strings.HasPrefix(trimmed, fenceMarker) {
+				inFence = false
+			}
+			continue
+		}
+		if marker := fenceOpenMarker(trimmed); marker != "" {
+			inFence = true
+			fenceMarker = marker
+			continue
+		}
+		eligible[i] = true
+	}
+	return eligible
+}
+
+// fenceOpenMarker returns the fence marker ("```" or "~~~") if the trimmed line opens
+// a code fence, or "" otherwise. The remainder of the line (info string) is ignored.
+func fenceOpenMarker(trimmed string) string {
+	for _, m := range fenceMarkers {
+		if strings.HasPrefix(trimmed, m) {
+			return m
+		}
+	}
+	return ""
 }
 
 // parseHeading parses a markdown line and returns the heading level (1-6) and title.
@@ -289,8 +342,13 @@ func SectionHashes(content string) map[string]string {
 		headIdx int // index of the heading line in lines
 	}
 
+	headingEligible := headingEligibleLines(lines)
+
 	var sections []section
 	for i, line := range lines {
+		if !headingEligible[i] {
+			continue
+		}
 		level, title := parseHeading(line)
 		if level == 1 || level == 2 {
 			sections = append(sections, section{title: title, level: level, headIdx: i})

--- a/internal/okf/okf_test.go
+++ b/internal/okf/okf_test.go
@@ -248,6 +248,108 @@ func TestListHeadings_Dimensioni(t *testing.T) {
 	}
 }
 
+// --- fence-aware heading detection (D87) ---
+
+// fencedFixtureBody reproduces the reported case (bash comments inside a backtick
+// fence) plus a ~~~ fence, an info string on the opening fence, and a heading
+// immediately after a closing fence. Used to assert ListHeadings, ExtractSection
+// and SectionHashes all agree on the same section boundaries.
+const fencedFixtureBody = "# Intro\n" +
+	"Testo introduttivo.\n" +
+	"```bash\n" +
+	"#!/usr/bin/env bash\n" +
+	"# Usage: foo.sh\n" +
+	"echo hi\n" +
+	"```\n" +
+	"## After fence\n" +
+	"Testo dopo la fence.\n" +
+	"~~~\n" +
+	"# not a heading either\n" +
+	"~~~\n" +
+	"# Final\n" +
+	"Fine."
+
+func TestListHeadings_IgnoraHeadingDentroFence(t *testing.T) {
+	got := ListHeadings(fencedFixtureBody)
+	if len(got) != 3 {
+		t.Fatalf("ListHeadings: expected 3 headings (fence lines ignored), got %d: %+v", len(got), got)
+	}
+	if got[0].Level != 1 || got[0].Title != "Intro" {
+		t.Errorf("ListHeadings[0]: got %+v", got[0])
+	}
+	if got[1].Level != 2 || got[1].Title != "After fence" {
+		t.Errorf("ListHeadings[1]: got %+v", got[1])
+	}
+	if got[2].Level != 1 || got[2].Title != "Final" {
+		t.Errorf("ListHeadings[2]: got %+v", got[2])
+	}
+}
+
+func TestExtractSection_IgnoraHeadingDentroFence(t *testing.T) {
+	got, ok := ExtractSection(fencedFixtureBody, "# Intro")
+	if !ok {
+		t.Fatal("ExtractSection: heading not found")
+	}
+	if !strings.Contains(got, "#!/usr/bin/env bash") || !strings.Contains(got, "# Usage: foo.sh") {
+		t.Fatal("ExtractSection: fence content must be preserved verbatim inside the section")
+	}
+	if strings.Contains(got, "Fine.") {
+		t.Fatal("ExtractSection: must stop before the next top-level heading (# Final)")
+	}
+}
+
+func TestSectionHashes_IgnoraHeadingDentroFence(t *testing.T) {
+	hashes := SectionHashes(fencedFixtureBody)
+	if _, ok := hashes["Usage: foo.sh"]; ok {
+		t.Fatal("SectionHashes: fenced '#' line must not be treated as a section heading")
+	}
+	if _, ok := hashes["Intro"]; !ok {
+		t.Fatal("SectionHashes: expected 'Intro' section")
+	}
+	if _, ok := hashes["After fence"]; !ok {
+		t.Fatal("SectionHashes: expected 'After fence' section")
+	}
+	if _, ok := hashes["Final"]; !ok {
+		t.Fatal("SectionHashes: expected 'Final' section")
+	}
+}
+
+func TestFenceAware_ConsumatoriConcordano(t *testing.T) {
+	headings := ListHeadings(fencedFixtureBody)
+	for _, h := range headings {
+		heading := strings.Repeat("#", h.Level) + " " + h.Title
+		section, ok := ExtractSection(fencedFixtureBody, heading)
+		if !ok {
+			t.Fatalf("ExtractSection: heading %q not found, but ListHeadings returned it", heading)
+		}
+		if h.Bytes != len(section) {
+			t.Errorf("mismatch for %q: ListHeadings.Bytes=%d, len(ExtractSection)=%d", heading, h.Bytes, len(section))
+		}
+	}
+}
+
+func TestListHeadings_FenceNonChiusa(t *testing.T) {
+	body := "# Heading\n```\n# Not a heading\nStill inside the fence.\n"
+	got := ListHeadings(body)
+	if len(got) != 1 {
+		t.Fatalf("ListHeadings: expected 1 heading (unclosed fence swallows the rest), got %d: %+v", len(got), got)
+	}
+	if got[0].Title != "Heading" {
+		t.Errorf("ListHeadings[0]: got %+v", got[0])
+	}
+}
+
+func TestListHeadings_HeadingSubitoDopoFenceChiusa(t *testing.T) {
+	body := "```\ncode\n```\n# Right After\nBody."
+	got := ListHeadings(body)
+	if len(got) != 1 {
+		t.Fatalf("ListHeadings: expected 1 heading, got %d: %+v", len(got), got)
+	}
+	if got[0].Level != 1 || got[0].Title != "Right After" {
+		t.Errorf("ListHeadings[0]: got %+v", got[0])
+	}
+}
+
 func TestListHeadings_BodySenzaHeading(t *testing.T) {
 	got := ListHeadings("Solo testo, nessun heading.\nSeconda riga.")
 	if len(got) != 0 {


### PR DESCRIPTION
## Summary
- `ListHeadings`, `ExtractSection` and `SectionHashes` (`internal/okf/okf.go`) now share a single `headingEligibleLines` line-iterator that tracks fenced code blocks (``` and ~~~, info string on the opening fence ignored, unclosed fence swallows the rest of the document), so `#` lines inside a fence (e.g. bash comments) are no longer misparsed as headings.
- Added `docs/decisions.md` D87 documenting the fence rules and the unclosed-fence choice.
- Tests: fixtures covering backtick fences with bash comments, `~~~` fences, info strings, unclosed fences, and a heading immediately after a closing fence; asserts the three consumers agree on section boundaries for the same fixtures.

## Test plan
- [x] `make vet` → exit 0
- [x] `make test` → exit 0 (all packages, including new `internal/okf` fence-aware tests)

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)