### PR TITLE
fix(service): create data dir on install, tolerate missing data dir, stable plist path

### DIFF
--- a/cmd/cartographer/main_test.go
+++ b/cmd/cartographer/main_test.go
@@ -49,10 +49,22 @@ func TestDiscoverKBPaths(t *testing.T) {
 	}
 }
 
-func TestDiscoverKBPathsNonexistent(t *testing.T) {
-	_, err := discoverKBPaths("/nonexistent/path/that/does/not/exist")
-	if err == nil {
-		t.Fatal("expected error for nonexistent directory, got nil")
+// TestDiscoverKBPathsMissingDirCreated covers the D83 fix: a missing data
+// dir must not fail server startup (launchd install races data dir
+// creation with the first serve, and a removed data dir must not
+// crash-loop the service). It is created and treated as empty.
+func TestDiscoverKBPathsMissingDirCreated(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "does-not-exist-yet")
+
+	got, err := discoverKBPaths(base)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty result, got %v", got)
+	}
+	if info, statErr := os.Stat(base); statErr != nil || !info.IsDir() {
+		t.Fatalf("expected data dir to be created at %q, stat: %v", base, statErr)
 	}
 }
 

--- a/cmd/cartographer/serve.go
+++ b/cmd/cartographer/serve.go
@@ -456,9 +456,19 @@ func resolveAuth(authCfg config.AuthConfig) (bool, error) {
 	}
 }
 
-// discoverKBPaths scans dataDir and returns the paths of its direct subdirectories (dotfiles excluded).
+// discoverKBPaths scans dataDir and returns the paths of its direct
+// subdirectories (dotfiles excluded). A missing dataDir is tolerated: it is
+// created and treated as empty (0 KB, matching D73's "empty data dir" case)
+// rather than failing the whole server startup.
 func discoverKBPaths(dataDir string) ([]string, error) {
 	entries, err := os.ReadDir(dataDir)
+	if os.IsNotExist(err) {
+		if mkErr := os.MkdirAll(dataDir, 0o755); mkErr != nil {
+			return nil, fmt.Errorf("create missing data dir %q: %w", dataDir, mkErr)
+		}
+		fmt.Fprintf(os.Stderr, "data dir %q did not exist, created\n", dataDir)
+		return nil, nil
+	}
 	if err != nil {
 		return nil, fmt.Errorf("read dir %q: %w", dataDir, err)
 	}

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1383,6 +1383,39 @@ b) **Plans move from `docs/plans/` files to GitHub issues** (label `plan`, templ
 
 **Rationale.** A `-beta` suffix in the tags would re-break `go install @latest` (Go considers prereleases only when no release version exists, and stable `v0.1.x` tags already do — the exact invisibility D80 fixed) and is redundant with 0.x semantics, which already declare instability. The pre-release flag gives the visible marker at zero tooling cost: Go reads tags, not GitHub release metadata.
 
+## D83 — Service install robustness: create the data dir, tolerate its absence, stable plist binary path
+
+**Status: implemented (2026-07-23).**
+
+**Context.** `service install` (D73) wrote a config pointing at `~/cartographer-data` but never created that
+directory, and `serve`'s `discoverKBPaths` (`cmd/cartographer/serve.go`) called `os.ReadDir` on it unconditionally,
+`log.Fatalf`-ing when the dir was missing — a fresh `brew install` produced a launchd `KeepAlive` crash-loop.
+Separately, the plist embedded the `filepath.EvalSymlinks`-resolved binary path, i.e. the **versioned** Homebrew
+Caskroom path (`/opt/homebrew/Caskroom/cartographer/<ver>/…`): every `brew upgrade` removed that path and broke the
+service until `service install` was re-run.
+
+**Decision.**
+
+a) **`Manager.Install`** (`internal/service/manager.go`) now `os.MkdirAll`s the data dir (the value from a
+freshly-generated config, or read back from an already-existing one) right after resolving the config path, and
+logs `created <dir>` to stderr when it does.
+
+b) **`discoverKBPaths`** (`cmd/cartographer/serve.go`) treats a missing data dir like an empty one: on
+`os.IsNotExist` it creates the dir, logs to stderr, and returns an empty slice instead of failing startup. The
+existing `log.Fatalf` at the call site still fires for other errors (permissions, not-a-directory).
+
+c) **The plist/unit binary path** (`internal/service/paths.go`, `resolveStableBinPath`) is the as-invoked
+`os.Executable()` path, no longer `EvalSymlinks`-resolved — except that a stable Homebrew symlink
+(`/opt/homebrew/bin/cartographer` or `/usr/local/bin/cartographer`) is preferred over it when the symlink resolves
+to the same file, so the recorded path survives `brew upgrade`. `Manager.Status` uses the same resolution so it
+reports the configured path.
+
+**Rationale.** All three are the same invariant from different angles: *install must never produce a non-bootable
+state, and serve must treat a missing data dir exactly like an empty one.* This **amends D73's assumption** that
+the data dir exists once the config is written — D73 correctly specified the empty-dir behavior (0 KB, `/health`
+up) but implicitly assumed someone had created the directory; D83 makes that explicit and enforced at both ends
+(install creates it, serve tolerates its absence either way).
+
 ## Known deviations from the specification
 
 - TUI configurator: implemented (D35), opt-in via `--tui`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -177,10 +177,11 @@ cartographer service uninstall               # removes the service; config and d
 
 `service install` (idempotent: re-running it rewrites the plist/unit and restarts):
 - generates `~/.config/cartographer/server.yaml` **only if it doesn't exist** (`--config` for a different path; `--data`, default `~/cartographer-data`, and `--http`, default `127.0.0.1:8080`, are only used at generation time — if the config already exists they are ignored with a warning: edit the file and run `service restart`);
-- macOS: LaunchAgent `~/Library/LaunchAgents/com.cartographer.serve.plist` (`KeepAlive`, logging to `~/Library/Logs/cartographer/server.log`);
+- creates the configured data dir if it doesn't exist yet (D83), so a fresh install never leaves `serve` pointed at a missing directory;
+- macOS: LaunchAgent `~/Library/LaunchAgents/com.cartographer.serve.plist` (`KeepAlive`, logging to `~/Library/Logs/cartographer/server.log`). The plist's binary path prefers a stable Homebrew symlink (`/opt/homebrew/bin/cartographer` or `/usr/local/bin/cartographer`) over the versioned Caskroom path, so it survives `brew upgrade` without a re-install (D83);
 - Linux: systemd user unit `~/.config/systemd/user/cartographer.service` (log via `journalctl --user -u cartographer`; on a headless host, `loginctl enable-linger <user>` is needed for the service to survive logout).
 
-Binds to **loopback** by default (`127.0.0.1:8080`) → auth stays in auto-off mode without exposing anything on the network. With an empty data dir the server starts with 0 KBs (`/health` is still up): create a subfolder per KB (or add `kbs:` entries to clone remotes, §Bootstrapping a KB) and `service restart`.
+Binds to **loopback** by default (`127.0.0.1:8080`) → auth stays in auto-off mode without exposing anything on the network. With an empty (or missing — D83: `serve` creates it and treats it as empty rather than failing) data dir the server starts with 0 KBs (`/health` is still up): create a subfolder per KB (or add `kbs:` entries to clone remotes, §Bootstrapping a KB) and `service restart`.
 
 `service status` uses systemctl-like exit codes: `0` running, `3` installed but stopped, `4` not installed — this is what lets `install.sh update` automatically restart only a running service (see §Client installation).
 

--- a/internal/service/manager.go
+++ b/internal/service/manager.go
@@ -85,9 +85,7 @@ func (m *Manager) Install(opts InstallOptions) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("service: resolve binary path: %w", err)
 	}
-	if resolved, err := filepath.EvalSymlinks(binPath); err == nil {
-		binPath = resolved
-	}
+	binPath = resolveStableBinPath(binPath)
 
 	configPath, err := opts.resolvedConfigPath()
 	if err != nil {
@@ -97,9 +95,13 @@ func (m *Manager) Install(opts InstallOptions) ([]string, error) {
 		return nil, fmt.Errorf("service: create config dir: %w", err)
 	}
 
+	dataDir := opts.DataDir
 	if _, err := os.Stat(configPath); err == nil {
 		if opts.DataExplicit || opts.HTTPExplicit {
 			warnings = append(warnings, fmt.Sprintf("config %s already exists; --data/--http are ignored (edit the file directly to change them)", configPath))
+		}
+		if cfg, cfgErr := config.Load(configPath); cfgErr == nil && cfg.Data != "" {
+			dataDir = cfg.Data
 		}
 	} else if os.IsNotExist(err) {
 		yamlData := DefaultServerYAML(opts.DataDir, opts.HTTPAddr)
@@ -108,6 +110,15 @@ func (m *Manager) Install(opts InstallOptions) ([]string, error) {
 		}
 	} else {
 		return nil, fmt.Errorf("service: stat config: %w", err)
+	}
+
+	if dataDir != "" {
+		if _, err := os.Stat(dataDir); os.IsNotExist(err) {
+			if err := os.MkdirAll(dataDir, 0o755); err != nil {
+				return nil, fmt.Errorf("service: create data dir: %w", err)
+			}
+			fmt.Fprintf(os.Stderr, "created %s\n", dataDir)
+		}
 	}
 
 	switch goos {
@@ -281,10 +292,7 @@ func (m *Manager) Status(configPath string) (Status, error) {
 		st.ConfigPath = p
 	}
 	if bin, err := osExecutable(); err == nil {
-		if resolved, err := filepath.EvalSymlinks(bin); err == nil {
-			bin = resolved
-		}
-		st.BinPath = bin
+		st.BinPath = resolveStableBinPath(bin)
 	}
 
 	switch goos {

--- a/internal/service/paths.go
+++ b/internal/service/paths.go
@@ -13,6 +13,37 @@ var (
 	goos        = runtime.GOOS
 )
 
+// stableBinSymlinks lists the Homebrew-managed symlinks that stay stable
+// across `brew upgrade` (unlike the versioned Caskroom path the binary is
+// actually invoked from). Var so tests can point it at a fake layout.
+var stableBinSymlinks = []string{
+	"/opt/homebrew/bin/cartographer",
+	"/usr/local/bin/cartographer",
+}
+
+// resolveStableBinPath returns the path to record in the generated
+// plist/unit for the given as-invoked binary path. It never resolves
+// symlinks on binPath itself (a resolved Homebrew Caskroom path is
+// version-pinned and breaks on every `brew upgrade`). If one of
+// stableBinSymlinks exists and resolves to the same file as binPath, that
+// stable symlink is preferred; otherwise binPath is returned unchanged.
+func resolveStableBinPath(binPath string) string {
+	target, err := filepath.EvalSymlinks(binPath)
+	if err != nil {
+		target = binPath
+	}
+	for _, candidate := range stableBinSymlinks {
+		resolved, err := filepath.EvalSymlinks(candidate)
+		if err != nil {
+			continue
+		}
+		if resolved == target {
+			return candidate
+		}
+	}
+	return binPath
+}
+
 // ConfigPath returns the standard path of the server YAML config generated
 // and consumed by `cartographer service`: ~/.config/cartographer/server.yaml.
 func ConfigPath() (string, error) {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -155,8 +156,9 @@ func TestInstall_GeneratesConfigAndPlist_Darwin(t *testing.T) {
 	osExecutable = func() (string, error) { return binPath, nil }
 	t.Cleanup(func() { osExecutable = origExecutable })
 
+	dataDir := filepath.Join(home, "cartographer-data")
 	m, stub := newTestManager()
-	warnings, err := m.Install(InstallOptions{DataDir: "/data", HTTPAddr: "127.0.0.1:8080"})
+	warnings, err := m.Install(InstallOptions{DataDir: dataDir, HTTPAddr: "127.0.0.1:8080"})
 	if err != nil {
 		t.Fatalf("Install: %v", err)
 	}
@@ -169,8 +171,11 @@ func TestInstall_GeneratesConfigAndPlist_Darwin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("config not written: %v", err)
 	}
-	if !strings.Contains(string(data), `data: "/data"`) {
-		t.Errorf("config content = %q, want data: \"/data\"", data)
+	if !strings.Contains(string(data), `data: `+strconv.Quote(dataDir)) {
+		t.Errorf("config content = %q, want data: %s", data, strconv.Quote(dataDir))
+	}
+	if _, err := os.Stat(dataDir); err != nil {
+		t.Errorf("data dir not created: %v", err)
 	}
 
 	plistPath := filepath.Join(home, "Library", "LaunchAgents", "com.cartographer.serve.plist")
@@ -189,6 +194,59 @@ func TestInstall_GeneratesConfigAndPlist_Darwin(t *testing.T) {
 	}
 }
 
+// TestInstall_PrefersStableCaskroomSymlink covers the D83 fix: the plist
+// must record the stable Homebrew symlink, not the versioned Caskroom path
+// os.Executable() resolves to (which brew upgrade removes on every version
+// bump, breaking the service until `service install` is re-run).
+func TestInstall_PrefersStableCaskroomSymlink(t *testing.T) {
+	home := withTestHome(t, "darwin")
+
+	// Fake Caskroom layout: the real binary lives under a versioned dir,
+	// and a stable symlink (mirroring /opt/homebrew/bin/cartographer)
+	// points at it.
+	caskDir := filepath.Join(home, "Caskroom", "cartographer", "0.1.0")
+	if err := os.MkdirAll(caskDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realBin := filepath.Join(caskDir, "cartographer")
+	if err := os.WriteFile(realBin, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stableSymlink := filepath.Join(home, "bin", "cartographer")
+	if err := os.MkdirAll(filepath.Dir(stableSymlink), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realBin, stableSymlink); err != nil {
+		t.Fatal(err)
+	}
+
+	origSymlinks := stableBinSymlinks
+	stableBinSymlinks = []string{stableSymlink}
+	t.Cleanup(func() { stableBinSymlinks = origSymlinks })
+
+	origExecutable := osExecutable
+	// os.Executable() as invoked returns the versioned Caskroom path.
+	osExecutable = func() (string, error) { return realBin, nil }
+	t.Cleanup(func() { osExecutable = origExecutable })
+
+	m, _ := newTestManager()
+	if _, err := m.Install(InstallOptions{DataDir: filepath.Join(home, "data"), HTTPAddr: "127.0.0.1:8080"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "com.cartographer.serve.plist")
+	plist, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatalf("plist not written: %v", err)
+	}
+	if !strings.Contains(string(plist), stableSymlink) {
+		t.Errorf("plist = %q, want it to contain the stable symlink %q", plist, stableSymlink)
+	}
+	if strings.Contains(string(plist), realBin) {
+		t.Errorf("plist = %q, must not contain the versioned Caskroom path %q", plist, realBin)
+	}
+}
+
 func TestInstall_ExistingConfigNotOverwritten_WarnsOnExplicitFlags(t *testing.T) {
 	home := withTestHome(t, "darwin")
 	binDir := t.TempDir()
@@ -200,13 +258,14 @@ func TestInstall_ExistingConfigNotOverwritten_WarnsOnExplicitFlags(t *testing.T)
 
 	configPath := filepath.Join(home, ".config", "cartographer", "server.yaml")
 	os.MkdirAll(filepath.Dir(configPath), 0o755)
-	existing := "http: \":9999\"\ndata: /custom\n"
+	customDataDir := filepath.Join(home, "custom")
+	existing := "http: \":9999\"\ndata: " + customDataDir + "\n"
 	if err := os.WriteFile(configPath, []byte(existing), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	m, _ := newTestManager()
-	warnings, err := m.Install(InstallOptions{DataDir: "/data", HTTPAddr: "127.0.0.1:8080", DataExplicit: true})
+	warnings, err := m.Install(InstallOptions{DataDir: filepath.Join(home, "data"), HTTPAddr: "127.0.0.1:8080", DataExplicit: true})
 	if err != nil {
 		t.Fatalf("Install: %v", err)
 	}
@@ -221,10 +280,13 @@ func TestInstall_ExistingConfigNotOverwritten_WarnsOnExplicitFlags(t *testing.T)
 	if string(got) != existing {
 		t.Errorf("existing config was modified: %q", got)
 	}
+	if _, err := os.Stat(customDataDir); err != nil {
+		t.Errorf("existing config's data dir not created: %v", err)
+	}
 }
 
 func TestInstall_Idempotent(t *testing.T) {
-	withTestHome(t, "darwin")
+	home := withTestHome(t, "darwin")
 	binDir := t.TempDir()
 	binPath := filepath.Join(binDir, "cartographer")
 	os.WriteFile(binPath, []byte("x"), 0o755)
@@ -233,7 +295,7 @@ func TestInstall_Idempotent(t *testing.T) {
 	t.Cleanup(func() { osExecutable = origExecutable })
 
 	m, _ := newTestManager()
-	opts := InstallOptions{DataDir: "/data", HTTPAddr: "127.0.0.1:8080"}
+	opts := InstallOptions{DataDir: filepath.Join(home, "data"), HTTPAddr: "127.0.0.1:8080"}
 	if _, err := m.Install(opts); err != nil {
 		t.Fatalf("first Install: %v", err)
 	}


### PR DESCRIPTION
## Summary

- **WP1**: `Manager.Install` now `os.MkdirAll`s the configured data dir (freshly generated or read back from an existing config) right after resolving the config path, logging `created <dir>` to stderr.
- **WP2**: `discoverKBPaths` tolerates a missing data dir: on `os.IsNotExist` it creates the dir, logs to stderr, and returns an empty slice instead of `log.Fatalf`-ing `serve` (which crash-loops the launchd `KeepAlive` job on a fresh install).
- **WP3**: the plist/unit binary path is the as-invoked `os.Executable()` path (no longer `EvalSymlinks`-resolved to the versioned Homebrew Caskroom path), preferring a stable symlink (`/opt/homebrew/bin/cartographer` or `/usr/local/bin/cartographer`) when it resolves to the same file, so the service survives `brew upgrade`. `Manager.Status` uses the same resolution.

Docs updated in the same PR: `docs/deployment.md` (§native local service) and a new `D83` entry in `docs/decisions.md` (amends D73's assumption that the data dir exists).

## Test plan

- [x] `make vet && make test` green
- [x] New/updated tests: `TestInstall_GeneratesConfigAndPlist_Darwin` (asserts data dir created), `TestInstall_ExistingConfigNotOverwritten_WarnsOnExplicitFlags` (asserts existing config's data dir created), `TestInstall_PrefersStableCaskroomSymlink` (fake Caskroom layout, plist contains the symlink not the versioned path), `TestDiscoverKBPathsMissingDirCreated` (missing dir created, empty result, no error)

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)