### PR TITLE
feat(http): readiness signal and per-KB path routing

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1416,6 +1416,33 @@ the data dir exists once the config is written — D73 correctly specified the e
 up) but implicitly assumed someone had created the directory; D83 makes that explicit and enforced at both ends
 (install creates it, serve tolerates its absence either way).
 
+## D84 — Readiness signal and per-KB path routing
+
+**Status: implemented (2026-07-23).**
+
+**Context.** Follow-up of D73's "0 KBs, `/health` active" attached choice: `/health` always returns
+`status:"ok"`, even with 0 KBs mounted, while the functional endpoint 400s (`kb parameter required`
+with no `?kb=` and more than one KB, or zero). No liveness/readiness distinction — agents and
+`connect` see a "healthy" server that is unusable. Separately, `/mcp/<name>` (implied by `kbs[].name`
+as "the name used everywhere", D53) was probed by a real user and not implemented: bare `/mcp`
+auto-routes only with exactly 1 KB, `?kb=` works, any other path 404s.
+
+**Decision.**
+- **WP1 — path routing.** `MultiKBServer.Handler` recognizes `/mcp/<name>` alongside the existing
+  bare `/mcp` (single-KB auto-route) and `/mcp?kb=<name>`. Unknown name → `404 unknown kb`. If both
+  the path and `?kb=` are present and name different KBs → `400 conflicting kb selection` (explicit
+  over silent precedence).
+- **WP2 — readiness.** `/health` (single-KB and MultiKB) gains `ready: <bool>` (single-KB: always
+  `true`; MultiKB: `len(kbs) > 0`); `status` stays `"ok"` unconditionally — readiness is additive,
+  it must never change liveness semantics for existing probes. New `/ready` endpoint on both
+  handlers: `200 {"ready":true}` / `503 {"ready":false,"kbs":0}`.
+
+**Rationale.** Keeping `/health` as pure liveness (never fails from a KB-mounting issue) avoids
+turning a "no KBs mounted yet" state into a restart-loop on k8s if `livenessProbe` were pointed at
+it; `/ready` gives `readinessProbe` a signal that actually reflects usability. Path routing closes
+the gap between what D53 already documented as "the name used everywhere" and what the HTTP layer
+actually accepted.
+
 ## Known deviations from the specification
 
 - TUI configurator: implemented (D35), opt-in via `--tui`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -119,7 +119,7 @@ Deployment's `env:` become redundant and can be removed.
 
 **Explicit KB name, git token, and per-KB SOPS key by convention (D53)**: `kbs[].name` fixes the
 KB's name (overrides the name derived from remote/path) — it's the name used everywhere: the HTTP
-endpoint (`/mcp/<name>`), the token scope (`kb:<name>:r|rw`), the clone directory (`<data>/<name>`), and the two
+endpoint (`/mcp/<name>`, see below), the token scope (`kb:<name>:r|rw`), the clone directory (`<data>/<name>`), and the two
 conventions below. With an `http(s)://` remote, if the file
 `<git.token_dir>/<name>.token` exists (content: the token, trimmed), the server uses it as the HTTPS
 credential for clone/fetch/pull/push of that KB, injected via `credential.helper` in the
@@ -181,7 +181,7 @@ cartographer service uninstall               # removes the service; config and d
 - macOS: LaunchAgent `~/Library/LaunchAgents/com.cartographer.serve.plist` (`KeepAlive`, logging to `~/Library/Logs/cartographer/server.log`). The plist's binary path prefers a stable Homebrew symlink (`/opt/homebrew/bin/cartographer` or `/usr/local/bin/cartographer`) over the versioned Caskroom path, so it survives `brew upgrade` without a re-install (D83);
 - Linux: systemd user unit `~/.config/systemd/user/cartographer.service` (log via `journalctl --user -u cartographer`; on a headless host, `loginctl enable-linger <user>` is needed for the service to survive logout).
 
-Binds to **loopback** by default (`127.0.0.1:8080`) → auth stays in auto-off mode without exposing anything on the network. With an empty (or missing — D83: `serve` creates it and treats it as empty rather than failing) data dir the server starts with 0 KBs (`/health` is still up): create a subfolder per KB (or add `kbs:` entries to clone remotes, §Bootstrapping a KB) and `service restart`.
+Binds to **loopback** by default (`127.0.0.1:8080`) → auth stays in auto-off mode without exposing anything on the network. With an empty (or missing — D83: `serve` creates it and treats it as empty rather than failing) data dir the server starts with 0 KBs — `/health` is still up (liveness: `status:"ok"`) but `/ready` reports `503 {"ready":false}` (D84, §Observability): create a subfolder per KB (or add `kbs:` entries to clone remotes, §Bootstrapping a KB) and `service restart`.
 
 `service status` uses systemctl-like exit codes: `0` running, `3` installed but stopped, `4` not installed — this is what lets `install.sh update` automatically restart only a running service (see §Client installation).
 
@@ -244,6 +244,17 @@ This topology serves **multiple clients** (one or more agents connected via `car
 `cartographer sync`, all over HTTP): git remains the sync/backup layer between the server and the
 remote KBs, not a requirement for the client.
 
+### HTTP routing (D84)
+
+`MultiKBServer.Handler` (`internal/mcpserver/httpserver.go`) selects a KB three ways:
+- bare `/mcp` — auto-routes when exactly one KB is mounted (single-KB convenience);
+- `/mcp?kb=<name>` — explicit selection by query parameter;
+- `/mcp/<name>` — explicit selection by path (the form implied by `kbs[].name`, §Configuration above).
+
+If both `/mcp/<name>` and `?kb=` are present and disagree, the request is rejected with `400
+conflicting kb selection` rather than silently picking one; an unknown `<name>` (either form) is
+`404 unknown kb`.
+
 ### Runtime secrets
 
 Git credentials, MCP tokens, **and** the age/SOPS key (`SOPS_AGE_KEY_FILE`/`SOPS_AGE_KEY_CMD`, or an IAM role for KMS) are runtime secrets — **never** in the bundles. The same applies to the bootstrap SSH key (`git.ssh_key`): always from a mounted Secret/volume, never in the ConfigMap nor in the committed YAML file.
@@ -267,7 +278,14 @@ Metrics derived from the audit log:
 - p99 latency of `search`.
 - Tokens consumed per phase (ingest, judge, deep lint, embedding).
 
-**`/health`** and readiness endpoints. SLI/SLO and alert thresholds. Without these the system is a black box in production.
+**Liveness vs readiness (D84)**: `/health` is liveness — `status:"ok"` unconditionally (a probe that
+restarted the process on `status != "ok"` must never fire from a KB-mounting issue); it also carries
+a `ready: <bool>` field (single-KB server: always `true`; MultiKB: `len(kbs) > 0`) for callers that
+want both signals from one request. `/ready` is the dedicated readiness endpoint: `200
+{"ready":true}` once at least one KB is mounted, `503 {"ready":false,"kbs":0}` otherwise (e.g. a
+fresh local install with an empty data dir, §Cold start). Point k8s `livenessProbe` at `/health` and
+`readinessProbe` at `/ready`. SLI/SLO and alert thresholds beyond this are still open — without them
+the system is otherwise a black box in production.
 
 ## Backup and disaster recovery
 

--- a/docs/transport-auth.md
+++ b/docs/transport-auth.md
@@ -30,8 +30,8 @@ Format: `kb:<name>:<r|rw>`, space or `;` separated (`auth.ParseScopes`). Example
 
 `<name>` is the KB name: `kbs[].name` explicit if set (D53), otherwise the **basename**
 of the directory/repo (last path segment, `.git` suffix removed) — the same derivation used
-for `?kb=<name>` routing and for the clone directory. A token's scope must match
-this name exactly.
+for `?kb=<name>`/`/mcp/<name>` routing (D84, see [`deployment.md`](deployment.md) §HTTP routing)
+and for the clone directory. A token's scope must match this name exactly.
 
 **Token configuration with scope** (YAML `auth.tokens` or `CARTOGRAPHER_TOKENS`/`--tokens`):
 - YAML: each entry is `{token: ..., scopes: ["kb:homelab:rw", "kb:archivio-storico:r"]}` (`config.TokenSpec`); a bare scalar (string) remains supported for backward compatibility and means full access.
@@ -40,7 +40,7 @@ this name exactly.
 
 **Enforcement** (`internal/auth`, `internal/mcpserver/httpserver.go`):
 1. `auth.TokenStore` (created via `auth.NewScopedTokenStore`) maps the token hash → `[]auth.KBScope`. `TokenStore.Middleware` validates the bearer and injects the scopes into the context (`auth.ContextWithScopes`/`ScopesFromContext`).
-2. The HTTP guard (`mcpAccessGuard` in `httpserver.go`, downstream of the Middleware, for each KB mounted at `/mcp?kb=<name>`) reads the scopes from the context: **empty/nil scopes → always pass** (full access). Otherwise it peeks at the JSON-RPC body (`io.LimitReader` 2MB) to decide whether the request needs `r` or `rw`, then **always restores `r.Body`** (`io.NopCloser` over the read bytes) so the downstream handler re-reads it intact.
+2. The HTTP guard (`mcpAccessGuard` in `httpserver.go`, downstream of the Middleware, for each KB mounted whether reached via `/mcp?kb=<name>` or `/mcp/<name>`) reads the scopes from the context: **empty/nil scopes → always pass** (full access). Otherwise it peeks at the JSON-RPC body (`io.LimitReader` 2MB) to decide whether the request needs `r` or `rw`, then **always restores `r.Body`** (`io.NopCloser` over the read bytes) so the downstream handler re-reads it intact.
 3. r/rw decision: `method != "tools/call"` (initialize, tools/list, ping, ...) → requires `r`; `tools/call` → requires `rw` if the tool is not marked `ReadOnly` (see `ToolRequiresWrite` in `internal/mcpserver/readonly.go`), otherwise `r`. **Fail-closed**: unparsable body or unknown tool → requires `rw`.
 4. Final check with `auth.HasAccess(scopes, kbName, needWrite)`; if denied → `403 forbidden` (`auth.Forbidden`).
 

--- a/internal/mcpserver/httpserver.go
+++ b/internal/mcpserver/httpserver.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/BeppeTemp/cartographer/internal/auth"
 )
@@ -14,11 +15,13 @@ import (
 // HTTPHandler returns an http.Handler that serves MCP over Streamable HTTP.
 // POST /mcp accepts a JSON-RPC 2.0 request and returns a JSON response.
 // GET /mcp opens an SSE stream (optional, not yet implemented).
-// GET /health returns 200 OK with a JSON status body.
+// GET /health returns 200 OK with a JSON status body (liveness).
+// GET /ready returns readiness (single-KB server is always ready).
 func (s *Server) HTTPHandler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/mcp", s.handleMCP)
 	mux.HandleFunc("/health", s.handleHealth)
+	mux.HandleFunc("/ready", s.handleReady)
 	return mux
 }
 
@@ -153,8 +156,22 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	result := map[string]interface{}{
 		"status":  "ok",
 		"version": s.version,
+		"ready":   true, // a single-KB server always has its one KB mounted
 	}
 	json.NewEncoder(w).Encode(result)
+}
+
+// handleReady reports readiness: a single-KB server is always ready (its one
+// KB is mounted at construction time), unlike MultiKBServer where 0 KBs
+// mounted means not ready.
+func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{"ready": true})
 }
 
 // ListenAndServe starts the HTTP server on the given address (e.g. ":8080").
@@ -195,6 +212,7 @@ func (s *Server) FullHTTPHandler(oauthMetadata []byte) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/mcp", s.handleMCP)
 	mux.HandleFunc("/health", s.handleHealth)
+	mux.HandleFunc("/ready", s.handleReady)
 	if oauthMetadata != nil {
 		mux.HandleFunc("/.well-known/oauth-protected-resource", WellKnownHandler(oauthMetadata))
 	}
@@ -242,21 +260,41 @@ func (m *MultiKBServer) MountKB(name string, setupFn func(s *Server)) {
 	m.kbs = append(m.kbs, KBInfo{Name: name, Status: "normal"})
 }
 
-// Handler returns the HTTP handler that routes /mcp?kb=<name> to the correct KB server.
+// Handler returns the HTTP handler that routes MCP requests to the correct
+// KB server. Three ways to select a KB:
+//   - bare /mcp: auto-routes when exactly one KB is mounted;
+//   - /mcp?kb=<name>: explicit selection by query parameter;
+//   - /mcp/<name>: explicit selection by path.
+//
+// /mcp/<name> and ?kb= may not disagree: if both are present and name the
+// same KB, path wins as the explicit route; if they differ, the request is
+// rejected with 400 (conflicting kb selection) rather than silently
+// preferring one over the other.
 func (m *MultiKBServer) Handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/health":
+		switch {
+		case r.URL.Path == "/health":
 			w.Header().Set("Content-Type", "application/json")
 			result := map[string]interface{}{
 				"status":  "ok",
 				"version": m.version,
 				"kbs":     m.kbs,
+				"ready":   len(m.servers) > 0,
 			}
 			json.NewEncoder(w).Encode(result)
 			return
 
-		case "/mcp":
+		case r.URL.Path == "/ready":
+			w.Header().Set("Content-Type", "application/json")
+			if len(m.servers) == 0 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				json.NewEncoder(w).Encode(map[string]interface{}{"ready": false, "kbs": 0})
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{"ready": true})
+			return
+
+		case r.URL.Path == "/mcp":
 			kbName := r.URL.Query().Get("kb")
 
 			// Single-KB mode: if only one KB is mounted, use it as default.
@@ -274,18 +312,33 @@ func (m *MultiKBServer) Handler() http.Handler {
 				http.Error(w, "kb parameter required", http.StatusBadRequest)
 				return
 			}
-			srv, ok := m.servers[kbName]
-			if !ok {
-				http.Error(w, fmt.Sprintf("KB %q not found", kbName), http.StatusNotFound)
+			m.serveKB(w, r, kbName)
+			return
+
+		case strings.HasPrefix(r.URL.Path, "/mcp/"):
+			pathName := strings.TrimPrefix(r.URL.Path, "/mcp/")
+			if queryName := r.URL.Query().Get("kb"); queryName != "" && queryName != pathName {
+				http.Error(w, "conflicting kb selection", http.StatusBadRequest)
 				return
 			}
-			mcpAccessGuard(kbName, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				srv.handleMCP(w, r)
-			})).ServeHTTP(w, r)
+			m.serveKB(w, r, pathName)
 			return
 
 		default:
 			http.Error(w, "not found", http.StatusNotFound)
 		}
 	})
+}
+
+// serveKB routes r to the named KB's MCP handler (through the per-KB access
+// guard), or responds 404 "unknown kb" if no KB with that name is mounted.
+func (m *MultiKBServer) serveKB(w http.ResponseWriter, r *http.Request, kbName string) {
+	srv, ok := m.servers[kbName]
+	if !ok {
+		http.Error(w, fmt.Sprintf("unknown kb %q", kbName), http.StatusNotFound)
+		return
+	}
+	mcpAccessGuard(kbName, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srv.handleMCP(w, r)
+	})).ServeHTTP(w, r)
 }

--- a/internal/mcpserver/httpserver_test.go
+++ b/internal/mcpserver/httpserver_test.go
@@ -1,0 +1,201 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newMultiKBTestHandler mounts the given KB names on a fresh MultiKBServer
+// and returns its Handler() unwrapped (no auth middleware), for routing and
+// readiness tests that don't care about scopes.
+func newMultiKBTestHandler(t *testing.T, names ...string) *MultiKBServer {
+	t.Helper()
+	multi := NewMultiKBServer("test")
+	for _, name := range names {
+		k := setupTestKB(t)
+		multi.MountKB(name, func(s *Server) {
+			RegisterKBTools(s, k, Deps{})
+		})
+	}
+	return multi
+}
+
+func TestMultiKB_PathRouting_KnownName(t *testing.T) {
+	multi := newMultiKBTestHandler(t, "kbx", "kby")
+	handler := multi.Handler()
+
+	rr := doMCP(handler, "kby", "", toolsListBody) // sanity: ?kb= still works
+	if rr.Code != http.StatusOK {
+		t.Fatalf("?kb=kby: status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/kbx", strings.NewReader(toolsListBody))
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("/mcp/kbx: status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestMultiKB_PathRouting_UnknownName(t *testing.T) {
+	multi := newMultiKBTestHandler(t, "kbx")
+	handler := multi.Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/does-not-exist", strings.NewReader(toolsListBody))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("/mcp/does-not-exist: status = %d, want 404; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestMultiKB_PathRouting_ConflictingKBSelection(t *testing.T) {
+	multi := newMultiKBTestHandler(t, "kbx", "kby")
+	handler := multi.Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/kbx?kb=kby", strings.NewReader(toolsListBody))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("/mcp/kbx?kb=kby: status = %d, want 400; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestMultiKB_PathRouting_AgreeingKBSelection(t *testing.T) {
+	multi := newMultiKBTestHandler(t, "kbx", "kby")
+	handler := multi.Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/kbx?kb=kbx", strings.NewReader(toolsListBody))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("/mcp/kbx?kb=kbx: status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestMultiKB_Ready_ZeroKBs(t *testing.T) {
+	multi := NewMultiKBServer("test")
+	handler := multi.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("/ready with 0 KBs: status = %d, want 503; body=%s", rr.Code, rr.Body.String())
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON body: %v", err)
+	}
+	if ready, _ := body["ready"].(bool); ready {
+		t.Fatalf("ready = %v, want false", body["ready"])
+	}
+	if kbs, _ := body["kbs"].(float64); kbs != 0 {
+		t.Fatalf("kbs = %v, want 0", body["kbs"])
+	}
+}
+
+func TestMultiKB_Ready_AtLeastOneKB(t *testing.T) {
+	multi := newMultiKBTestHandler(t, "kbx")
+	handler := multi.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("/ready with 1 KB: status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON body: %v", err)
+	}
+	if ready, _ := body["ready"].(bool); !ready {
+		t.Fatalf("ready = %v, want true", body["ready"])
+	}
+}
+
+func TestMultiKB_Health_IncludesReady(t *testing.T) {
+	// 0 KBs: status stays "ok" (liveness invariant), ready is false.
+	multi := NewMultiKBServer("test")
+	handler := multi.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("/health: status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON body: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Fatalf("status = %v, want \"ok\" (liveness must not break)", body["status"])
+	}
+	if ready, _ := body["ready"].(bool); ready {
+		t.Fatalf("ready = %v, want false with 0 KBs", body["ready"])
+	}
+
+	// 1 KB: ready flips to true.
+	multi = newMultiKBTestHandler(t, "kbx")
+	handler = multi.Handler()
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON body: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Fatalf("status = %v, want \"ok\"", body["status"])
+	}
+	if ready, _ := body["ready"].(bool); !ready {
+		t.Fatalf("ready = %v, want true with 1 KB", body["ready"])
+	}
+}
+
+func TestServer_Health_IncludesReady(t *testing.T) {
+	s := New("test")
+	handler := s.HTTPHandler()
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("/health: status = %d, want 200", rr.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON body: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Fatalf("status = %v, want \"ok\"", body["status"])
+	}
+	if ready, _ := body["ready"].(bool); !ready {
+		t.Fatalf("ready = %v, want true (single-KB server always ready)", body["ready"])
+	}
+}
+
+func TestServer_Ready(t *testing.T) {
+	s := New("test")
+	handler := s.HTTPHandler()
+
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("/ready: status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON body: %v", err)
+	}
+	if ready, _ := body["ready"].(bool); !ready {
+		t.Fatalf("ready = %v, want true", body["ready"])
+	}
+}


### PR DESCRIPTION
## Summary
- WP1: `/mcp/<name>` path routing on `MultiKBServer.Handler`, alongside bare `/mcp` (single-KB auto-route) and `/mcp?kb=<name>`; unknown name → 404 `unknown kb`; path+query naming different KBs → 400 `conflicting kb selection`.
- WP2: `ready: <bool>` field on `/health` (single-KB: always true; MultiKB: `len(kbs) > 0`), `status` stays `"ok"` unconditionally (liveness invariant preserved); new `/ready` endpoint on both handlers (200/503).
- Docs: `docs/deployment.md` (new §HTTP routing, liveness vs readiness in §Observability), `docs/transport-auth.md` (routing cross-reference), `docs/decisions.md` (D84, follow-up of D73).

## Test plan
- [x] `make vet` → exit 0
- [x] `make test` → exit 0 (all packages green, new tests in `internal/mcpserver/httpserver_test.go`)
- [x] `make smoke-http` → passes

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)