### PR TITLE
docs: plan procedure surveys open plan issues for overlap

### DIFF
--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -12,16 +12,22 @@ Claude-side glue.
 
 ## Writing a plan
 
-1. Reserve the next free D number (`grep "^## D" docs/decisions.md | tail -3`)
+1. Survey the open plans before designing, not just the code:
+   `gh issue list --label plan --state open`, then read the candidates that
+   touch the same area. A request already covered by an open plan (or already
+   implemented on `main`) is reported back, not re-planned; a partial overlap
+   means extending/amending the existing issue or stating the relationship
+   (execution order, shared files) in the new one.
+2. Reserve the next free D number (`grep "^## D" docs/decisions.md | tail -3`)
    and use it in the title: `Plan: <title> (D<n>)`. The D entry is written **at
    the end of implementation**, not now: the plan is its draft.
-2. Derive the real `file:line` pointers before writing (graphify query /
+3. Derive the real `file:line` pointers before writing (graphify query /
    targeted symbol grep): the plan contains pointers, not paraphrases.
-3. Write the body (in English) to a scratch file following the template
+4. Write the body (in English) to a scratch file following the template
    structure, then:
    `gh issue create --title "Plan: <title> (D<n>)" --label plan --body-file <file>`.
-4. Apply the self-sufficiency test from `CONTRIBUTING.md` before submitting.
-5. One analysis, several plans → every issue states the cross-plan execution
+5. Apply the self-sufficiency test from `CONTRIBUTING.md` before submitting.
+6. One analysis, several plans → every issue states the cross-plan execution
    order and which sibling plans touch the same files (those land strictly
    sequentially, never in parallel). Amend a plan by editing the issue body
    while nothing is implemented yet; once implementation starts, amend via

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,12 @@ discussion into a self-contained implementation plan. The pattern: one session
 **only bridge** between the two — the implementer does not see the analysis
 discussion.
 
+Before designing, survey the **open plan issues** (label `plan`) as well as the
+code: a request already covered by an open plan or already implemented on
+`main` is reported, not re-planned; a partial overlap is reconciled by amending
+the existing issue or by stating the relationship (execution order, shared
+files) in the new one.
+
 Self-sufficiency test (determines the level of detail): a fresh session with
 only the issue and the repo must be able to implement without asking questions.
 


### PR DESCRIPTION
Adds an explicit pre-design step to the plan workflow: survey open `plan` issues (not just the code) before writing a new plan — requests already covered by an open plan or already on `main` are reported, not re-planned; partial overlaps are reconciled via amendment or explicit cross-plan ordering.

Touches `CONTRIBUTING.md` §Plan issues (agent-neutral procedure) and `.claude/skills/plan/SKILL.md` (step 1 of Writing a plan). Docs-only.