### PR TITLE
docs: plan skill codifies sibling cross-link mechanics

### DIFF
--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -32,6 +32,10 @@ Claude-side glue.
    sequentially, never in parallel). Amend a plan by editing the issue body
    while nothing is implemented yet; once implementation starts, amend via
    comments only.
+7. Sibling cross-links: create the issues in execution order, then amend each
+   body to reference siblings as `D<n> (#<issue>)` — the numbers exist only
+   after creation. A pointer into a sibling's not-yet-implemented artifact
+   cites the plan (`D<n> WP<m>`), never an invented `file:line`.
 
 ## Consuming a plan (implementing session)
 


### PR DESCRIPTION
Session-proven addition to the plan skill: create sibling issues in execution order and amend bodies afterwards to cross-link them as `D<n> (#<issue>)` (numbers exist only after creation); pointers into a sibling's not-yet-implemented artifacts cite the plan (`D<n> WP<m>`), never an invented `file:line`. Docs-only.