### PR TITLE
feat(cli): kb create and first-KB guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,31 +111,32 @@ go install github.com/BeppeTemp/cartographer/cmd/cartographer@latest
 
 ## Quick start
 
+The primary path is four commands: install the binary, run it as a native service, create your
+first KB, and connect an agent client to it.
+
 ```bash
-# Local stdio (Local Core)
-cartographer serve --kb /path/to/kb --init
+brew install beppetemp/tap/cartographer   # or curl install.sh, or `go install` (see Install above)
+cartographer service install              # generates config, installs and starts the service
+cartographer kb create <name>             # scaffolds a KB in the service's data dir
+cartographer connect                      # connects an agent client (Claude Code, OpenCode, Codex, Kiro)
+```
 
-# HTTP multi-KB (Server profile, auth disabled)
-CARTOGRAPHER_KB=/data/kb CARTOGRAPHER_HTTP=:8080 CARTOGRAPHER_AUTH=false \
-  cartographer serve
+`cartographer kb create <name>` prints how to get the server to pick up the new KB
+(`cartographer service restart`, or `--restart` to do it and wait for it automatically); `service
+install` itself hints at `kb create` if it starts with no KB mounted yet.
 
-# HTTP with auth
-CARTOGRAPHER_KB=/data/kb CARTOGRAPHER_HTTP=:8080 CARTOGRAPHER_AUTH=true \
-  CARTOGRAPHER_TOKENS=mytoken cartographer serve
+`connect` with no flags in a TTY opens an interactive form (server URL, server
+name, token env var, auth) instead of the flag defaults; pass `--no-input` to
+force the non-interactive behavior. Once connected:
 
-# Local native service (launchd on macOS, systemd user unit on Linux)
-cartographer service install   # generates config, installs and starts the service
-cartographer service status    # exit 0 running / 3 stopped / 4 not installed
-
-# Connect an agent client (Claude Code, OpenCode, Codex, Kiro) to a running server
-cartographer connect
+```bash
 cartographer status   # drift check: exit 0 in-sync / 1 drift / 2 error
 cartographer sync     # re-apply after drift
 ```
 
-`connect` with no flags in a TTY opens an interactive form (server URL, server
-name, token env var, auth) instead of the flag defaults; pass `--no-input` to
-force the non-interactive behavior.
+For local stdio use (a single KB, no service, typically for development) or a manually-configured
+HTTP server, see `serve --kb <path> --init` in `docs/deployment.md` — the native-service path above
+covers everyday use.
 
 ## Configuration
 

--- a/cmd/cartographer/kbcmd.go
+++ b/cmd/cartographer/kbcmd.go
@@ -1,0 +1,302 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/BeppeTemp/cartographer/internal/clientconfig"
+	"github.com/BeppeTemp/cartographer/internal/config"
+	"github.com/BeppeTemp/cartographer/internal/kb"
+	"github.com/BeppeTemp/cartographer/internal/service"
+)
+
+// healthCheckTimeout bounds a single GET of /health (kb create's post-create
+// guidance, service install's no-KB hint) — generous enough for a same-
+// machine loopback call, short enough not to hang the CLI if the local
+// service is down.
+const healthCheckTimeout = 2 * time.Second
+
+// healthPollInterval/restartWaitTimeout/noKBHintWaitTimeout bound the
+// best-effort polling loops in waitHealthy/printNoKBHintIfEmpty: none of
+// them gate the command's success (KB creation / service install already
+// happened), they only affect what guidance gets printed afterwards.
+const (
+	healthPollInterval  = 200 * time.Millisecond
+	restartWaitTimeout  = 10 * time.Second
+	noKBHintWaitTimeout = 3 * time.Second
+)
+
+// printPostCreateGuidanceFn indirects printPostCreateGuidance so tests can
+// stub it out: it otherwise reaches out over the network (real
+// ~/.cartographer.yaml / service config on the machine running the test),
+// which a unit test for the scaffold itself has no business doing.
+var printPostCreateGuidanceFn = printPostCreateGuidance
+
+// cmdKB dispatches `cartographer kb <subcommand>`.
+func cmdKB(args []string) int {
+	target, rest := splitPositional(args, "")
+	switch target {
+	case "create":
+		return cmdKBCreate(rest)
+	default:
+		fmt.Fprintln(os.Stderr, "Error: usage: cartographer kb create <name> [--data <dir>] [--restart]")
+		return 2
+	}
+}
+
+// kbNameRe validates a KB name as directory-safe: letters, digits, '-', '_'
+// only — no '/', '.', or whitespace, so the name can never escape
+// <dataDir>/<name> (no ".." is even expressible) and matches the kebab-case
+// convention already documented for KB names (D53, skillbundle kb-create
+// SKILL.md). No stricter/pre-existing validator exists elsewhere in the
+// codebase (config.KBSpec.Name is an unvalidated free string) — this is it.
+var kbNameRe = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+// validateKBName returns an error describing why name is not a usable KB
+// name, or nil if it is.
+func validateKBName(name string) error {
+	if name == "" {
+		return fmt.Errorf("KB name must not be empty")
+	}
+	if !kbNameRe.MatchString(name) {
+		return fmt.Errorf("invalid KB name %q: only letters, digits, '-', and '_' are allowed", name)
+	}
+	return nil
+}
+
+// cmdKBCreate implements `cartographer kb create <name> [--data <dir>]
+// [--restart]`: scaffolds a new KB at <data>/<name> via the same kb.Init
+// bootstrap used by `serve --kb <path> --init` (git init + OKF layout), then
+// prints guidance on how to get the server to pick it up (WP2, D85). The
+// data dir resolution mirrors `service install`'s: the running service's
+// config YAML `data:` field, falling back to defaultDataDir()
+// (~/cartographer-data); --data overrides both.
+func cmdKBCreate(args []string) int {
+	// <name> is a leading positional argument, before the flags (see usage:
+	// "kb create <name> [--data <dir>] [--restart]") — flag.Parse stops at
+	// the first non-flag token, so it must be pulled out first (same
+	// splitPositional dance as `service <target>` and `sync <provider>`).
+	name, rest := splitPositional(args, "")
+
+	fs := flag.NewFlagSet("kb create", flag.ExitOnError)
+	dataFlag := fs.String("data", "", "KB data directory (default: the server config's data:, or "+defaultDataDir()+")")
+	restartFlag := fs.Bool("restart", false, "Restart the local service and wait until healthy after creating the KB")
+	fs.Parse(rest)
+
+	if name == "" || fs.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "Usage: cartographer kb create <name> [--data <dir>] [--restart]")
+		return 2
+	}
+	if err := validateKBName(name); err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		return 2
+	}
+
+	dataDir := *dataFlag
+	if dataDir == "" {
+		dataDir = resolveServerDataDir()
+	}
+
+	path := filepath.Join(dataDir, name)
+	if _, err := os.Stat(path); err == nil {
+		fmt.Fprintf(os.Stderr, "Error: %s already exists\n", path)
+		return 1
+	} else if !os.IsNotExist(err) {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		return 1
+	}
+
+	// kb.Init creates <path> (and its parents, i.e. dataDir too) itself —
+	// no separate MkdirAll(dataDir) needed.
+	if _, err := kb.Init(path); err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		return 1
+	}
+	fmt.Printf("KB %q created at %s\n", name, path)
+
+	printPostCreateGuidanceFn(*restartFlag)
+	return 0
+}
+
+// resolveServerDataDir mirrors the data-dir precedence of `service install`
+// (service.go:defaultDataDir, config.Load's Data field): the local service's
+// config YAML `data:` field if the config exists and sets one, otherwise
+// defaultDataDir() (~/cartographer-data).
+func resolveServerDataDir() string {
+	if cfgPath, err := service.ConfigPath(); err == nil {
+		if cfg, err := config.Load(cfgPath); err == nil && cfg.Data != "" {
+			return cfg.Data
+		}
+	}
+	return defaultDataDir()
+}
+
+// healthInfo is the subset of the /health JSON body kb create's guidance
+// and service install's no-KB hint care about. KBs is a pointer so hasNoKBs
+// can tell "field absent" (pre-D84 shape, or a single-KB server, which never
+// has a kbs field at all) from "present and empty" (MultiKB server, no
+// subdir mounted) — the two cases need different fallbacks. The "ready"
+// field (D84) is intentionally not decoded here: both a pre-D84 and a
+// post-D84 server answer this struct correctly, since a missing field just
+// leaves KBs nil.
+type healthInfo struct {
+	KBs *[]json.RawMessage `json:"kbs"`
+}
+
+// hasNoKBs reports whether the health response indicates zero KBs mounted.
+// If the kbs field is present, its length decides. If it's absent
+// (single-KB server shape, or a pre-D84 server that predates the field),
+// fall back to checking dataDir directly — this is the "absent+data-dir
+// empty" half of the WP2 spec.
+func (h *healthInfo) hasNoKBs(dataDir string) bool {
+	if h.KBs != nil {
+		return len(*h.KBs) == 0
+	}
+	entries, err := discoverKBPaths(dataDir)
+	return err == nil && len(entries) == 0
+}
+
+// fetchHealth GETs <baseURL>/health and decodes the fields this package
+// cares about (hasNoKBs). Returns an error if the server is unreachable or
+// does not respond 200 — every caller here treats that as "can't tell, stay
+// silent" rather than a hard failure: this guidance is always best-effort
+// and never blocks `kb create`/`service install`'s own success.
+func fetchHealth(baseURL string) (*healthInfo, error) {
+	client := http.Client{Timeout: healthCheckTimeout}
+	resp, err := client.Get(strings.TrimRight(baseURL, "/") + "/health")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s/health: status %d", baseURL, resp.StatusCode)
+	}
+	var h healthInfo
+	if err := json.NewDecoder(resp.Body).Decode(&h); err != nil {
+		return nil, err
+	}
+	return &h, nil
+}
+
+// serverBaseURL resolves the local server's base HTTP URL (no /mcp or
+// /health suffix). The authoritative source is the service config YAML's
+// `http:` field (service.ConfigPath, D85) — this is what `serve` actually
+// binds to, and is known even before `cartographer connect` has ever run.
+// If that config doesn't exist or has no http: set (stdio-only, or not
+// installed as a service yet), fall back to deriving it the way the client
+// does: .cartographer.yaml server_url, defaulting to
+// http://localhost:8080/mcp (clientconfig.Default), with the /mcp path
+// stripped.
+func serverBaseURL() string {
+	if cfgPath, err := service.ConfigPath(); err == nil {
+		if cfg, err := config.Load(cfgPath); err == nil && cfg.HTTP != "" {
+			if url := httpAddrToBaseURL(cfg.HTTP); url != "" {
+				return url
+			}
+		}
+	}
+
+	serverURL := clientconfig.Default().ServerURL
+	if dir, err := clientconfig.TargetDir(); err == nil {
+		if cfg, err := clientconfig.Load(dir); err == nil {
+			serverURL = cfg.ServerURL
+		}
+	}
+	return strings.TrimSuffix(serverURL, "/mcp")
+}
+
+// httpAddrToBaseURL turns a server http listen address (e.g. ":8080" or
+// "127.0.0.1:8080") into a base URL ("http://127.0.0.1:8080"), normalizing a
+// bare port to loopback the same way internal/service's healthURL does.
+// Returns "" if addr does not parse as host:port.
+func httpAddrToBaseURL(addr string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return ""
+	}
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	return "http://" + net.JoinHostPort(host, port)
+}
+
+// printPostCreateGuidance is WP2's post-create half: if a local server
+// answers /health, tell the user how to get the new KB mounted — either the
+// plain hint (`cartographer service restart`) or, with restart=true
+// (--restart), actually restart it and wait for it to become healthy again.
+// If no server answers at all, stay silent: there is nothing running to
+// restart, and the user is presumably still mid-setup (e.g. using the KB
+// with `serve --kb <path>` directly, no service involved).
+func printPostCreateGuidance(restart bool) {
+	base := serverBaseURL()
+	if _, err := fetchHealth(base); err != nil {
+		return
+	}
+
+	if !restart {
+		fmt.Println("Restart the service to mount it: cartographer service restart")
+		return
+	}
+
+	fmt.Println("Restarting the service...")
+	if err := service.NewManager().Restart(); err != nil {
+		fmt.Fprintln(os.Stderr, "Error: restart failed:", err)
+		return
+	}
+	if waitHealthy(base) {
+		fmt.Println("service healthy")
+	} else {
+		fmt.Fprintf(os.Stderr, "Warning: service did not report healthy within %s\n", restartWaitTimeout)
+	}
+}
+
+// waitHealthy polls <baseURL>/health until it responds or
+// restartWaitTimeout elapses, returning whether it became healthy in time.
+func waitHealthy(baseURL string) bool {
+	deadline := time.Now().Add(restartWaitTimeout)
+	for {
+		if _, err := fetchHealth(baseURL); err == nil {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(healthPollInterval)
+	}
+}
+
+// printNoKBHintIfEmpty is WP2's post-install half, called by
+// cmdServiceInstall after a successful `service install`: it waits (briefly)
+// for the just-(re)started service to answer /health, and if it reports
+// zero KBs mounted (hasNoKBs), prints a hint pointing at `kb create`.
+// dataDir is the data directory Install resolved (opts.DataDir as passed,
+// or the pre-existing config's data:) — used by hasNoKBs's fallback when
+// the kbs field itself is absent. Best-effort throughout: never returns an
+// error, never affects service install's own exit code.
+func printNoKBHintIfEmpty(dataDir string) {
+	base := serverBaseURL()
+	deadline := time.Now().Add(noKBHintWaitTimeout)
+	var h *healthInfo
+	var err error
+	for {
+		h, err = fetchHealth(base)
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+		time.Sleep(healthPollInterval)
+	}
+	if h.hasNoKBs(dataDir) {
+		fmt.Println("no KB mounted yet — create one with: cartographer kb create <name>")
+	}
+}

--- a/cmd/cartographer/kbcmd_test.go
+++ b/cmd/cartographer/kbcmd_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateKBName(t *testing.T) {
+	cases := []struct {
+		name    string
+		wantErr bool
+	}{
+		{"alpha", false},
+		{"alpha-beta", false},
+		{"alpha_beta", false},
+		{"Alpha123", false},
+		{"", true},
+		{"alpha/beta", true},
+		{"../escape", true},
+		{"alpha.beta", true},
+		{"alpha beta", true},
+		{"alpha:beta", true},
+	}
+	for _, tc := range cases {
+		err := validateKBName(tc.name)
+		if tc.wantErr && err == nil {
+			t.Errorf("validateKBName(%q) = nil, want error", tc.name)
+		}
+		if !tc.wantErr && err != nil {
+			t.Errorf("validateKBName(%q) = %v, want nil", tc.name, err)
+		}
+	}
+}
+
+// withNoGuidance stubs printPostCreateGuidanceFn to a no-op for the
+// duration of f, so cmdKBCreate tests never reach out over the network
+// (real ~/.cartographer.yaml / service config on the test machine).
+func withNoGuidance(t *testing.T, f func()) {
+	t.Helper()
+	orig := printPostCreateGuidanceFn
+	printPostCreateGuidanceFn = func(bool) {}
+	defer func() { printPostCreateGuidanceFn = orig }()
+	f()
+}
+
+func TestCmdKBCreateScaffold(t *testing.T) {
+	dataDir := t.TempDir()
+
+	var code int
+	out := withStdout(t, func() {
+		withNoGuidance(t, func() {
+			code = cmdKBCreate([]string{"alpha", "--data", dataDir})
+		})
+	})
+	if code != 0 {
+		t.Fatalf("cmdKBCreate = %d, want 0 (output: %s)", code, out)
+	}
+
+	kbPath := filepath.Join(dataDir, "alpha")
+	for _, rel := range []string{"data/index.md", "data/log.md", ".git"} {
+		if _, err := os.Stat(filepath.Join(kbPath, rel)); err != nil {
+			t.Errorf("expected %s to exist: %v", rel, err)
+		}
+	}
+}
+
+func TestCmdKBCreateSecondRunError(t *testing.T) {
+	dataDir := t.TempDir()
+
+	withNoGuidance(t, func() {
+		if code := cmdKBCreate([]string{"alpha", "--data", dataDir}); code != 0 {
+			t.Fatalf("first cmdKBCreate = %d, want 0", code)
+		}
+	})
+
+	var code int
+	withNoGuidance(t, func() {
+		code = cmdKBCreate([]string{"alpha", "--data", dataDir})
+	})
+	if code == 0 {
+		t.Fatal("second cmdKBCreate = 0, want non-zero (already exists)")
+	}
+}
+
+func TestCmdKBCreateInvalidName(t *testing.T) {
+	dataDir := t.TempDir()
+
+	var code int
+	withNoGuidance(t, func() {
+		code = cmdKBCreate([]string{"not/valid", "--data", dataDir})
+	})
+	if code == 0 {
+		t.Fatal("cmdKBCreate with invalid name = 0, want non-zero")
+	}
+}
+
+func TestRunKBDispatch(t *testing.T) {
+	origKBFn := kbFn
+	defer func() { kbFn = origKBFn }()
+	var gotArgs []string
+	kbFn = func(args []string) int {
+		gotArgs = args
+		return 9
+	}
+
+	if code := run([]string{"kb", "create", "alpha"}); code != 9 {
+		t.Errorf("run([kb create alpha]) = %d, want 9", code)
+	}
+	want := []string{"create", "alpha"}
+	if len(gotArgs) != len(want) {
+		t.Fatalf("kbFn args = %v, want %v", gotArgs, want)
+	}
+	for i := range want {
+		if gotArgs[i] != want[i] {
+			t.Errorf("kbFn args[%d] = %q, want %q", i, gotArgs[i], want[i])
+		}
+	}
+}

--- a/cmd/cartographer/main.go
+++ b/cmd/cartographer/main.go
@@ -22,6 +22,7 @@ type subcommand struct {
 // subcommands lists every subcommand for the usage output.
 var subcommands = []subcommand{
 	{"serve", "Run the MCP server (stdio or HTTP)"},
+	{"kb", "Create and manage local KBs (kb create <name>)"},
 	{"version", "Print the build version"},
 	{"help", "Show this help message"},
 	{"agents", "List detected/connected agent clients on this machine"},
@@ -50,6 +51,7 @@ var (
 	runTUIFn     = runTUI
 	importFn     = cmdImport
 	resolveFn    = cmdResolve
+	kbFn         = cmdKB
 )
 
 func main() {
@@ -76,6 +78,8 @@ func run(args []string) int {
 	switch cmd {
 	case "serve":
 		return serveFn(rest)
+	case "kb":
+		return kbFn(rest)
 	case "version":
 		return versionFn()
 	case "help", "-h", "--help":

--- a/cmd/cartographer/service.go
+++ b/cmd/cartographer/service.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/BeppeTemp/cartographer/internal/config"
 	"github.com/BeppeTemp/cartographer/internal/service"
 )
 
@@ -70,6 +71,13 @@ func cmdServiceInstall(args []string) int {
 		return exitStatusError
 	}
 	fmt.Println("service installed and started")
+
+	dataDir := *dataFlag
+	if cfg, cfgErr := config.Load(*configFlag); cfgErr == nil && cfg.Data != "" {
+		dataDir = cfg.Data
+	}
+	printNoKBHintIfEmpty(dataDir)
+
 	return exitStatusRunning
 }
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1443,6 +1443,41 @@ it; `/ready` gives `readinessProbe` a signal that actually reflects usability. P
 the gap between what D53 already documented as "the name used everywhere" and what the HTTP layer
 actually accepted.
 
+## D85 — `kb create` and first-KB onboarding: a CLI command, not only the agentic skill
+
+**Status: implemented (2026-07-24).**
+
+**Context.** With an empty data dir the server mounts 0 KBs and `/mcp` 400s, but nothing guided a
+first-time user to create one: the CLI dispatch had no `kb` subcommand — creation existed only as
+the agentic `kb-create` skill (Gitea-repo-first, operator-only), and neither `service install` nor
+`connect` offered a hint. The happy path (`brew install` → `service install` → connect) had no step
+in between to actually get a KB onto disk.
+
+**Decision.**
+- **WP1 — `cartographer kb create <name>` (`cmd/cartographer/kbcmd.go`).** Scaffolds
+  `<data>/<name>` via the exact `kb.Init` bootstrap `serve --kb <path> --init` already uses (git
+  init + OKF layout) — no second scaffold implementation. Data dir resolution mirrors `service
+  install`'s: the local service's config YAML `data:` field, else `~/cartographer-data`; `--data`
+  overrides. Name validated as directory-safe (`^[A-Za-z0-9_-]+$` — no existing validator to reuse,
+  none existed before this).
+- **WP2 — guidance.** After a successful create, `kb create` probes the local server's `/health`
+  (base URL: the service config's `http:` if present, else the way `connect` derives it —
+  `.cartographer.yaml` `server_url`/localhost default, `/mcp` stripped) and, if reachable, prints
+  the `service restart` hint (or does it and waits healthy, with `--restart`). `service install`
+  probes the same way after installing and, if `/health` reports 0 KBs mounted, prints a hint
+  pointing at `kb create`. Both parse `/health` defensively: the `ready`/`kbs` fields are D84
+  additions, absent on an older server — `kbs` absent falls back to checking the data dir directly.
+- **WP3 — narrative.** README's quick start and `docs/deployment.md`'s native-service example both
+  lead with the 4-command path (`brew install` → `service install` → `kb create <name>` →
+  `connect`); `serve --kb <path> --init` remains documented as the stdio/dev path.
+
+**Rationale.** A CLI command belongs on every machine that already has the binary, works without
+Gitea/a git remote, and matches the plain local-service topology (no persistence concerns — the
+data dir itself is the persistence layer, unlike the k8s/GitOps topology the `kb-create` skill
+targets). The skill remains the right tool for that GitOps case (per-KB Gitea repo, service user,
+ConfigMap `kbs:` entry): `kb create` doesn't replace it, it covers the case the skill doesn't —
+a single local/native-service machine with no remote yet.
+
 ## D87 — Fence-aware heading detection: shared line iterator for `ListHeadings`/`ExtractSection`/`SectionHashes`
 
 **Status: implemented (2026-07-23).**

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -173,6 +173,7 @@ cartographer service install                 # generates config + plist/unit, st
 cartographer service status                  # binary, config, installed/running/healthy
 cartographer service start|stop|restart
 cartographer service uninstall               # removes the service; config and data remain
+cartographer kb create <name>                # scaffolds a KB in the service's data dir (D85)
 ```
 
 `service install` (idempotent: re-running it rewrites the plist/unit and restarts):
@@ -181,7 +182,7 @@ cartographer service uninstall               # removes the service; config and d
 - macOS: LaunchAgent `~/Library/LaunchAgents/com.cartographer.serve.plist` (`KeepAlive`, logging to `~/Library/Logs/cartographer/server.log`). The plist's binary path prefers a stable Homebrew symlink (`/opt/homebrew/bin/cartographer` or `/usr/local/bin/cartographer`) over the versioned Caskroom path, so it survives `brew upgrade` without a re-install (D83);
 - Linux: systemd user unit `~/.config/systemd/user/cartographer.service` (log via `journalctl --user -u cartographer`; on a headless host, `loginctl enable-linger <user>` is needed for the service to survive logout).
 
-Binds to **loopback** by default (`127.0.0.1:8080`) → auth stays in auto-off mode without exposing anything on the network. With an empty (or missing — D83: `serve` creates it and treats it as empty rather than failing) data dir the server starts with 0 KBs — `/health` is still up (liveness: `status:"ok"`) but `/ready` reports `503 {"ready":false}` (D84, §Observability): create a subfolder per KB (or add `kbs:` entries to clone remotes, §Bootstrapping a KB) and `service restart`.
+Binds to **loopback** by default (`127.0.0.1:8080`) → auth stays in auto-off mode without exposing anything on the network. With an empty (or missing — D83: `serve` creates it and treats it as empty rather than failing) data dir the server starts with 0 KBs — `/health` is still up (liveness: `status:"ok"`) but `/ready` reports `503 {"ready":false}` (D84, §Observability): `cartographer kb create <name>` scaffolds a subfolder KB the same way `serve --kb <path> --init` would (D85; `service install` itself prints a hint pointing at it if it starts with 0 KBs mounted), or add `kbs:` entries to clone remotes (§Bootstrapping a KB) — either way, `service restart` (or `kb create --restart`, which does this for you and waits for the server to report healthy again) is what makes the new KB visible.
 
 `service status` uses systemctl-like exit codes: `0` running, `3` installed but stopped, `4` not installed — this is what lets `install.sh update` automatically restart only a running service (see §Client installation).
 


### PR DESCRIPTION
## Summary

- Adds `cartographer kb create <name>` (`cmd/cartographer/kbcmd.go`), scaffolding `<data>/<name>` via the exact `kb.Init` bootstrap already used by `serve --kb <path> --init` — no second scaffold implementation.
- WP2: post-create guidance (probes local `/health`, prints/`--restart`s the service) and a post-`service install` hint pointing at `kb create` when 0 KBs are mounted. Both tolerate a pre-D84 `/health` response (missing `ready`/`kbs` fields).
- WP3: README quick start and `docs/deployment.md`'s native-service example now lead with the 4-command onboarding path (`brew install` → `service install` → `kb create <name>` → `connect`); `serve --kb <path> --init` remains documented as the stdio/dev path.
- `D85` entry in `docs/decisions.md`.

## Test plan

- [x] `make vet && make test` → exit 0
- [x] `make smoke` → OK
- [x] Manual: `kb create` scaffold (git init + OKF layout), second-run "already exists" error, invalid-name rejection
- [x] New tests: name-validation table test, scaffold test, second-run error test, dispatch test (`cmd/cartographer/kbcmd_test.go`)

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)