### PR TITLE
fix(search): multi-term FTS matching and mode schema coherence

### DIFF
--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -41,7 +41,7 @@ Tools marked **[A]** (advanced, `advancedToolNames` in `internal/mcpserver/visib
 
 | Tool | Purpose |
 |---|---|
-| `search(query, [scope], [use_semantic])` **[R]** | Keyword or hybrid (keyword + vector) search. `use_semantic=true` requires Ollama to be configured. Every hit includes `title` (from the frontmatter) and `snippet` (an excerpt of ~200 chars around the match; FTS5 uses its native `snippet()`, otherwise it's extracted in-memory) — avoids a `concept_read` just to judge a hit's relevance (D70). |
+| `search(query, [scope], [mode])` **[R]** | Keyword, semantic, or hybrid (keyword + vector) search. `mode` is `keyword` (default), `semantic`, or `hybrid`; semantic/hybrid require Ollama to be configured. `use_semantic=true` remains a deprecated alias for `mode=hybrid`. Keyword matching first requires all query terms, then retries with any term if that returns no hits. Every hit includes `title` (from the frontmatter) and `snippet` (an excerpt of ~200 chars around the match; FTS5 uses its native `snippet()`, otherwise it's extracted in-memory) — avoids a `concept_read` just to judge a hit's relevance (D70). |
 | `index_rebuild()` **[R]** **[A]** | Rebuilds the keyword index (in-memory and FTS5 if present) and the embeddings if Ollama is active (with a content-hash cache). Read-only: it mutates only the derived/gitignored index, never KB content (D45). |
 
 ### Writing and ingest
@@ -109,7 +109,7 @@ See `docs/sync.md` for the full model (Manifest, Lock, Diff, layered triggers).
 
 Semantic search is available when the server is started with `--ollama <url>` (or `CARTOGRAPHER_OLLAMA=<url>`). In that case:
 
-- The `search` tool accepts `use_semantic=true` to combine keyword + cosine similarity (hybrid mode).
+- The `search` tool accepts `mode=semantic` or `mode=hybrid` to use vector similarity; `use_semantic=true` remains a deprecated alias for `mode=hybrid`.
 - The `index_rebuild` tool rebuilds the keyword index and per-concept embeddings.
 - The model is configurable via `CARTOGRAPHER_OLLAMA_MODEL` (default: `nomic-embed-text`).
 - If Ollama is unreachable or embedding fails, keyword search is always available as a fallback.
@@ -119,7 +119,7 @@ Semantic search is available when the server is started with `--ollama <url>` (o
 **Rebuildable index** (*vault = truth, index = disposable*), with two persistence levels:
 
 - **In-memory (default/Core)**: a pure-Go keyword inverted index (`internal/search`) + an in-memory vector store (`internal/embed`). Rebuilt on every startup by walking the concepts.
-- **Persisted SQLite (`internal/sqlindex`, D32)**: when the KB has an openable `.cartographer/index.db`, keyword search uses **FTS5 with a trigram tokenizer** (supports substrings, not just whole words) and embeddings are persisted in SQLite with a **content-hash cache** — `index_rebuild` recomputes Ollama embeddings only for concepts whose hash changed. On this path, the `search` response's `mode` field is `keyword_fts5`/`hybrid_fts5`. Best-effort: if the DB can't be opened or FTS5 is unavailable, it degrades to the in-memory path.
+- **Persisted SQLite (`internal/sqlindex`, D32)**: when the KB has an openable `.cartographer/index.db`, keyword search uses **FTS5 with a trigram tokenizer** (supports substrings, not just whole words). Multi-term matching tries all terms first, then any term only if the all-terms search is empty; terms shorter than three characters are omitted from the FTS match. Embeddings are persisted in SQLite with a **content-hash cache** — `index_rebuild` recomputes Ollama embeddings only for concepts whose hash changed. On this path, the `search` response's `mode` field is `keyword_fts5`/`hybrid_fts5`. Best-effort: if the DB can't be opened or FTS5 is unavailable, it degrades to the in-memory path.
 - **Semantic**: embedding vectors (e.g. Ollama), cosine similarity outside SQL. Independent commit: if the embedder is down, keyword search still moves forward. Embedder-identity guard: full re-embedding if the model changes (content-hash invalidates the cache).
 
 At small scale `index.md` alone can be enough, and keyword search beats embeddings on cost; semantic search is nonetheless active from the start in the Server profile and scales with the wiki.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1506,6 +1506,14 @@ a single local/native-service machine with no remote yet.
 
 **Rationale.** Reusing the existing `Frontmatter.Delete` and `WriteConcept` validation means null-as-unset needed no new protected-key logic — the "type is required" invariant already did the job. Emptiness-only `map_delete` (rather than a recursive/forced delete) keeps map removal a safe, git-diffable no-op unless the caller has actually finished migrating content out, consistent with `concept_delete`/`concept_move` never silently discarding concepts.
 
+## D89 — Multi-term search fallback and coherent search modes
+
+**Status: implemented (2026-07-24).**
+
+**Decision.** FTS5 keyword queries tokenize on whitespace and first require all usable terms; an empty result retries once with any term. Tokens shorter than three characters are excluded from the trigram MATCH, preserving the prior whole-query behavior when no usable token remains. The in-memory index follows the same all-terms-then-any-term policy. Both search profiles expose `mode: keyword|semantic|hybrid`; `use_semantic=true` remains a deprecated alias for `mode=hybrid`.
+
+**Rationale.** Requiring a whole multi-word trigram phrase was stricter than the in-memory all-terms behavior and missed documents containing the terms apart. The OR retry improves recall only when the more precise result is empty, while preserving ranking and ordinary keyword behavior. This unifies the public schema without changing the capability gate: as established by D43 and AD11, semantic/hybrid search still requires a server started with Ollama and keyword search remains available without it.
+
 ## Known deviations from the specification
 
 - TUI configurator: implemented (D35), opt-in via `--tui`.

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -11,9 +11,15 @@ import (
 	"testing"
 	"testing/fstest"
 
+	"github.com/BeppeTemp/cartographer/internal/embed"
 	"github.com/BeppeTemp/cartographer/internal/kb"
 	"github.com/BeppeTemp/cartographer/internal/sqlindex"
 )
+
+type testEmbedder struct{}
+
+func (testEmbedder) Embed(string) (embed.Vector, error) { return embed.Vector{1, 0}, nil }
+func (testEmbedder) Model() string                      { return "test" }
 
 // setupTestKB creates a temporary KB with minimal content for tests.
 func setupTestKB(t *testing.T) *kb.KB {
@@ -861,6 +867,44 @@ func TestServer_Validate(t *testing.T) {
 	}
 	if !strings.Contains(tr.Content[0].Text, "senza-tipo.md") {
 		t.Errorf("validate: output does not contain expected error: %s", tr.Content[0].Text)
+	}
+}
+
+func TestSearch_ModeProfiles(t *testing.T) {
+	k := setupTestKB(t)
+	idx, meta := buildIndex(k)
+	live := newLiveIndex(idx, meta)
+
+	core := toolSearch(k, live, Deps{})
+	if !strings.Contains(string(core.InputSchema), `"mode"`) {
+		t.Fatal("Core search schema does not expose mode")
+	}
+	result, err := core.Handler(json.RawMessage(`{"query":"runbook","mode":"semantic"}`))
+	if err != nil {
+		t.Fatalf("Core semantic mode: %v", err)
+	}
+	if !result.IsError || !strings.Contains(result.Content[0].Text, "semantic/hybrid require a server started with --ollama") {
+		t.Fatalf("Core semantic mode got %+v", result)
+	}
+
+	store := embed.NewStore()
+	store.Add("manutenzione/test-runbook", embed.Vector{1, 0})
+	hybrid := toolSearch(k, live, Deps{Embedder: testEmbedder{}, VecStore: store})
+	if !strings.Contains(string(hybrid.InputSchema), `"mode"`) {
+		t.Fatal("hybrid search schema does not expose mode")
+	}
+	for _, args := range []string{
+		`{"query":"runbook","mode":"semantic"}`,
+		`{"query":"runbook","mode":"hybrid"}`,
+		`{"query":"runbook","use_semantic":true}`,
+	} {
+		result, err := hybrid.Handler(json.RawMessage(args))
+		if err != nil {
+			t.Fatalf("hybrid mode %s: %v", args, err)
+		}
+		if result.IsError || !strings.Contains(result.Content[0].Text, `"mode": "hybrid"`) {
+			t.Fatalf("hybrid mode %s got %+v", args, result)
+		}
 	}
 }
 

--- a/internal/mcpserver/tools_search.go
+++ b/internal/mcpserver/tools_search.go
@@ -32,9 +32,10 @@ var hybridSearchInputSchema = json.RawMessage(`{
 			"type": "integer",
 			"description": "Maximum number of results (default 20)"
 		},
-		"use_semantic": {
-			"type": "boolean",
-			"description": "If true, combines keyword search with vector similarity (requires Ollama). Default false."
+		"mode": {
+			"type": "string",
+			"enum": ["keyword", "semantic", "hybrid"],
+			"description": "Search mode: keyword (default), semantic, or hybrid (requires Ollama)."
 		}
 	}
 }`)
@@ -59,7 +60,8 @@ var keywordOnlySearchInputSchema = json.RawMessage(`{
 		},
 		"mode": {
 			"type": "string",
-			"description": "Search mode: keyword (default). Semantic and hybrid modes not yet available."
+			"enum": ["keyword", "semantic", "hybrid"],
+			"description": "Search mode: keyword (default), semantic, or hybrid. Semantic and hybrid require Ollama."
 		}
 	}
 }`)
@@ -90,11 +92,11 @@ func toolSearch(k *kb.KB, live *liveIndex, deps Deps) Tool {
 	hasEmbed := deps.Embedder != nil && deps.VecStore != nil
 	hasSQL := deps.SQLIndex != nil
 
-	description := "Keyword search over KB concepts. Returns matching concept IDs ranked by relevance. All query terms must appear (AND semantics)."
+	description := "Keyword search over KB concepts. Returns matching concept IDs ranked by relevance. All query terms are preferred (AND, then OR fallback)."
 	schema := keywordOnlySearchInputSchema
 	switch {
 	case hasEmbed:
-		description = "Keyword and optional semantic search over KB concepts. Set use_semantic=true to combine vector similarity with keyword results."
+		description = "Keyword, semantic, and hybrid search over KB concepts. Set mode=hybrid to combine keyword and vector results."
 		schema = hybridSearchInputSchema
 	case hasSQL:
 		description = "Keyword search over KB concepts (SQLite FTS5 with substring matching). Returns matching concept IDs ranked by relevance."
@@ -130,7 +132,7 @@ func handleKeywordOnlySearch(live *liveIndex, args json.RawMessage) (ToolResult,
 		return errorResult("'query' is required"), nil
 	}
 	if params.Mode != "" && params.Mode != "keyword" {
-		return errorResult(fmt.Sprintf("mode %q not available; only 'keyword' is supported in Core", params.Mode)), nil
+		return errorResult(fmt.Sprintf("mode %q not available: semantic/hybrid require a server started with --ollama", params.Mode)), nil
 	}
 
 	hits := live.get().Search(params.Query, params.Scope, params.Limit)
@@ -164,6 +166,7 @@ func handleHybridSearch(live *liveIndex, deps Deps, args json.RawMessage) (ToolR
 		Query       string `json:"query"`
 		Scope       string `json:"scope"`
 		Limit       int    `json:"limit"`
+		Mode        string `json:"mode"`
 		UseSemantic bool   `json:"use_semantic"`
 	}
 	if err := json.Unmarshal(args, &params); err != nil {
@@ -172,6 +175,10 @@ func handleHybridSearch(live *liveIndex, deps Deps, args json.RawMessage) (ToolR
 	if params.Query == "" {
 		return errorResult("'query' is required"), nil
 	}
+	if params.Mode != "" && params.Mode != "keyword" && params.Mode != "semantic" && params.Mode != "hybrid" {
+		return errorResult(fmt.Sprintf("invalid mode %q; expected keyword, semantic, or hybrid", params.Mode)), nil
+	}
+	useSemantic := params.UseSemantic || params.Mode == "semantic" || params.Mode == "hybrid"
 	limit := params.Limit
 	if limit <= 0 {
 		limit = 20
@@ -217,7 +224,7 @@ func handleHybridSearch(live *liveIndex, deps Deps, args json.RawMessage) (ToolR
 		kwSet[h.ID] = h.Score
 	}
 
-	if !params.UseSemantic {
+	if !useSemantic {
 		sort.Slice(kwHits, func(i, j int) bool {
 			if kwHits[i].Score != kwHits[j].Score {
 				return kwHits[i].Score > kwHits[j].Score

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -62,7 +62,7 @@ func (idx *Index) remove(id string) {
 }
 
 // Search returns hits matching the query, scored by term-frequency relevance.
-// All query terms must appear in a document (AND semantics).
+// It first requires all query terms, then falls back to any term if needed.
 // If scope is non-empty, only concepts whose ID starts with scope are returned.
 func (idx *Index) Search(query string, scope string, limit int) []Hit {
 	if limit <= 0 {
@@ -73,23 +73,9 @@ func (idx *Index) Search(query string, scope string, limit int) []Hit {
 		return nil
 	}
 
-	candidates := idx.posting(terms[0])
-	if candidates == nil {
-		return nil
-	}
-	for _, term := range terms[1:] {
-		next := idx.posting(term)
-		if next == nil {
-			return nil
-		}
-		for id := range candidates {
-			if _, ok := next[id]; !ok {
-				delete(candidates, id)
-			}
-		}
-		if len(candidates) == 0 {
-			return nil
-		}
+	candidates := idx.andCandidates(terms)
+	if len(candidates) == 0 && len(terms) >= 2 {
+		candidates = idx.orCandidates(terms)
 	}
 
 	var hits []Hit
@@ -122,6 +108,38 @@ func (idx *Index) Search(query string, scope string, limit int) []Hit {
 		hits = hits[:limit]
 	}
 	return hits
+}
+
+func (idx *Index) andCandidates(terms []string) map[string]int {
+	candidates := idx.posting(terms[0])
+	if candidates == nil {
+		return nil
+	}
+	for _, term := range terms[1:] {
+		next := idx.posting(term)
+		if next == nil {
+			return nil
+		}
+		for id := range candidates {
+			if _, ok := next[id]; !ok {
+				delete(candidates, id)
+			}
+		}
+		if len(candidates) == 0 {
+			return nil
+		}
+	}
+	return candidates
+}
+
+func (idx *Index) orCandidates(terms []string) map[string]int {
+	candidates := make(map[string]int)
+	for _, term := range terms {
+		for id := range idx.posting(term) {
+			candidates[id] = 1
+		}
+	}
+	return candidates
 }
 
 // posting returns a copy of the posting list for a term.

--- a/internal/search/index_test.go
+++ b/internal/search/index_test.go
@@ -47,6 +47,22 @@ func TestIndex_SearchMultiTerm(t *testing.T) {
 	}
 }
 
+func TestIndex_SearchMultiTermORFallback(t *testing.T) {
+	idx := New()
+	idx.Add("both", "karpenter handles cluster downscaler work")
+	idx.Add("first", "karpenter provisions nodes")
+	idx.Add("second", "downscaler schedules maintenance")
+
+	hits := idx.Search("karpenter downscaler", "", 10)
+	if len(hits) != 1 || hits[0].ID != "both" {
+		t.Fatalf("AND search got %+v, want only both", hits)
+	}
+	hits = idx.Search("provisions maintenance", "", 10)
+	if len(hits) != 2 {
+		t.Fatalf("OR fallback got %+v, want 2 hits", hits)
+	}
+}
+
 func TestIndex_SearchScope(t *testing.T) {
 	idx := New()
 	idx.Add("arch/runbook", "production deploy runbook")

--- a/internal/sqlindex/sqlindex.go
+++ b/internal/sqlindex/sqlindex.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode/utf8"
 
 	_ "modernc.org/sqlite" // register "sqlite" driver (pure-Go, no CGo)
 )
@@ -153,7 +154,22 @@ func (ix *Index) Delete(id string) error {
 // Any double quotes in the input are stripped to avoid syntax errors.
 func sanitizeFTSQuery(q string) string {
 	clean := strings.ReplaceAll(q, "\"", "")
-	return `"` + clean + `"`
+	tokens := ftsTokens(clean)
+	if len(tokens) == 0 {
+		return `"` + clean + `"`
+	}
+	return `"` + strings.Join(tokens, `" AND "`) + `"`
+}
+
+// ftsTokens returns query terms accepted by FTS5's trigram tokenizer.
+func ftsTokens(q string) []string {
+	var tokens []string
+	for _, token := range strings.Fields(q) {
+		if utf8.RuneCountInString(token) >= 3 {
+			tokens = append(tokens, token)
+		}
+	}
+	return tokens
 }
 
 // ftsSnippetTokens bounds the width of the excerpt returned by FTS5's
@@ -175,11 +191,21 @@ func (ix *Index) SearchFTS(query, scope string, limit int) ([]Hit, error) {
 		return nil, nil
 	}
 
-	sanitized := sanitizeFTSQuery(q)
+	hits, err := ix.searchFTS(sanitizeFTSQuery(q), scope, limit)
+	if err != nil {
+		return nil, err
+	}
 
+	tokens := ftsTokens(strings.ReplaceAll(q, "\"", ""))
+	if len(hits) == 0 && len(tokens) >= 2 {
+		return ix.searchFTS(`"`+strings.Join(tokens, `" OR "`)+`"`, scope, limit)
+	}
+	return hits, nil
+}
+
+func (ix *Index) searchFTS(query, scope string, limit int) ([]Hit, error) {
 	var rows *sql.Rows
 	var err error
-
 	if scope != "" {
 		rows, err = ix.db.Query(
 			`SELECT c.id, -1.0 * bm25(concepts_fts) AS score,
@@ -189,7 +215,7 @@ func (ix *Index) SearchFTS(query, scope string, limit int) ([]Hit, error) {
 			 WHERE concepts_fts MATCH ? AND c.id LIKE ?
 			 ORDER BY score DESC
 			 LIMIT ?`,
-			ftsSnippetTokens, sanitized, scope+"%", limit,
+			ftsSnippetTokens, query, scope+"%", limit,
 		)
 	} else {
 		rows, err = ix.db.Query(
@@ -200,7 +226,7 @@ func (ix *Index) SearchFTS(query, scope string, limit int) ([]Hit, error) {
 			 WHERE concepts_fts MATCH ?
 			 ORDER BY score DESC
 			 LIMIT ?`,
-			ftsSnippetTokens, sanitized, limit,
+			ftsSnippetTokens, query, limit,
 		)
 	}
 	if err != nil {

--- a/internal/sqlindex/sqlindex_test.go
+++ b/internal/sqlindex/sqlindex_test.go
@@ -79,6 +79,65 @@ func TestUpsertAndSearchFTS(t *testing.T) {
 	}
 }
 
+func TestSearchFTS_MultiTermFallback(t *testing.T) {
+	ix, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer ix.Close()
+	if err := ix.Upsert("both", "h1", "karpenter handles cluster downscaler work"); err != nil {
+		t.Fatalf("Upsert both: %v", err)
+	}
+	if err := ix.Upsert("first", "h2", "karpenter provisions nodes"); err != nil {
+		t.Fatalf("Upsert first: %v", err)
+	}
+	if err := ix.Upsert("second", "h3", "downscaler schedules maintenance"); err != nil {
+		t.Fatalf("Upsert second: %v", err)
+	}
+
+	hits, err := ix.SearchFTS("karpenter downscaler", "", 10)
+	if err != nil {
+		t.Fatalf("SearchFTS AND: %v", err)
+	}
+	if len(hits) != 1 || hits[0].ID != "both" {
+		t.Fatalf("AND search got %+v, want only both", hits)
+	}
+
+	hits, err = ix.SearchFTS("provisions maintenance", "", 10)
+	if err != nil {
+		t.Fatalf("SearchFTS OR fallback: %v", err)
+	}
+	if len(hits) != 2 {
+		t.Fatalf("OR fallback got %+v, want 2 hits", hits)
+	}
+}
+
+func TestSearchFTS_ShortTokensAndSingleTerm(t *testing.T) {
+	ix, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer ix.Close()
+	if err := ix.Upsert("c", "h", "api gateway kubernetes"); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	hits, err := ix.SearchFTS("an kubernetes", "", 10)
+	if err != nil {
+		t.Fatalf("SearchFTS short token: %v", err)
+	}
+	if len(hits) != 1 || hits[0].ID != "c" {
+		t.Fatalf("short-token search got %+v, want c", hits)
+	}
+	hits, err = ix.SearchFTS("api", "", 10)
+	if err != nil {
+		t.Fatalf("SearchFTS single term: %v", err)
+	}
+	if len(hits) != 1 || hits[0].ID != "c" {
+		t.Fatalf("single-term search got %+v, want c", hits)
+	}
+}
+
 func TestUpsertUpdate(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "test.db")
 	ix, err := Open(path)


### PR DESCRIPTION
Implements #21 (D89). **Delegated to Codex (`gpt-5.6-terra`)**, coordinator-reviewed.

- **WP1 — multi-term FTS.** `sanitizeFTSQuery` tokenizes on whitespace and ANDs the terms (was a whole-string trigram phrase match); tokens shorter than 3 chars are dropped from the MATCH, falling back to the prior whole-query behavior when none remain. `SearchFTS` retries once with OR when the AND query yields 0 results and there are ≥2 tokens (ranking/bm25 unchanged). Same all-terms-then-any-term policy applied to the in-memory index.
- **WP2 — coherent `mode`.** Both profiles expose `mode: keyword|semantic|hybrid`; the hybrid handler maps `mode` and keeps `use_semantic=true` as a deprecated alias for `hybrid`. The keyword-only rejection message now reads "semantic/hybrid require a server started with --ollama". Capability gate unchanged (D43/AD11).

Tests: sqlindex AND/OR + short-token + single-term; in-memory index parity; `server_test.go` mode accepted/rejected per profile + `use_semantic` alias. `make vet && make test` green (re-verified by the coordinator).

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)