### PR TITLE
feat(onboarding): agent-driven install — kb clone, runbook, prompt template

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,16 @@ curl -fsSL https://raw.githubusercontent.com/BeppeTemp/cartographer/main/install
 go install github.com/BeppeTemp/cartographer/cmd/cartographer@latest
 ```
 
+### Agent-driven install
+
+Give an agent this prompt to install Cartographer, mount its first KB, connect itself, and verify the setup:
+
+```text
+Set up Cartographer on this machine by following
+https://raw.githubusercontent.com/BeppeTemp/cartographer/main/docs/agent-install.md
+My first knowledge base is at: `<git remote URL>`
+```
+
 ## Quick start
 
 The primary path is four commands: install the binary, run it as a native service, create your

--- a/cmd/cartographer/kbcmd.go
+++ b/cmd/cartographer/kbcmd.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/BeppeTemp/cartographer/internal/clientconfig"
 	"github.com/BeppeTemp/cartographer/internal/config"
+	"github.com/BeppeTemp/cartographer/internal/gitx"
 	"github.com/BeppeTemp/cartographer/internal/kb"
 	"github.com/BeppeTemp/cartographer/internal/service"
 )
@@ -46,8 +47,10 @@ func cmdKB(args []string) int {
 	switch target {
 	case "create":
 		return cmdKBCreate(rest)
+	case "clone":
+		return cmdKBClone(rest)
 	default:
-		fmt.Fprintln(os.Stderr, "Error: usage: cartographer kb create <name> [--data <dir>] [--restart]")
+		fmt.Fprintln(os.Stderr, "Error: usage: cartographer kb create <name> [--data <dir>] [--restart]\n       cartographer kb clone <remote> [name] [--data <dir>] [--restart]")
 		return 2
 	}
 }
@@ -122,6 +125,70 @@ func cmdKBCreate(args []string) int {
 	}
 	fmt.Printf("KB %q created at %s\n", name, path)
 
+	printPostCreateGuidanceFn(*restartFlag)
+	return 0
+}
+
+// cmdKBClone implements `cartographer kb clone <remote> [name] [--data <dir>]
+// [--restart]`: mounts a remote KB in the local service data directory. A
+// failed clone or a clone that is not an OKF KB is removed, so auto-discovery
+// never mistakes an unusable directory for a mountable KB.
+func cmdKBClone(args []string) int {
+	remote, rest := splitPositional(args, "")
+	name, rest := splitPositional(rest, "")
+
+	fs := flag.NewFlagSet("kb clone", flag.ExitOnError)
+	dataFlag := fs.String("data", "", "KB data directory (default: the server config's data:, or "+defaultDataDir()+")")
+	restartFlag := fs.Bool("restart", false, "Restart the local service and wait until healthy after mounting the KB")
+	fs.Parse(rest)
+
+	if remote == "" || fs.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "Usage: cartographer kb clone <remote> [name] [--data <dir>] [--restart]")
+		return 2
+	}
+	if name == "" {
+		name = remoteKBName(remote)
+	}
+	if err := validateKBName(name); err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		return 2
+	}
+
+	dataDir := *dataFlag
+	if dataDir == "" {
+		dataDir = resolveServerDataDir()
+	}
+	path := filepath.Join(dataDir, name)
+	if _, err := os.Stat(path); err == nil {
+		fmt.Fprintf(os.Stderr, "Error: %s already exists\n", path)
+		return 1
+	} else if !os.IsNotExist(err) {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		return 1
+	}
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		return 1
+	}
+
+	cloned := false
+	defer func() {
+		if !cloned {
+			_ = os.RemoveAll(path)
+		}
+	}()
+	if err := gitx.Clone(remote, path); err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		fmt.Fprintln(os.Stderr, "Hint: authenticate git with your SSH agent or credential helper, then retry.")
+		return 1
+	}
+	if _, err := kb.Open(path); err != nil {
+		fmt.Fprintln(os.Stderr, "Error: not an OKF KB — import it with the kb-import skill, push, then retry")
+		return 1
+	}
+
+	cloned = true
+	fmt.Printf("KB %q mounted at %s\n", name, path)
 	printPostCreateGuidanceFn(*restartFlag)
 	return 0
 }

--- a/cmd/cartographer/kbcmd_test.go
+++ b/cmd/cartographer/kbcmd_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/BeppeTemp/cartographer/internal/kb"
 )
 
 func TestValidateKBName(t *testing.T) {
@@ -92,6 +94,128 @@ func TestCmdKBCreateInvalidName(t *testing.T) {
 	})
 	if code == 0 {
 		t.Fatal("cmdKBCreate with invalid name = 0, want non-zero")
+	}
+}
+
+func TestCmdKBClone(t *testing.T) {
+	if !hasGit() {
+		t.Skip("git not in PATH, skipping KB clone test")
+	}
+
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "source")
+	if _, err := kb.Init(src); err != nil {
+		t.Fatalf("kb.Init(source): %v", err)
+	}
+	branchOut, err := os.ReadFile(filepath.Join(src, ".git", "HEAD"))
+	if err != nil {
+		t.Fatalf("read source HEAD: %v", err)
+	}
+	branch := string(branchOut[len("ref: refs/heads/"):])
+	branch = branch[:len(branch)-1]
+
+	bare := filepath.Join(tmp, "wiki-kb.git")
+	mustRunGit(t, "", "init", "--bare", bare)
+	mustRunGit(t, src, "remote", "add", "origin", bare)
+	mustRunGit(t, src, "push", "origin", branch+":"+branch)
+	mustRunGit(t, bare, "symbolic-ref", "HEAD", "refs/heads/"+branch)
+
+	data := filepath.Join(tmp, "data")
+	remote := "file://" + bare
+	withNoGuidance(t, func() {
+		if code := cmdKBClone([]string{remote, "--data", data}); code != 0 {
+			t.Fatalf("cmdKBClone = %d, want 0", code)
+		}
+	})
+
+	mounted := filepath.Join(data, "wiki-kb")
+	if _, err := kb.Open(mounted); err != nil {
+		t.Fatalf("kb.Open(mounted clone): %v", err)
+	}
+	for _, rel := range []string{"data/index.md", "data/log.md", ".git"} {
+		if _, err := os.Stat(filepath.Join(mounted, rel)); err != nil {
+			t.Errorf("mounted clone missing %s: %v", rel, err)
+		}
+	}
+	if code := cmdKBClone([]string{remote, "--data", data}); code == 0 {
+		t.Fatal("second cmdKBClone = 0, want already-exists error")
+	}
+}
+
+func TestCmdKBCloneFailureCleansPartialDestination(t *testing.T) {
+	if !hasGit() {
+		t.Skip("git not in PATH, skipping KB clone test")
+	}
+
+	data := filepath.Join(t.TempDir(), "data")
+	withNoGuidance(t, func() {
+		if code := cmdKBClone([]string{"file:///does-not-exist/missing.git", "--data", data}); code == 0 {
+			t.Fatal("cmdKBClone(missing remote) = 0, want error")
+		}
+	})
+	if _, err := os.Stat(filepath.Join(data, "missing")); !os.IsNotExist(err) {
+		t.Fatalf("failed clone destination still exists: %v", err)
+	}
+}
+
+func TestCmdKBCloneRejectsNonOKFRemoteAndCleansDestination(t *testing.T) {
+	if !hasGit() {
+		t.Skip("git not in PATH, skipping KB clone test")
+	}
+
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "source")
+	mustRunGit(t, "", "init", src)
+	mustRunGit(t, src, "config", "user.email", "test@wiki.local")
+	mustRunGit(t, src, "config", "user.name", "Wiki Test")
+	if err := os.WriteFile(filepath.Join(src, "stray.txt"), []byte("not an OKF KB\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunGit(t, src, "add", "stray.txt")
+	mustRunGit(t, src, "commit", "-m", "stray")
+	branchOut, err := os.ReadFile(filepath.Join(src, ".git", "HEAD"))
+	if err != nil {
+		t.Fatalf("read source HEAD: %v", err)
+	}
+	branch := string(branchOut[len("ref: refs/heads/"):])
+	branch = branch[:len(branch)-1]
+
+	bare := filepath.Join(tmp, "non-okf.git")
+	mustRunGit(t, "", "init", "--bare", bare)
+	mustRunGit(t, src, "remote", "add", "origin", bare)
+	mustRunGit(t, src, "push", "origin", branch+":"+branch)
+	mustRunGit(t, bare, "symbolic-ref", "HEAD", "refs/heads/"+branch)
+
+	data := filepath.Join(tmp, "data")
+	withNoGuidance(t, func() {
+		if code := cmdKBClone([]string{"file://" + bare, "--data", data}); code == 0 {
+			t.Fatal("cmdKBClone(non-OKF) = 0, want error")
+		}
+	})
+	if _, err := os.Stat(filepath.Join(data, "non-okf")); !os.IsNotExist(err) {
+		t.Fatalf("non-OKF clone still exists: %v", err)
+	}
+}
+
+func TestCmdKBCloneNameDerivation(t *testing.T) {
+	cases := []struct {
+		remote  string
+		want    string
+		wantErr bool
+	}{
+		{"https://example.test/team/wiki.git", "wiki", false},
+		{"ssh://git@example.test/team/wiki.git/", "wiki", false},
+		{"git@example.test:team/wiki.git", "wiki", false},
+		{"https://example.test/team/bad.name.git", "bad.name", true},
+	}
+	for _, tc := range cases {
+		got := remoteKBName(tc.remote)
+		if got != tc.want {
+			t.Errorf("remoteKBName(%q) = %q, want %q", tc.remote, got, tc.want)
+		}
+		if err := validateKBName(got); (err != nil) != tc.wantErr {
+			t.Errorf("validateKBName(remoteKBName(%q)) error = %v, wantErr %v", tc.remote, err, tc.wantErr)
+		}
 	}
 }
 

--- a/cmd/cartographer/main.go
+++ b/cmd/cartographer/main.go
@@ -22,7 +22,7 @@ type subcommand struct {
 // subcommands lists every subcommand for the usage output.
 var subcommands = []subcommand{
 	{"serve", "Run the MCP server (stdio or HTTP)"},
-	{"kb", "Create and manage local KBs (kb create <name>)"},
+	{"kb", "Create or mount local KBs (kb create|clone)"},
 	{"version", "Print the build version"},
 	{"help", "Show this help message"},
 	{"agents", "List detected/connected agent clients on this machine"},

--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -1,0 +1,113 @@
+# Agent-driven installation
+
+Use this runbook when the user supplies the Cartographer repository link and, optionally, the git
+remote for their first Knowledge Base (KB). Execute every command in order; report the expected
+result before continuing.
+
+## 1. Install Cartographer
+
+Detect the platform:
+
+```bash
+uname -s
+```
+
+Expected output: `Darwin` on macOS, or the name of another supported Unix-like platform. On macOS,
+first check for Homebrew:
+
+```bash
+command -v brew
+```
+
+Expected output: the path to `brew`. If it is present, install Cartographer:
+
+```bash
+brew install beppetemp/tap/cartographer
+```
+
+Expected output: Homebrew reports that `cartographer` was installed. If `brew` is absent, install
+the current release instead:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/BeppeTemp/cartographer/main/install.sh | sh
+```
+
+Expected output: the installer reports the destination of the `cartographer` binary.
+
+Confirm the binary is available:
+
+```bash
+cartographer version
+```
+
+Expected output: a Cartographer version.
+
+## 2. Install the local service
+
+```bash
+cartographer service install
+```
+
+Expected output: the native user service is installed and started. It listens on
+`http://127.0.0.1:8080` and its data directory is ready for KBs.
+
+## 3. Mount the first KB
+
+When the user supplied a KB remote, mount it through Cartographer:
+
+```bash
+cartographer kb clone <git-remote-url> --restart
+```
+
+Expected output: `KB "<name>" mounted at <data-dir>/<name>`, followed by service restart and
+health guidance. Do not clone the repository into the service data directory yourself.
+
+When no remote was supplied, create a new KB instead:
+
+```bash
+cartographer kb create <name> --restart
+```
+
+Expected output: `KB "<name>" created at <data-dir>/<name>`, followed by `service healthy`.
+
+## 4. Connect the executing agent
+
+First identify the installed provider name:
+
+```bash
+cartographer agents
+```
+
+Expected output: a table listing `claude`, `opencode`, `codex`, and `kiro` with installation state.
+Connect the executing provider with `--agents`; for example, for Codex:
+
+```bash
+cartographer connect --agents codex
+```
+
+Expected output: the generated MCP configuration paths and a reminder to restart the agent session.
+With two or more mounted KBs, Cartographer automatically creates one MCP entry per KB.
+
+## 5. Verify the installation
+
+```bash
+cartographer version
+curl -fsS http://127.0.0.1:8080/health
+cartographer status
+```
+
+Expected output: a version, then health JSON containing `"ready":true`, then in-sync status with
+exit code 0. Restart the connected agent session after this check so it loads the MCP tools and
+provisioned skills.
+
+`connect` provisioned the bundled skills, including `cartographer-ops`. Use that skill for ongoing
+operations, diagnosis, upgrades, and synchronization after installation.
+
+## Failures
+
+| Observed symptom | Next action |
+|---|---|
+| `command -v brew` has no output | Run the `install.sh` command in step 1. |
+| The service reports that port 8080 is busy | Stop or reconfigure the process using the port, then rerun `cartographer service install`. |
+| `kb clone` reports a git authentication failure | Configure ambient credentials (an SSH agent for SSH remotes or a git credential helper for HTTPS), then rerun the same `kb clone` command. |
+| `kb clone` says `not an OKF KB` | Use the `kb-import` skill to import the remote into an OKF KB, push it, then rerun `kb clone`. |

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1594,6 +1594,19 @@ and validates every bundled skill and asserts the manifest inventory.
 the end-to-end runbook available to agents on client machines that do not have the repository
 checked out.
 
+## D97 — Agent-driven onboarding mounts remotes through `kb clone`
+
+**Decision.** `cartographer kb clone <remote> [name]` is the local-service entry point for an
+existing first KB. It derives and validates the destination name, clones only into the managed data
+directory, validates the result as OKF, and removes a failed or invalid clone. The stable,
+agent-addressed `docs/agent-install.md` runbook covers installation, service setup, mounting,
+provider connection, and verification; README exposes it as a copy-paste prompt template.
+
+**Rationale.** A hand-run `git clone` cannot enforce the data-directory, name, cleanup, and OKF
+invariants that make a directory mountable by the service. Keeping the bootstrap runbook separate
+from the human tutorial gives an agent a raw-URL-safe, imperative procedure before Cartographer or
+its provisioned `cartographer-ops` skill exists locally.
+
 ## Known deviations from the specification
 
 - TUI configurator: implemented (D35), opt-in via `--tui`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -174,6 +174,7 @@ cartographer service status                  # binary, config, installed/running
 cartographer service start|stop|restart
 cartographer service uninstall               # removes the service; config and data remain
 cartographer kb create <name>                # scaffolds a KB in the service's data dir (D85)
+cartographer kb clone <remote>               # mounts an existing remote KB in that data dir (D97)
 ```
 
 `service install` (idempotent: re-running it rewrites the plist/unit and restarts):
@@ -182,7 +183,7 @@ cartographer kb create <name>                # scaffolds a KB in the service's d
 - macOS: LaunchAgent `~/Library/LaunchAgents/com.cartographer.serve.plist` (`KeepAlive`, logging to `~/Library/Logs/cartographer/server.log`). The plist's binary path prefers a stable Homebrew symlink (`/opt/homebrew/bin/cartographer` or `/usr/local/bin/cartographer`) over the versioned Caskroom path, so it survives `brew upgrade` without a re-install (D83);
 - Linux: systemd user unit `~/.config/systemd/user/cartographer.service` (log via `journalctl --user -u cartographer`; on a headless host, `loginctl enable-linger <user>` is needed for the service to survive logout).
 
-Binds to **loopback** by default (`127.0.0.1:8080`) → auth stays in auto-off mode without exposing anything on the network. With an empty (or missing — D83: `serve` creates it and treats it as empty rather than failing) data dir the server starts with 0 KBs — `/health` is still up (liveness: `status:"ok"`) but `/ready` reports `503 {"ready":false}` (D84, §Observability): `cartographer kb create <name>` scaffolds a subfolder KB the same way `serve --kb <path> --init` would (D85; `service install` itself prints a hint pointing at it if it starts with 0 KBs mounted), or add `kbs:` entries to clone remotes (§Bootstrapping a KB) — either way, `service restart` (or `kb create --restart`, which does this for you and waits for the server to report healthy again) is what makes the new KB visible.
+Binds to **loopback** by default (`127.0.0.1:8080`) → auth stays in auto-off mode without exposing anything on the network. With an empty (or missing — D83: `serve` creates it and treats it as empty rather than failing) data dir the server starts with 0 KBs — `/health` is still up (liveness: `status:"ok"`) but `/ready` reports `503 {"ready":false}` (D84, §Observability): `cartographer kb create <name>` scaffolds a subfolder KB the same way `serve --kb <path> --init` would (D85), while `cartographer kb clone <remote>` mounts an existing OKF remote there (D97; `service install` itself prints a hint pointing at creation if it starts with 0 KBs mounted), or add `kbs:` entries to clone remotes (§Bootstrapping a KB) — either way, `service restart` (or `kb create --restart` / `kb clone --restart`, which do this for you and wait for the server to report healthy again) is what makes the new KB visible.
 
 `service status` uses systemctl-like exit codes: `0` running, `3` installed but stopped, `4` not installed — this is what lets `install.sh update` automatically restart only a running service (see §Client installation).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,6 +21,9 @@ go install github.com/BeppeTemp/cartographer/cmd/cartographer@latest
 multi-provider client (`connect` / `status` / `sync`), and a TUI dashboard
 (run it with no arguments in a terminal).
 
+If an agent is performing the installation from a repository link and a first KB remote, use the
+imperative [agent-driven installation runbook](agent-install.md) instead of this human walkthrough.
+
 ## 2. Start a server with a fresh KB
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ only the pages relevant to your task.
 | File | Contents |
 |---|---|
 | [getting-started.md](getting-started.md) | Zero-to-wiki tutorial: install, first KB, connect an agent, first session |
+| [agent-install.md](agent-install.md) | Command-by-command runbook for an agent to install Cartographer, mount a first KB, connect, and verify |
 | [deployment.md](deployment.md) | Topologies (native local service / k8s / multi-server), server config, observability, backup/DR, crash recovery, upgrades, CI/CD |
 | [configurator.md](configurator.md) | Multi-provider client (`cartographer agents/connect/disconnect/status/sync` + TUI): flags, generated files per provider, `.cartographer.yaml`, lockfile v2, installation |
 | [control-plane.md](control-plane.md) | Go server, complete MCP tool API (source of truth for the list), search index, validation and provenance |
@@ -71,3 +72,4 @@ matching file **in the same session/PR** as the change:
 | New test level or pre-release checklist change | `testing.md` |
 | Contributor workflow (PR flow, plan issues, build loop) | `CONTRIBUTING.md` |
 | User-facing install/onboarding flow | `getting-started.md` + README |
+| Agent-driven install/onboarding flow | `agent-install.md` + README |

--- a/internal/skillbundle/bundled/cartographer-ops/SKILL.md
+++ b/internal/skillbundle/bundled/cartographer-ops/SKILL.md
@@ -19,6 +19,7 @@ around writes.
 | `cartographer serve` | Starting the server directly, for development or a custom deployment. |
 | `cartographer service install\|status\|restart` | Installing, checking, or restarting the native local service. |
 | `cartographer kb create <name>` | Creating the first local KB in the service data directory. |
+| `cartographer kb clone <remote> [name]` | Mounting an existing OKF KB remote in the service data directory. |
 | `cartographer connect [provider\|all] [--agents a,b]` | Connecting one or more detected agent clients to a server. |
 | `cartographer status` | Checking client configuration and provisioning drift. |
 | `cartographer sync` | Realigning provisioned skills, agents, hooks, and instructions. |


### PR DESCRIPTION
Implements all work packages for D97.

Closes #36

Generated-with: Codex