### PR TITLE
fix(sync): pull remote changes on the read path

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -46,9 +46,9 @@ git:
   # (trimmed content = the token), used as HTTPS git credentials for that KB's
   # remote — e.g. /etc/kb-git-tokens/wiki-kb.token for the "wiki-kb" KB above.
   # token_dir: /etc/kb-git-tokens
-  # in_window (D76): freshness window for SyncIn (fetch+pull-rebase) — writes
-  # within this window of the last successful SyncIn skip it. Default 30s,
-  # 0 = sync on every write.
+  # in_window (D76, D93): freshness window for SyncIn (fetch+pull-rebase) — reads
+  # and writes within this window of the last successful SyncIn skip it. Default 30s,
+  # 0 = sync on every read and write.
   # in_window: 30s
   # out_debounce (D76): debounce window for the async per-KB push worker —
   # bursts of writes coalesce into one push, out_debounce after the last one.

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -17,6 +17,8 @@ For each mounted KB, the server keeps only a **rebuildable derived index** and a
 
 **Commit per logical operation (Step 1 — local commit)**: every write tool (`concept_write`, `concept_patch`, `map_create`, `map_delete`, `concept_expand`, `log_append`, `snapshot`, `supersede`, `concept_move`, `concept_delete`, `conflict_resolve`, `skill_install`) is wrapped by `gitWrap`, which acquires the per-KB mutex, runs the tool, and on success (no application error) calls `CommitOp`. A failed commit does not turn a successful operation into an error: it is logged to stderr. `AutoCommit=false` (the struct's zero value) leaves everything unchanged and keeps compatibility with existing tests.
 
+**Read freshness across instances (D93)**: when `git.sync` is enabled and a KB has an `origin`, every tool marked **[R]** piggybacks a fetch + pull-rebase before handling the read, at most once per `git.in_window` per KB. A pull that moves HEAD reconciles the derived indexes before the read, so a remote concept becomes both readable and searchable. Read-side sync is best-effort: a fetch error is logged and serves the local replica; a rebase conflict is registered and its concepts are marked degraded, then the read still serves the local tree. There is no background poller.
+
 ## MCP API
 
 This list is the **source of truth** for the active tools (do not duplicate counts elsewhere).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1579,6 +1579,14 @@ whereas path routing is newer and not required by all clients. Separate agent-vi
 the KB choice explicit and prevent a second mounted KB from turning an existing bare `/mcp` entry
 into a 400, without introducing a client-side multiplexing protocol.
 
+## D93 — Read-path Git freshness
+
+**Status: implemented (2026-07-24).**
+
+**Decision.** Every read-only MCP tool piggybacks `SyncIn` before serving a Git-synchronised KB. The existing `git.in_window` / `CARTOGRAPHER_SYNC_IN_WINDOW` freshness window limits both reads and writes to at most one fetch per KB per window. A pull that moves HEAD uses D90's reconciliation callback before the handler runs. A read-side rebase conflict is registered and marked degraded, while other sync failures are logged; either failure still serves the current local tree.
+
+**Rationale.** Piggybacking avoids a per-KB background poller and its lifecycle/conflict-context complexity while bounding remote work with the existing window. Reads must stay available during a remote or rebase failure, so stale/degraded local content is preferable to turning an otherwise valid read into an MCP error.
+
 ## D96 — Operations knowledge ships as a bundled skill
 
 **Status: implemented (2026-07-24).**

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -60,14 +60,14 @@ kbs:                          # (kbs[]) explicit KBs, local path or remote git (
                                                       # does not imply it
 git:
   autocommit: true            # (git.autocommit) commit after every write
-  sync: true                  # (git.sync) fetch/pull-rebase+push if the KB has a remote
+  sync: true                  # (git.sync) read/write fetch/pull-rebase + post-write push if the KB has a remote
   ssh_key: /etc/kb-ssh/id_ed25519      # (git.ssh_key) default SSH identity for cloning kbs[] remotes
   known_hosts: /etc/kb-ssh/known_hosts # (git.known_hosts) host verification for the same clone
   author_name: cartographer            # (git.author_name) default author/committer (final fallback)
   author_email: cartographer@localhost # (git.author_email)
   token_dir: /etc/kb-git-tokens         # (git.token_dir) directory <token_dir>/<name>.token (D53, see below)
   in_window: 30s                # (git.in_window) SyncIn freshness window: within this duration
-                                # since the last successful fetch+pull, subsequent writes skip it
+                                # since the last successful fetch+pull, subsequent reads and writes skip it
                                 # (no-op). Default 30s, 0 = sync on every write (D76)
   out_debounce: 3s              # (git.out_debounce) debounce of the per-KB async push after the
                                 # commit: N writes in quick succession = 1 push. Default 3s, 0 = push
@@ -146,9 +146,9 @@ Every startup option has a corresponding environment variable (the CLI flag take
 | `CARTOGRAPHER_TOKENS` | `--tokens` | Bearer tokens, comma/whitespace-separated. Each entry is either a bare `token` (admin, full access to every KB) or `token\|scope1;scope2` with per-KB scopes `kb:<name>:r\|rw` (scopes separated by `;`, never by spaces/commas, to avoid colliding with the between-entry separator). E.g. `admintok, readtok\|kb:wiki:r, writetok\|kb:wiki:rw;kb:notes:r` (D44). |
 | `CARTOGRAPHER_AUTH` | — | Explicit auth toggle (see §Auth) |
 | `CARTOGRAPHER_GIT_AUTOCOMMIT` | `--git-autocommit` | Enables the git commit after every write. Default `true`; set to `false` or `0` to disable. |
-| `CARTOGRAPHER_GIT_SYNC` | `--git-sync` | If the KB has an `origin` remote, runs fetch+pull-rebase before and push after every write (git as inter-instance sync). Default `true`; `false`/`0` to disable. Inert if the KB has no remote. |
+| `CARTOGRAPHER_GIT_SYNC` | `--git-sync` | If the KB has an `origin` remote, runs fetch+pull-rebase before reads and writes, then pushes after writes (git as inter-instance sync). Default `true`; `false`/`0` to disable. Inert if the KB has no remote. Read-side sync is best-effort: a network failure serves the local replica; a rebase conflict is registered and the read also serves locally. |
 | `CARTOGRAPHER_GIT_TOKEN_DIR` | — | Directory with one file per KB (`<dir>/<name>.token`) used as the HTTPS credential for that KB's git (D53, see §Bootstrapping a KB from a git remote). |
-| `CARTOGRAPHER_SYNC_IN_WINDOW` | — | Go duration (e.g. `30s`, `0`) of the freshness window on `SyncIn`: within this window since the last successful fetch+pull, subsequent writes skip it. Default `30s`; `0` = sync on every write (D76). |
+| `CARTOGRAPHER_SYNC_IN_WINDOW` | — | Go duration (e.g. `30s`, `0`) of the freshness window on `SyncIn`: within this window since the last successful fetch+pull, subsequent reads and writes skip it. Default `30s`; `0` = sync on every read and write (D76, D93). |
 | `CARTOGRAPHER_SYNC_OUT_DEBOUNCE` | — | Go duration (e.g. `3s`, `0`) of the per-KB async push debounce: N writes in quick succession = 1 push, performed this long after the last signal. Default `3s`; `0` = push synchronously inline, no worker (rollback flag, D76). |
 | `CARTOGRAPHER_SOPS_AGE_KEY_DIR` | — | Directory with a per-KB age key (`<dir>/<name>.age`), a fallback checked before `CARTOGRAPHER_SOPS_AGE_KEY_FILE` (D53). |
 | `CARTOGRAPHER_TOOLS_PROFILE` | `--tools-profile` | `tools/list` tool profile: `agent` (default, only the core set for the LLM agent) \| `full` (all of them). Hidden tools remain callable via `tools/call` (D65, → `control-plane.md` §MCP API). |

--- a/internal/kb/gitsync.go
+++ b/internal/kb/gitsync.go
@@ -28,8 +28,49 @@ func (k *KB) hasRemote() (string, bool) {
 	return "origin", true
 }
 
+// SyncInDue reports whether a SyncIn call could run a fetch. It is deliberately
+// safe to call before acquiring the git lock so read-side callers can avoid the
+// lock on the common disabled, no-remote, and fresh-window paths. A concurrent
+// SyncIn may make the answer stale before the caller acquires that lock; SyncIn
+// repeats the check and safely becomes a no-op in that case.
+func (k *KB) SyncInDue() bool {
+	if !k.GitSync || !gitx.IsRepo(k.Root) {
+		return false
+	}
+	if k.syncInWithinWindow() {
+		return false
+	}
+	if _, ok := k.hasRemote(); !ok {
+		return false
+	}
+	branch, _ := gitx.Branch(k.Root)
+	return branch != ""
+}
+
+func (k *KB) syncInWithinWindow() bool {
+	if k.SyncInWindow <= 0 {
+		return false
+	}
+	k.lastSyncInMu.RLock()
+	last := k.lastSyncIn
+	k.lastSyncInMu.RUnlock()
+	return !last.IsZero() && time.Since(last) < k.SyncInWindow
+}
+
+func (k *KB) setLastSyncIn(now time.Time) {
+	k.lastSyncInMu.Lock()
+	k.lastSyncIn = now
+	k.lastSyncInMu.Unlock()
+}
+
+func (k *KB) lastSyncInAt() time.Time {
+	k.lastSyncInMu.RLock()
+	defer k.lastSyncInMu.RUnlock()
+	return k.lastSyncIn
+}
+
 // SyncIn performs a fetch + pull --rebase --autostash from the "origin" remote
-// BEFORE a write operation. It is a no-op when:
+// before a git-synchronised operation. It is a no-op when:
 //   - k.GitSync is false, or
 //   - the KB root is not a git repository, or
 //   - no "origin" remote is configured, or
@@ -37,37 +78,30 @@ func (k *KB) hasRemote() (string, bool) {
 //     successful SyncIn happened less than k.SyncInWindow ago (D76/WP3) —
 //     avoids a redundant fetch+pull on every write during a burst.
 //
-// Returns gitx.ErrRebaseConflict if the pull hits a conflict (the rebase is
-// aborted automatically). Other network/git errors are propagated as-is.
-// lastSyncIn is only updated after a fetch+pull that actually succeeds.
-func (k *KB) SyncIn() error {
-	if !k.GitSync || !gitx.IsRepo(k.Root) {
-		return nil
+// The returned bool reports whether a fetch was attempted, including a fetch
+// that failed. Returns gitx.ErrRebaseConflict if the pull hits a conflict (the
+// rebase is aborted automatically). Other network/git errors are propagated as
+// is. lastSyncIn is only updated after a fetch+pull that actually succeeds.
+// Callers must hold the git lock.
+func (k *KB) SyncIn() (bool, error) {
+	if !k.SyncInDue() {
+		return false, nil
 	}
-	if k.SyncInWindow > 0 && !k.lastSyncIn.IsZero() && time.Since(k.lastSyncIn) < k.SyncInWindow {
-		return nil
-	}
-	remote, ok := k.hasRemote()
-	if !ok {
-		return nil
-	}
+	remote := "origin"
 	branch, _ := gitx.Branch(k.Root)
-	if branch == "" {
-		return nil // detached HEAD — skip sync
-	}
 	headBefore, _ := gitx.HeadSHA(k.Root)
 	// Fetch first to update remote refs.
 	if err := gitx.Fetch(k.Root, remote, k.GitEnv...); err != nil {
-		return fmt.Errorf("SyncIn fetch: %w", err)
+		return true, fmt.Errorf("SyncIn fetch: %w", err)
 	}
 	if err := gitx.PullRebaseAutostash(k.Root, remote, branch, k.GitEnv...); err != nil {
-		return err
+		return true, err
 	}
-	k.lastSyncIn = time.Now()
+	k.setLastSyncIn(time.Now())
 	if headAfter, err := gitx.HeadSHA(k.Root); err == nil && headAfter != headBefore && k.OnSyncIn != nil {
 		k.OnSyncIn()
 	}
-	return nil
+	return true, nil
 }
 
 // SyncOut pushes the current branch to "origin" AFTER a successful commit.

--- a/internal/kb/kb.go
+++ b/internal/kb/kb.go
@@ -80,10 +80,11 @@ type KB struct {
 	mu sync.Mutex // serialises git operations (see gitsync.go)
 
 	// lastSyncIn is the timestamp of the last successful SyncIn (fetch+pull).
-	// It is only ever read/written while the caller holds the git lock
-	// (gitWrap runs SyncIn under k.WithGitLock), so no separate mutex is
-	// needed. Zero value means "never synced".
-	lastSyncIn time.Time
+	// Read-side sync checks it before taking mu, so lastSyncInMu protects this
+	// small freshness cache independently of the git-operation lock. Zero value
+	// means "never synced".
+	lastSyncInMu sync.RWMutex
+	lastSyncIn   time.Time
 
 	// pushMu guards all async-push-worker bookkeeping below (see
 	// pushworker.go). It is a distinct lock from mu/WithGitLock, which the

--- a/internal/kb/sync_remote_test.go
+++ b/internal/kb/sync_remote_test.go
@@ -122,10 +122,10 @@ func TestSyncIn_FreshnessWindow_SkipsRedundantFetch(t *testing.T) {
 	branch, _ := gitx.Branch(k.Root)
 
 	k.SyncInWindow = 30 * time.Second
-	if err := k.SyncIn(); err != nil {
+	if _, err := k.SyncIn(); err != nil {
 		t.Fatalf("first SyncIn: %v", err)
 	}
-	if k.lastSyncIn.IsZero() {
+	if k.lastSyncInAt().IsZero() {
 		t.Fatalf("first SyncIn should have set lastSyncIn")
 	}
 
@@ -133,7 +133,7 @@ func TestSyncIn_FreshnessWindow_SkipsRedundantFetch(t *testing.T) {
 
 	// Second SyncIn, immediately after the first: within the freshness
 	// window, so it must be a no-op and NOT pull the remote change down.
-	if err := k.SyncIn(); err != nil {
+	if _, err := k.SyncIn(); err != nil {
 		t.Fatalf("second SyncIn (within window): %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(k.Root, "remote-change.txt")); err == nil {
@@ -142,8 +142,8 @@ func TestSyncIn_FreshnessWindow_SkipsRedundantFetch(t *testing.T) {
 
 	// Simulate the window having elapsed by rewinding lastSyncIn: SyncIn
 	// must now actually fetch and pull the remote change.
-	k.lastSyncIn = time.Now().Add(-31 * time.Second)
-	if err := k.SyncIn(); err != nil {
+	k.setLastSyncIn(time.Now().Add(-31 * time.Second))
+	if _, err := k.SyncIn(); err != nil {
 		t.Fatalf("third SyncIn (window elapsed): %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(k.Root, "remote-change.txt")); err != nil {
@@ -165,7 +165,7 @@ func TestSyncIn_WindowZero_AlwaysFetches(t *testing.T) {
 	k.SyncInWindow = 0 // current behavior: sync on every call
 	callbackCalls := 0
 	k.OnSyncIn = func() { callbackCalls++ }
-	if err := k.SyncIn(); err != nil {
+	if _, err := k.SyncIn(); err != nil {
 		t.Fatalf("first SyncIn: %v", err)
 	}
 	if callbackCalls != 0 {
@@ -174,7 +174,7 @@ func TestSyncIn_WindowZero_AlwaysFetches(t *testing.T) {
 
 	pushCommitToBare(t, bare, branch, "remote-change.txt")
 
-	if err := k.SyncIn(); err != nil {
+	if _, err := k.SyncIn(); err != nil {
 		t.Fatalf("second SyncIn: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(k.Root, "remote-change.txt")); err != nil {
@@ -196,7 +196,7 @@ func TestSyncIn_NoRemote_NoOp(t *testing.T) {
 	}
 	k.GitSync = true // enabled but with no remote → still a no-op
 
-	if err := k.SyncIn(); err != nil {
+	if _, err := k.SyncIn(); err != nil {
 		t.Fatalf("SyncIn without a remote must be a no-op, err: %v", err)
 	}
 }

--- a/internal/mcpserver/gitwrap.go
+++ b/internal/mcpserver/gitwrap.go
@@ -50,7 +50,7 @@ func gitWrap(k *kb.KB, t Tool) Tool {
 			// Step 2: fetch + pull --rebase before every write operation.
 			// If the KB has no remote or GitSync is false, SyncIn is a no-op.
 			syncInStart := time.Now()
-			syncErr := k.SyncIn()
+			_, syncErr := k.SyncIn()
 			syncInDur = time.Since(syncInStart)
 			if syncErr != nil {
 				var rce *gitx.RebaseConflictError
@@ -110,6 +110,58 @@ func gitWrap(k *kb.KB, t Tool) Tool {
 		})
 		total := time.Since(start)
 		fmt.Fprintln(os.Stderr, formatTiming(commitMessage(orig.Name, args), syncInDur, handlerDur, commitDur, pushDur, pushAsync, total))
+		return res, handlerErr
+	}
+	return t
+}
+
+// readSyncWrap refreshes a Git-synchronised KB before serving a read. Unlike
+// gitWrap, sync failures are deliberately non-fatal: a reader receives the
+// best currently available local view while an operator can still inspect the
+// stderr diagnostic or the conflict registry.
+func readSyncWrap(k *kb.KB, t Tool) Tool {
+	orig := t
+	t.Handler = func(args json.RawMessage) (ToolResult, error) {
+		// Avoid the git lock entirely when sync is disabled, no remote exists, or
+		// the successful SyncIn is still within its freshness window. The check
+		// can race another SyncIn; SyncIn repeats it after this wrapper acquires
+		// the lock, turning that case into a harmless no-op.
+		if !k.SyncInDue() {
+			return orig.Handler(args)
+		}
+
+		var res ToolResult
+		var handlerErr error
+		var syncInDur, handlerDur time.Duration
+		var fetchRan bool
+		start := time.Now()
+		_ = k.WithGitLock(func() error { // inner func always returns nil
+			syncInStart := time.Now()
+			var syncErr error
+			fetchRan, syncErr = k.SyncIn()
+			if fetchRan {
+				syncInDur = time.Since(syncInStart)
+			}
+			if syncErr != nil {
+				var rce *gitx.RebaseConflictError
+				if errors.As(syncErr, &rce) {
+					n := handleConflictError(k, rce)
+					fmt.Fprintf(os.Stderr,
+						"cartographer: git conflict during read sync (%s): registered %d concept(s) as degraded\n",
+						orig.Name, n)
+				} else {
+					fmt.Fprintf(os.Stderr, "cartographer: git sync failed during read (%s): %v\n", orig.Name, syncErr)
+				}
+			}
+
+			handlerStart := time.Now()
+			res, handlerErr = orig.Handler(args)
+			handlerDur = time.Since(handlerStart)
+			return nil
+		})
+		if fetchRan {
+			fmt.Fprintln(os.Stderr, formatTiming(orig.Name, syncInDur, handlerDur, 0, 0, false, time.Since(start)))
+		}
 		return res, handlerErr
 	}
 	return t

--- a/internal/mcpserver/gitwrap_test.go
+++ b/internal/mcpserver/gitwrap_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/BeppeTemp/cartographer/internal/gitx"
 	"github.com/BeppeTemp/cartographer/internal/kb"
+	"github.com/BeppeTemp/cartographer/internal/sqlindex"
 )
 
 // setupGitKB initialises a temp KB and verifies the initial git commit was made.
@@ -174,6 +175,157 @@ func remoteCommitCount(t *testing.T, dir, branch string) string {
 		t.Fatalf("git rev-list --count: %v\n%s", err, out)
 	}
 	return strings.TrimSpace(string(out))
+}
+
+// pushRemoteFile simulates a second server by committing a KB file through a
+// fresh clone of the shared bare remote.
+func pushRemoteFile(t *testing.T, bare, branch, relPath, content, message string) {
+	t.Helper()
+	clone := filepath.Join(t.TempDir(), "clone")
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+	run(filepath.Dir(clone), "clone", bare, clone)
+	run(clone, "checkout", branch)
+	path := filepath.Join(clone, relPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(clone, "add", relPath)
+	run(clone, "-c", "user.email=test@test", "-c", "user.name=test", "commit", "-m", message)
+	run(clone, "push", "origin", branch)
+}
+
+func syncInForTest(t *testing.T, k *kb.KB) {
+	t.Helper()
+	if err := k.WithGitLock(func() error {
+		_, err := k.SyncIn()
+		return err
+	}); err != nil {
+		t.Fatalf("SyncIn: %v", err)
+	}
+}
+
+func TestReadSyncWrap_RefreshesRemoteConceptAndSearch(t *testing.T) {
+	k, bare := setupGitKBWithRemote(t)
+	k.GitSync = true
+	if err := k.SyncOut(); err != nil {
+		t.Fatalf("seed SyncOut: %v", err)
+	}
+	k.SyncInWindow = time.Hour
+	branch, _ := gitx.Branch(k.Root)
+
+	sqlIdx, err := sqlindex.Open(filepath.Join(t.TempDir(), "index.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqlIdx.Close()
+	s := New("0.1.0-test")
+	RegisterKBTools(s, k, Deps{SQLIndex: sqlIdx})
+
+	pushRemoteFile(t, bare, branch, "data/remote/fresh.md", "---\ntype: Note\ntitle: Fresh\n---\nremote-sync-fresh\n", "remote fresh")
+	resps := runMCPSequence(t, s, []string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"concept_read","arguments":{"id":"remote/fresh"}}}`,
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"search","arguments":{"query":"remote-sync-fresh"}}}`,
+	})
+	if got := decodeToolResult(t, resps[1]); got.IsError || !strings.Contains(got.Content[0].Text, "remote-sync-fresh") {
+		t.Fatalf("concept_read after remote change = %+v", got)
+	}
+	if got := decodeToolResult(t, resps[2]); got.IsError || !strings.Contains(got.Content[0].Text, "remote/fresh") {
+		t.Fatalf("search after read-side SyncIn = %+v", got)
+	}
+
+	// A second remote commit remains invisible during the freshness window: the
+	// immediate read must not fetch again.
+	pushRemoteFile(t, bare, branch, "data/remote/second.md", "---\ntype: Note\ntitle: Second\n---\nremote-sync-second\n", "remote second")
+	resps = runMCPSequence(t, s, []string{
+		`{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"concept_read","arguments":{"id":"remote/second"}}}`,
+	})
+	if got := decodeToolResult(t, resps[0]); !got.IsError {
+		t.Fatalf("concept_read within SyncInWindow fetched remote change: %+v", got)
+	}
+
+	// Disabling the window makes the next read fetch the pending change.
+	k.SyncInWindow = 0
+	resps = runMCPSequence(t, s, []string{
+		`{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"concept_read","arguments":{"id":"remote/second"}}}`,
+	})
+	if got := decodeToolResult(t, resps[0]); got.IsError || !strings.Contains(got.Content[0].Text, "remote-sync-second") {
+		t.Fatalf("concept_read after SyncInWindow disabled = %+v", got)
+	}
+}
+
+func TestReadSyncWrap_ConflictDegradesAndServesLocalRead(t *testing.T) {
+	k, bare := setupGitKBWithRemote(t)
+	k.GitSync = true
+	if err := k.SyncOut(); err != nil {
+		t.Fatalf("seed SyncOut: %v", err)
+	}
+	branch, _ := gitx.Branch(k.Root)
+	path := "data/remote/conflict.md"
+	base := "---\ntype: Note\ntitle: Conflict\n---\nbase\n"
+	pushRemoteFile(t, bare, branch, path, base, "remote base")
+	syncInForTest(t, k)
+
+	local := "---\ntype: Note\ntitle: Conflict\n---\nlocal version\n"
+	if err := os.WriteFile(filepath.Join(k.Root, path), []byte(local), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := gitx.Commit(k.Root, "local conflict", "test", "test@test"); err != nil {
+		t.Fatal(err)
+	}
+	remote := "---\ntype: Note\ntitle: Conflict\n---\nremote version\n"
+	pushRemoteFile(t, bare, branch, path, remote, "remote conflict")
+
+	s := New("0.1.0-test")
+	RegisterKBTools(s, k, Deps{})
+	resps := runMCPSequence(t, s, []string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"concept_read","arguments":{"id":"remote/conflict"}}}`,
+	})
+	if got := decodeToolResult(t, resps[1]); got.IsError || !strings.Contains(got.Content[0].Text, "local version") {
+		t.Fatalf("read after rebase conflict = %+v", got)
+	}
+	conflicts, err := k.ListConflicts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(conflicts) != 1 || conflicts[0].ConceptID != "remote/conflict" {
+		t.Fatalf("registered conflicts = %+v", conflicts)
+	}
+}
+
+func TestReadSyncWrap_DisabledOrNoRemoteKeepsReadPathWorking(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		gitSync bool
+	}{
+		{name: "sync disabled", gitSync: false},
+		{name: "no remote", gitSync: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			k := setupTestKB(t)
+			k.GitSync = tc.gitSync
+			s := New("0.1.0-test")
+			RegisterKBTools(s, k, Deps{})
+			resps := runMCPSequence(t, s, []string{
+				`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}`,
+				`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"concept_read","arguments":{"id":"manutenzione/test-runbook"}}}`,
+			})
+			if got := decodeToolResult(t, resps[1]); got.IsError || !strings.Contains(got.Content[0].Text, "Test Runbook") {
+				t.Fatalf("concept_read = %+v", got)
+			}
+		})
+	}
 }
 
 // TestGitWrap_AsyncPush_CommitIsSyncPushIsDeferred verifies the D76/WP4

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -40,6 +40,13 @@ type Deps struct {
 //
 // Builds the keyword index at registration time.
 func RegisterKBTools(s *Server, k *kb.KB, deps Deps) {
+	register := func(t Tool) {
+		if t.ReadOnly {
+			t = readSyncWrap(k, t)
+		}
+		s.RegisterTool(t)
+	}
+
 	// D76/WP4: route conflicts detected by the async push worker (see
 	// pushworker.go) through the same conflict-registry/degraded handling
 	// used for synchronous pushes in gitWrap. No-op when SyncOutDebounce==0
@@ -65,52 +72,52 @@ func RegisterKBTools(s *Server, k *kb.KB, deps Deps) {
 		}
 	}
 
-	s.RegisterTool(toolAtlasOverview(k))
-	s.RegisterTool(toolIndexGet(k))
-	s.RegisterTool(toolConceptRead(k))
-	s.RegisterTool(toolLogTail(k))
-	s.RegisterTool(gitWrap(k, toolConceptWrite(k, live, deps.SQLIndex)))
-	s.RegisterTool(gitWrap(k, toolConceptPatch(k, live, deps.SQLIndex)))
-	s.RegisterTool(gitWrap(k, toolMapCreate(k)))
-	s.RegisterTool(gitWrap(k, toolMapDelete(k)))
-	s.RegisterTool(gitWrap(k, toolConceptExpand(k)))
-	s.RegisterTool(gitWrap(k, toolLogAppend(k)))
-	s.RegisterTool(gitWrap(k, toolSnapshot(k)))
-	s.RegisterTool(toolValidate(k))
-	s.RegisterTool(toolMapList(k))
-	s.RegisterTool(toolConceptList(k))
-	s.RegisterTool(toolGraphNeighbors(k))
-	s.RegisterTool(toolSearch(k, live, deps))
-	s.RegisterTool(toolIndexRebuild(k, live, deps))
-	s.RegisterTool(toolReindex(k, live, deps.SQLIndex))
-	s.RegisterTool(toolLint(k))
-	s.RegisterTool(toolCommitGate(k))
-	s.RegisterTool(toolGateCheck(k))
-	s.RegisterTool(gitWrap(k, toolSupersede(k)))
-	s.RegisterTool(gitWrap(k, toolConceptMove(k, live, deps.SQLIndex)))
-	s.RegisterTool(gitWrap(k, toolConceptDelete(k, live, deps.SQLIndex)))
-	s.RegisterTool(gitWrap(k, toolConflictResolve(k)))
-	s.RegisterTool(toolKBStatus(k))
-	s.RegisterTool(toolContradictionReport(k))
-	s.RegisterTool(toolConflictsList(k))
-	s.RegisterTool(toolGitConflictResolve(k))
-	s.RegisterTool(toolServiceGet(k))
-	s.RegisterTool(toolServiceList(k))
-	s.RegisterTool(toolArtifactRead(k))
-	s.RegisterTool(toolArtifactList(k))
+	register(toolAtlasOverview(k))
+	register(toolIndexGet(k))
+	register(toolConceptRead(k))
+	register(toolLogTail(k))
+	register(gitWrap(k, toolConceptWrite(k, live, deps.SQLIndex)))
+	register(gitWrap(k, toolConceptPatch(k, live, deps.SQLIndex)))
+	register(gitWrap(k, toolMapCreate(k)))
+	register(gitWrap(k, toolMapDelete(k)))
+	register(gitWrap(k, toolConceptExpand(k)))
+	register(gitWrap(k, toolLogAppend(k)))
+	register(gitWrap(k, toolSnapshot(k)))
+	register(toolValidate(k))
+	register(toolMapList(k))
+	register(toolConceptList(k))
+	register(toolGraphNeighbors(k))
+	register(toolSearch(k, live, deps))
+	register(toolIndexRebuild(k, live, deps))
+	register(toolReindex(k, live, deps.SQLIndex))
+	register(toolLint(k))
+	register(toolCommitGate(k))
+	register(toolGateCheck(k))
+	register(gitWrap(k, toolSupersede(k)))
+	register(gitWrap(k, toolConceptMove(k, live, deps.SQLIndex)))
+	register(gitWrap(k, toolConceptDelete(k, live, deps.SQLIndex)))
+	register(gitWrap(k, toolConflictResolve(k)))
+	register(toolKBStatus(k))
+	register(toolContradictionReport(k))
+	register(toolConflictsList(k))
+	register(toolGitConflictResolve(k))
+	register(toolServiceGet(k))
+	register(toolServiceList(k))
+	register(toolArtifactRead(k))
+	register(toolArtifactList(k))
 	if k.AllowArtifactWrite {
-		s.RegisterTool(artifactNotifyWrap(s, gitWrap(k, toolArtifactWrite(k))))
-		s.RegisterTool(artifactNotifyWrap(s, gitWrap(k, toolArtifactDelete(k))))
+		register(artifactNotifyWrap(s, gitWrap(k, toolArtifactWrite(k))))
+		register(artifactNotifyWrap(s, gitWrap(k, toolArtifactDelete(k))))
 	}
 
 	if deps.BundleFS != nil {
-		s.RegisterTool(toolSkillListWithBundle(k, deps.BundleFS))
-		s.RegisterTool(notifyWrap(s, gitWrap(k, toolSkillInstall(k, deps.BundleFS)), "notifications/skills/list_changed"))
-		s.RegisterTool(toolSyncCheck(k, deps.BundleFS))
-		s.RegisterTool(toolSyncApply(k, deps.BundleFS))
-		s.RegisterTool(toolSyncPull(k, deps.BundleFS))
+		register(toolSkillListWithBundle(k, deps.BundleFS))
+		register(notifyWrap(s, gitWrap(k, toolSkillInstall(k, deps.BundleFS)), "notifications/skills/list_changed"))
+		register(toolSyncCheck(k, deps.BundleFS))
+		register(toolSyncApply(k, deps.BundleFS))
+		register(toolSyncPull(k, deps.BundleFS))
 	} else {
-		s.RegisterTool(toolSkillList(k))
+		register(toolSkillList(k))
 	}
 }
 


### PR DESCRIPTION
Implements all work packages for D93.

Closes #26

Generated-with: Codex