### PR TITLE
feat(client): surface server and client versions with upgrade drift hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ name, token env var, auth) instead of the flag defaults; pass `--no-input` to
 force the non-interactive behavior. Once connected:
 
 ```bash
-cartographer status   # drift check: exit 0 in-sync / 1 drift / 2 error
+cartographer status   # drift check and client/server version check after upgrades; exit 0 in-sync / 1 drift / 2 error
 cartographer sync     # re-apply after drift
 ```
 

--- a/cmd/cartographer/status.go
+++ b/cmd/cartographer/status.go
@@ -4,10 +4,25 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
+	"github.com/BeppeTemp/cartographer/internal/client"
 	"github.com/BeppeTemp/cartographer/internal/clientconfig"
 	"github.com/BeppeTemp/cartographer/internal/configurator"
 	"github.com/BeppeTemp/cartographer/internal/provisioning"
+	"github.com/BeppeTemp/cartographer/internal/service"
+)
+
+const statusHealthTimeout = 5 * time.Second
+
+// Indirection keeps cmdStatus's version report independently testable without
+// a network connection or a real launchd/systemd service.
+var (
+	statusHealthFn = func(cfg *clientconfig.Config) (*client.Health, error) {
+		return client.New(cfg.ServerURL, resolveToken(cfg)).Health(statusHealthTimeout)
+	}
+	statusManifestFn = fetchMergedManifest
+	statusServiceFn  = func() (service.Status, error) { return service.NewManager().Status("") }
 )
 
 // cmdStatus reports the sync status of every connected provider against the
@@ -32,7 +47,9 @@ func cmdStatus(args []string) int {
 		return 0
 	}
 
-	m, err := fetchMergedManifest(cfg)
+	printVersionStatus(cfg)
+
+	m, err := statusManifestFn(cfg)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)
 		return 2
@@ -95,4 +112,29 @@ func cmdStatus(args []string) int {
 		return 1
 	}
 	return 0
+}
+
+// printVersionStatus reports the binary versions before the artifact status.
+// A failed health request is intentionally non-fatal here: the following
+// sync_pull still performs the existing artifact check and preserves its exit
+// code/error behaviour. Version skew is advisory, never provisioning drift.
+func printVersionStatus(cfg *clientconfig.Config) {
+	health, err := statusHealthFn(cfg)
+	if err != nil {
+		fmt.Printf("client %s — server unreachable (%s)\n", version, cfg.ServerURL)
+		return
+	}
+
+	fmt.Printf("client %s — server %s (%s)\n", version, health.Version, cfg.ServerURL)
+	if version == "" || health.Version == "" || version == "dev" || health.Version == "dev" || version == health.Version {
+		return
+	}
+
+	fmt.Printf("version skew: client %s ≠ server %s\n", version, health.Version)
+	if !isLoopbackURL(cfg.ServerURL) {
+		return
+	}
+	if st, err := statusServiceFn(); err == nil && st.Installed {
+		fmt.Println("local service may still run the old binary — run: cartographer service restart")
+	}
 }

--- a/cmd/cartographer/status_test.go
+++ b/cmd/cartographer/status_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/BeppeTemp/cartographer/internal/client"
+	"github.com/BeppeTemp/cartographer/internal/clientconfig"
+	"github.com/BeppeTemp/cartographer/internal/provisioning"
+	"github.com/BeppeTemp/cartographer/internal/service"
+)
+
+func TestCmdStatus_VersionReport(t *testing.T) {
+	cases := []struct {
+		name             string
+		serverURL        string
+		clientVersion    string
+		serverVersion    string
+		serviceInstalled bool
+		want             []string
+		dontWant         []string
+	}{
+		{
+			name:          "matching versions",
+			serverURL:     "https://cartographer.example/mcp",
+			clientVersion: "v1.2.3",
+			serverVersion: "v1.2.3",
+			want:          []string{"client v1.2.3 — server v1.2.3 (https://cartographer.example/mcp)", "[claude] in-sync"},
+			dontWant:      []string{"version skew:", "old binary"},
+		},
+		{
+			name:          "remote skew",
+			serverURL:     "https://cartographer.example/mcp",
+			clientVersion: "v1.2.3",
+			serverVersion: "v1.2.2",
+			want:          []string{"version skew: client v1.2.3 ≠ server v1.2.2"},
+			dontWant:      []string{"old binary"},
+		},
+		{
+			name:             "loopback installed service",
+			serverURL:        "http://127.0.0.1:8080/mcp",
+			clientVersion:    "v1.2.3",
+			serverVersion:    "v1.2.2",
+			serviceInstalled: true,
+			want: []string{
+				"version skew: client v1.2.3 ≠ server v1.2.2",
+				"local service may still run the old binary — run: cartographer service restart",
+			},
+		},
+		{
+			name:          "dev is silent",
+			serverURL:     "https://cartographer.example/mcp",
+			clientVersion: "dev",
+			serverVersion: "v1.2.2",
+			want:          []string{"client dev — server v1.2.2"},
+			dontWant:      []string{"version skew:", "old binary"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			if err := clientconfig.Save(home, &clientconfig.Config{ServerURL: tc.serverURL, Agents: []string{"claude"}, Trust: true}); err != nil {
+				t.Fatalf("save config: %v", err)
+			}
+			if err := provisioning.WriteLockFile(lockFilePath(home), provisioning.LockFile{Providers: map[string]provisioning.Lock{
+				"claude": {Provider: "claude", AppliedRevision: "rev1"},
+			}}); err != nil {
+				t.Fatalf("write lockfile: %v", err)
+			}
+
+			oldVersion, oldHealth, oldManifest, oldService := version, statusHealthFn, statusManifestFn, statusServiceFn
+			version = tc.clientVersion
+			statusHealthFn = func(*clientconfig.Config) (*client.Health, error) {
+				return &client.Health{Version: tc.serverVersion}, nil
+			}
+			statusManifestFn = func(*clientconfig.Config) (provisioning.Manifest, error) {
+				return provisioning.Manifest{Revision: "rev1"}, nil
+			}
+			statusServiceFn = func() (service.Status, error) { return service.Status{Installed: tc.serviceInstalled}, nil }
+			t.Cleanup(func() {
+				version, statusHealthFn, statusManifestFn, statusServiceFn = oldVersion, oldHealth, oldManifest, oldService
+			})
+
+			out := withStdout(t, func() {
+				if code := cmdStatus(nil); code != 0 {
+					t.Errorf("cmdStatus = %d, want 0", code)
+				}
+			})
+			for _, want := range tc.want {
+				if !strings.Contains(out, want) {
+					t.Errorf("output = %q, want %q", out, want)
+				}
+			}
+			for _, dontWant := range tc.dontWant {
+				if strings.Contains(out, dontWant) {
+					t.Errorf("output = %q, must not contain %q", out, dontWant)
+				}
+			}
+		})
+	}
+}

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -135,7 +135,9 @@ cartographer status
 Exit code: `0` all providers in sync, `1` at least one provider in drift, `2` error (no
 `.cartographer.yaml`, server unreachable, ...). For every provider it also prints per-kind
 counts (`provisioning.KindCounts`), e.g. `skill 4/5 · agent 2/2 · hook 1/1`. On drift it
-prints the diff (added/updated/removed, with `signed`).
+prints the diff (added/updated/removed, with `signed`). Before the artifact report it prints the
+client and server versions. A non-`dev` mismatch is a warning only (it does not change the exit
+code); on loopback, an installed local service also gets a `cartographer service restart` hint.
 
 ### `cartographer sync`
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1595,6 +1595,14 @@ into a 400, without introducing a client-side multiplexing protocol.
 
 **Rationale.** Every MCP write already creates a Git commit, so Git supplies the authoritative timestamp, author and concept-level history without introducing client state. A compact per-concept aggregate answers a return-to-work digest without exposing raw commit noise.
 
+## D95 — Upgrade transparency through version-skew hints
+
+**Status: implemented (2026-07-24).**
+
+**Decision.** `cartographer status` reports the client and server versions before its provisioning-artifact result. A non-`dev` version mismatch is advisory and leaves the existing status exit codes unchanged; for a loopback server with an installed native service, the warning includes the explicit `cartographer service restart` command. Servers that predate the health version field remain compatible and simply produce no skew warning.
+
+**Rationale.** A Homebrew upgrade replaces the binary at the stable path, but cannot safely replace a process already executing it. Automatically restarting from a cask hook could interrupt an in-flight write and bypass the operator's drain decision, while an explicit, contextual hint makes the necessary restart visible. The same report makes a client ahead of a Kubernetes image rollout observable without inventing a separate drift state.
+
 ## D96 — Operations knowledge ships as a bundled skill
 
 **Status: implemented (2026-07-24).**

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -324,6 +324,7 @@ At boot the server detects and repairs an interrupted git state: a half-finished
 ## Upgrades, schema migration, and repo growth
 
 - **Server upgrade** with mounted KBs: drain (flush pushes, release mutexes) before restart.
+- **Homebrew upgrade**: `brew upgrade` replaces the binary behind Homebrew's stable symlink, but an already-running native service keeps its old process until `cartographer service restart`. Run `cartographer status` after upgrading: it reports client/server versions and warns about skew, including the restart hint for an installed local service. Do not restart from a cask hook: an explicit restart keeps the operator in control of the drain. For Kubernetes, bump the image tag; connected clients surface the same version skew while the rollout catches up.
 - **Schema versioning**: bundle-level `okf_version` **and** per-concept `schema_version`, with a migration procedure for existing `.md` files (no destructive overwrite).
 - **Repo growth**: retention/archival of closed journals, `git-LFS` or blobless/shallow clone for large `raw/` content, incremental index for `commit_gate`.
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -36,9 +36,10 @@ type MCPClient struct {
 // distinguish an older server that did not send either field from an explicit
 // false/empty value.
 type Health struct {
-	Status string      `json:"status"`
-	Ready  *bool       `json:"ready"`
-	KBs    *[]HealthKB `json:"kbs"`
+	Status  string      `json:"status"`
+	Version string      `json:"version"`
+	Ready   *bool       `json:"ready"`
+	KBs     *[]HealthKB `json:"kbs"`
 }
 
 // HealthKB is the additive per-KB item returned by a MultiKB server's

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -215,7 +215,7 @@ func TestPing_DoesNotMutateClientTimeout(t *testing.T) {
 	}
 }
 
-func TestHealth_StripsMCPPathAndPreservesAbsentFields(t *testing.T) {
+func TestHealth_StripsMCPPathAndParsesVersion(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("method = %s, want GET", r.Method)
@@ -224,7 +224,7 @@ func TestHealth_StripsMCPPathAndPreservesAbsentFields(t *testing.T) {
 			t.Errorf("path = %q, want /health", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"status":"ok","kbs":[]}`))
+		w.Write([]byte(`{"status":"ok","version":"v1.2.3","kbs":[]}`))
 	}))
 	defer srv.Close()
 
@@ -232,7 +232,23 @@ func TestHealth_StripsMCPPathAndPreservesAbsentFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Health: %v", err)
 	}
-	if health.Status != "ok" || health.Ready != nil || health.KBs == nil || len(*health.KBs) != 0 {
-		t.Errorf("Health = %+v, want status=ok ready=nil kbs=empty-present", health)
+	if health.Status != "ok" || health.Version != "v1.2.3" || health.Ready != nil || health.KBs == nil || len(*health.KBs) != 0 {
+		t.Errorf("Health = %+v, want status=ok version=v1.2.3 ready=nil kbs=empty-present", health)
+	}
+}
+
+func TestHealth_PreservesAbsentVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer srv.Close()
+
+	health, err := client.New(srv.URL, "").Health(time.Second)
+	if err != nil {
+		t.Fatalf("Health: %v", err)
+	}
+	if health.Version != "" {
+		t.Errorf("Health.Version = %q, want empty for an older server", health.Version)
 	}
 }


### PR DESCRIPTION
Implements all work packages for D95.

Closes #34

Generated-with: Codex