### PR TITLE
feat(docs): publish docs/ to GitHub Pages with MkDocs Material

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,58 @@
+name: docs
+
+# Publishes docs/ to GitHub Pages via MkDocs Material. The source of truth
+# stays the markdown in docs/ (updated in the same PR as the code, see
+# docs/index.md §Maintenance rules); this only renders it.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - run: pip install mkdocs-material==9.6.14
+      # --strict turns broken internal links and nav typos into build failures,
+      # so a PR that moves a page can't silently break the published site.
+      - run: mkdocs build --strict
+      - uses: actions/upload-pages-artifact@v4
+        if: github.event_name != 'pull_request'
+        with:
+          path: site
+
+  deploy:
+    name: deploy
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ test/e2e/                   # Agent-level E2E harness
 
 ## Documentation
 
+Browsable at **[beppetemp.github.io/cartographer](https://beppetemp.github.io/cartographer/)** — same content as `docs/`, rendered.
+
 The full index lives in [`docs/index.md`](docs/index.md). Main entry points:
 
 - [`docs/overview.md`](docs/overview.md) — vision, guiding principles, architecture

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1641,6 +1641,14 @@ Applied by extracting six backlog items from the prose into issues #51–#56 (fi
 
 **Consequences.** `docs/index.md` §Maintenance rules gains the routing row ("feature not implemented → issue, never prose"). `roadmap.md` §Planned work is a pointer to the `enhancement` label. A plan issue (label `plan`) remains the design→implementation handoff for *scheduled* work: `enhancement` is the not-yet-scheduled backlog.
 
+## D100 — Community surfaces: Pages from `docs/`, Discussions on, Wiki off
+
+**Decision.** Three GitHub surfaces settled at once. **Wiki: disabled.** **Pages: enabled**, built by MkDocs Material from `docs/` (`mkdocs.yml`, workflow `.github/workflows/docs.yml`, `mkdocs build --strict`) — the markdown in `docs/` stays the single source, the site is only a rendering of it. **Discussions: enabled**, as the place for questions whose answer isn't documentation yet; when an answer stabilizes it is promoted into `docs/` through a PR.
+
+**Rationale.** The wiki is a *separate git repo*: no PR, no `test` check, no review, and — decisive here — no way to change it in the same commit as the code, which is the project's central documentation invariant (D98, `docs/index.md` §Maintenance rules). It would have re-created, in a place nobody diffs, exactly the drift D98 removed. It adds nothing for agents either (they read `docs/` from the repo or by raw URL; `agent-install.md` is already the raw-URL-safe runbook, D97), and it would put runbooks that run `curl … | sh` and handle tokens somewhere editable without review. Pages gives the readability a wiki promises without giving up the PR flow.
+
+**Consequences.** `--strict` makes a broken internal link a build failure, so moving a page breaks CI instead of the published site: the two `../` links out of `docs/` (`config.example.yaml`, `test/e2e/README.md`) became absolute GitHub URLs. The nav in `mkdocs.yml` mirrors the grouping of `docs/index.md`, which remains the canonical map — a new page goes in both.
+
 ## Known deviations from the specification
 
 - TUI configurator: implemented (D35), opt-in via `--tui`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -26,7 +26,7 @@ The server process is **ephemeral** (k8s pod or local service); what persists on
 (`internal/config`, `config.Default()`). The YAML file is optional: without `--config`, only
 defaults + env + flags apply, as in earlier versions.
 
-Full annotated example: [`config.example.yaml`](../config.example.yaml) (repo root).
+Full annotated example: [`config.example.yaml`](https://github.com/BeppeTemp/cartographer/blob/main/config.example.yaml) (repo root).
 Schema (`internal/config.Config`, YAML tags in parentheses):
 
 ```yaml

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -81,7 +81,7 @@ use `E2E_MODEL=opencode-go/claude-sonnet-4-5 make e2e`.
 
 The oracle is the **state of the KB on filesystem and git**, not the text produced by the agent
 (operator-vs-agent principle). Every scenario is self-contained: it creates its own KB, starts
-and stops its own server (trap EXIT). See [`test/e2e/README.md`](../test/e2e/README.md)
+and stops its own server (trap EXIT). See [`test/e2e/README.md`](https://github.com/BeppeTemp/cartographer/blob/main/test/e2e/README.md)
 for prerequisites, flags and how to add scenarios.
 
 #### Available E2E scenarios

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,73 @@
+site_name: Cartographer
+site_description: MCP server for the Agentic Wiki — Karpathy pattern + Open Knowledge Format
+site_url: https://beppetemp.github.io/cartographer/
+repo_url: https://github.com/BeppeTemp/cartographer
+repo_name: BeppeTemp/cartographer
+edit_uri: edit/main/docs/
+copyright: Apache-2.0 — the docs are the files in docs/, published as-is
+
+docs_dir: docs
+
+theme:
+  name: material
+  icon:
+    repo: fontawesome/brands/github
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.top
+    - navigation.tracking
+    - content.action.edit
+    - content.code.copy
+    - search.highlight
+    - search.suggest
+    - toc.follow
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - pymdownx.details
+  - pymdownx.superfences
+  - toc:
+      permalink: true
+
+plugins:
+  - search
+
+# Mirrors the grouping of docs/index.md — that page stays the canonical map,
+# this nav is only the sidebar rendering of it.
+nav:
+  - Home: index.md
+  - Using Cartographer:
+      - Getting started: getting-started.md
+      - Agent install runbook: agent-install.md
+      - Deployment: deployment.md
+      - Client (configurator): configurator.md
+      - Control plane (MCP API): control-plane.md
+      - Data plane (KB model): data-plane.md
+      - Skills, services, secrets: skills-services-secrets.md
+      - Provisioning sync: sync.md
+      - Use cases: use-cases.md
+  - Internals & contributing:
+      - Overview: overview.md
+      - Concurrency and git: concurrency.md
+      - Transport and auth: transport-auth.md
+      - Operating loop: loop.md
+      - Interoperability: interoperability.md
+      - Decisions: decisions.md
+      - Go conventions: conventions.md
+      - Roadmap and status: roadmap.md
+      - Testing: testing.md
+      - References: references.md


### PR DESCRIPTION
Settles the three GitHub surfaces discussed: **Wiki off, Pages on, Discussions on** (D100).

## Why not the wiki

The wiki tab was enabled and empty. A wiki is a **separate git repo**: no PR, no `test` check, no review, and no way to change it in the same commit as the code — the documentation invariant D98 just reinforced. It would have re-created, somewhere nobody diffs, exactly the drift #57 removed. It adds nothing for agents (they read `docs/` from the repo or by raw URL; `agent-install.md` is already the raw-URL-safe runbook), and it would put runbooks that run `curl … | sh` and handle tokens somewhere editable without review.

Already applied outside this PR (repo settings): `has_wiki=false`, `has_discussions=true`.

## What's in here

- `mkdocs.yml` — MkDocs Material over `docs_dir: docs`, light/dark toggle, search, "edit this page" pointing at `docs/` on `main`. The nav **mirrors the grouping of `docs/index.md`**, which stays the canonical map: a new page goes in both.
- `.github/workflows/docs.yml` — builds on PRs (no deploy) and deploys on `main`, path-filtered to `docs/**` + `mkdocs.yml`. Uses `mkdocs build --strict`: a broken internal link or a nav typo **fails CI** instead of silently breaking the published site.
- Consequence of `--strict`: the two links pointing outside `docs/` (`../config.example.yaml`, `../test/e2e/README.md`) are now absolute GitHub URLs.
- README links the site; D100 records the decision.

Build verified locally with the same pinned version the workflow installs (`mkdocs-material==9.6.14`): `mkdocs build --strict` clean, 20 pages generated, zero link warnings.

## After merge

Pages must be switched to **source: GitHub Actions** in Settings → Pages for the first deploy to publish at https://beppetemp.github.io/cartographer/.