### PR TITLE
fix(mcp): opt-in per-KB tool-name prefix for flat-namespace clients

### DIFF
--- a/cmd/cartographer/connect.go
+++ b/cmd/cartographer/connect.go
@@ -491,6 +491,9 @@ func doConnect(opts connectOptions) (connectResult, error) {
 	if err != nil {
 		return connectResult{}, err
 	}
+	if w := kiroFlatNamespaceWarning(opts.Providers, entries); w != "" {
+		configWarnings = append(configWarnings, w)
+	}
 
 	// 1b. Ensure the bootstrap hook (D60): purely local, independent of the
 	// server manifest fetched in step 2 below — must be in place even when that

--- a/cmd/cartographer/multikb.go
+++ b/cmd/cartographer/multikb.go
@@ -40,6 +40,29 @@ func enumerateKBs(serverURL string, auth bool, tokenEnv string) (names []string,
 	return names, true, nil
 }
 
+// kiroFlatNamespaceWarning returns a non-empty warning when providers
+// includes kiro and entries has 2 or more entries (a multi-KB connection):
+// Kiro's MCP tool namespace is flat across servers — unlike Claude Code,
+// Codex and OpenCode, which namespace tools per server (verified empirically,
+// see the D102 issue thread) — so without a server-side tool_prefix on the
+// extra KBs, only one of them stays reachable in a Kiro session, silently.
+// There is no reliable client-side way to know whether the server has
+// prefixes configured (GET /health does not expose them), so the warning is
+// unconditional on the precondition rather than trying to guess (D102).
+func kiroFlatNamespaceWarning(providers []string, entries []mcpEntry) string {
+	if len(entries) < 2 {
+		return ""
+	}
+	for _, p := range providers {
+		if configurator.Provider(p) == configurator.ProviderKiro {
+			return fmt.Sprintf("kiro has a flat MCP tool namespace across servers: writing %d MCP entries "+
+				"means only one KB's tools will be reachable in a Kiro session unless the server mounts the "+
+				"others with a tool_prefix (see docs/deployment.md §MCP tool-name prefix)", len(entries))
+		}
+	}
+	return ""
+}
+
 // entriesForKBs implements D92's compatibility rule: a zero/one-KB server
 // keeps one bare entry; a multi-KB server gets one explicitly-scoped entry per
 // KB. url.URL is used rather than concatenation so an existing query survives.

--- a/cmd/cartographer/multikb_test.go
+++ b/cmd/cartographer/multikb_test.go
@@ -92,6 +92,51 @@ func TestDoConnect_PerKBEntries_AllProviders(t *testing.T) {
 	}
 }
 
+// TestKiroFlatNamespaceWarning covers the D102 client-side follow-up: a
+// warning fires unconditionally whenever kiro is among the target providers
+// and >=2 MCP entries are about to be written (multi-KB), and stays silent
+// otherwise (single entry, or no kiro provider).
+func TestKiroFlatNamespaceWarning(t *testing.T) {
+	twoEntries := []mcpEntry{{Name: "cartographer-alpha"}, {Name: "cartographer-beta"}}
+	oneEntry := []mcpEntry{{Name: "cartographer"}}
+
+	if w := kiroFlatNamespaceWarning([]string{"kiro"}, twoEntries); w == "" {
+		t.Error("expected a warning: kiro provider + 2 entries")
+	}
+	if w := kiroFlatNamespaceWarning([]string{"claude", "kiro", "codex"}, twoEntries); w == "" {
+		t.Error("expected a warning: kiro among several providers + 2 entries")
+	}
+	if w := kiroFlatNamespaceWarning([]string{"kiro"}, oneEntry); w != "" {
+		t.Errorf("expected no warning for a single entry, got %q", w)
+	}
+	if w := kiroFlatNamespaceWarning([]string{"claude", "codex", "opencode"}, twoEntries); w != "" {
+		t.Errorf("expected no warning without kiro among the providers, got %q", w)
+	}
+}
+
+// TestDoConnect_Kiro_MultiKB_WarnsFlatNamespace exercises the warning through
+// doConnect end-to-end: connecting kiro to a 2-KB server surfaces the
+// warning in connectResult.Warnings (rendered on stderr by
+// printConnectResult / the TUI).
+func TestDoConnect_Kiro_MultiKB_WarnsFlatNamespace(t *testing.T) {
+	srv := multiKBServer(t, `{"status":"ok","kbs":[{"name":"alpha"},{"name":"beta"}]}`)
+	defer srv.Close()
+	dir := t.TempDir()
+	res, err := doConnect(connectOptions{Providers: []string{"kiro"}, Dir: dir, ServerURL: srv.URL + "/mcp", Name: "cartographer", TokenEnv: "TOKEN", Trust: true})
+	if err != nil {
+		t.Fatalf("doConnect: %v", err)
+	}
+	found := false
+	for _, w := range res.Warnings {
+		if strings.Contains(w, "flat MCP tool namespace") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a flat-namespace warning in %v", res.Warnings)
+	}
+}
+
 func TestEntriesForKBs_SingleStaysBare(t *testing.T) {
 	entries, err := entriesForKBs("wiki", "https://example.test/mcp", []string{"only"})
 	if err != nil || len(entries) != 1 || entries[0].Name != "wiki" || entries[0].URL != "https://example.test/mcp" {

--- a/cmd/cartographer/serve.go
+++ b/cmd/cartographer/serve.go
@@ -241,7 +241,8 @@ func runServe(cfg *config.Config) {
 
 	seenNames := make(map[string]string) // name → first path seen
 	var kbs []*kb.KB
-	var kbNames []string // index-aligned with kbs
+	var kbNames []string        // index-aligned with kbs
+	var kbToolPrefixes []string // index-aligned with kbs (D102, "" = unprefixed)
 	for _, m := range mounts {
 		var k *kb.KB
 		var err error
@@ -271,9 +272,14 @@ func runServe(cfg *config.Config) {
 			log.Printf("warning: KB name collision %q (first: %s, duplicate: %s) — skipping duplicate", name, prev, m.Path)
 			continue
 		}
+		toolPrefix, err := config.ResolveToolPrefix(m.Spec, cfg.MCP.ToolPrefixMode, name)
+		if err != nil {
+			log.Fatal(err)
+		}
 		seenNames[name] = m.Path
 		kbs = append(kbs, k)
 		kbNames = append(kbNames, name)
+		kbToolPrefixes = append(kbToolPrefixes, toolPrefix)
 	}
 
 	if len(kbs) == 0 && (cfg.Data == "" || cfg.HTTP == "") {
@@ -312,7 +318,7 @@ func runServe(cfg *config.Config) {
 	}
 
 	if cfg.HTTP != "" {
-		serveHTTP(cfg.HTTP, kbs, kbNames, cfg.Auth, cfg.ToolsProfile, emb, vecStore, sqlIdxs, auditLog)
+		serveHTTP(cfg.HTTP, kbs, kbNames, kbToolPrefixes, cfg.Auth, cfg.ToolsProfile, emb, vecStore, sqlIdxs, auditLog)
 	} else {
 		serveStdio(kbs[0], cfg.ToolsProfile, emb, vecStore, sqlIdxs, auditLog)
 	}
@@ -340,7 +346,7 @@ func serveStdio(k *kb.KB, toolsProfile string, emb embed.Embedder, store *embed.
 	}
 }
 
-func serveHTTP(addr string, kbs []*kb.KB, names []string, authCfg config.AuthConfig, toolsProfile string, emb embed.Embedder, vecStore *embed.Store, sqlIdxs map[string]*sqlindex.Index, auditLog *audit.Log) {
+func serveHTTP(addr string, kbs []*kb.KB, names []string, toolPrefixes []string, authCfg config.AuthConfig, toolsProfile string, emb embed.Embedder, vecStore *embed.Store, sqlIdxs map[string]*sqlindex.Index, auditLog *audit.Log) {
 	if auditLog != nil {
 		log.Printf("audit log active")
 	}
@@ -360,15 +366,32 @@ func serveHTTP(addr string, kbs []*kb.KB, names []string, authCfg config.AuthCon
 	}
 
 	multi := mcpserver.NewMultiKBServer(version)
+	// serverInfo.name (D102) identifies the mounted KB only when more than
+	// one is mounted — a single-KB HTTP server keeps the historical bare
+	// "cartographer" (asserted verbatim in server_test.go).
+	multiKB := len(kbs) > 1
 	for i, k := range kbs {
 		k := k
 		name := names[i]
-		multi.MountKB(name, func(s *mcpserver.Server) {
+		prefix := toolPrefixes[i]
+		err := multi.MountKBWithPrefix(name, prefix, func(s *mcpserver.Server) {
+			if multiKB {
+				s.SetDisplayName("cartographer:" + name)
+			}
 			sqlIdx := sqlIdxs[filepath.Clean(k.Root)]
 			mcpserver.RegisterKBTools(s, k, mcpserver.Deps{Embedder: emb, VecStore: vecStore, SQLIndex: sqlIdx, BundleFS: skillbundle.FS})
 			s.SetToolsProfile(toolsProfile)
 		})
-		log.Printf("mounted KB %q at %s (tools profile: %s)", name, k.Root, toolsProfile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		// The unprefixed line stays exactly as it was pre-D102: the prefix is
+		// only mentioned when there is one.
+		prefixLog := ""
+		if prefix != "" {
+			prefixLog = fmt.Sprintf(", tool prefix: %s__", prefix)
+		}
+		log.Printf("mounted KB %q at %s (tools profile: %s%s)", name, k.Root, toolsProfile, prefixLog)
 	}
 
 	handler := store.Middleware(multi.Handler())

--- a/cmd/cartographer/sync.go
+++ b/cmd/cartographer/sync.go
@@ -58,6 +58,9 @@ func cmdSync(args []string) int {
 			fmt.Fprintln(os.Stderr, "Error:", err)
 			return 2
 		}
+		if w := kiroFlatNamespaceWarning(cfg.Agents, entries); w != "" {
+			warnings = append(warnings, w)
+		}
 		for _, w := range warnings {
 			fmt.Fprintf(os.Stderr, "warning: %s\n", w)
 		}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -33,6 +33,18 @@ kbs:
                                    # KB (default false, D71): writing a skill means
                                    # injecting instructions that clients will run —
                                    # grant per-KB, an rw token alone does not imply it
+    # tool_prefix: "locale"        # (D102) opt-in per-KB MCP tool-name prefix: this
+                                   # KB's tools register as "locale__<tool>" instead
+                                   # of "<tool>". Default "" (off). Needed for MCP
+                                   # clients with a flat tool namespace across servers
+                                   # (e.g. Kiro CLI) when mounting 2+ KBs; wins over
+                                   # mcp.tool_prefix_mode below. See docs/deployment.md
+                                   # §MCP tool-name prefix.
+mcp:
+  # tool_prefix_mode: "off"        # (D102) off (default) | kb-name — global default
+                                   # applied to every KB above that doesn't set its own
+                                   # tool_prefix; kb-name derives the prefix from the
+                                   # KB's own name.
 git:
   autocommit: true
   sync: true

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -46,6 +46,14 @@ removes entries for disappeared KBs, and performs the bare↔suffixed rename on
 one-to-many transitions. If the server cannot be reached, it leaves the MCP
 entries and `kbs` list untouched and warns; run `sync` again once it is up.
 
+**Kiro and flat tool namespaces (D102).** Kiro's MCP tool namespace is flat across servers, unlike
+Claude Code/Codex/OpenCode which namespace per server: writing 2+ MCP entries for `kiro` (i.e.
+connecting to a 2+-KB server) leaves only one KB's tools reachable in a Kiro session unless the
+*server* mounts the others with a `tool_prefix` (`docs/deployment.md` §MCP tool-name prefix, D102).
+`connect`/`sync` print an unconditional warning on stderr in that case — they cannot tell from
+`/health` whether the server already has prefixes configured, so the warning fires on the
+precondition alone; the operator is expected to add `tool_prefix`/`tool_prefix_mode` server-side.
+
 ```bash
 cartographer connect                                   # all agents detected on the machine
 cartographer connect claude                             # Claude Code only

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -107,7 +107,7 @@ Tools marked **[A]** (advanced, `advancedToolNames` in `internal/mcpserver/visib
 
 See `docs/sync.md` for the full model (Manifest, Lock, Diff, layered triggers).
 
-> Multi-KB: every tool that operates on content accepts a `kb` parameter (omittable if there is only one KB).
+> Multi-KB: which KB a tool call reaches is decided per-connection, not per-call — `?kb=<name>` (query param) or `/mcp/<name>` (path) select one KB's isolated `Server` for the whole session; no tool takes a `kb` argument. Every KB exposes the same tool names by default, which flat-namespace MCP clients (e.g. Kiro) cannot disambiguate across servers — see `tool_prefix` in [`deployment.md`](deployment.md) §MCP tool-name prefix.
 
 ## Semantic search
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1665,6 +1665,41 @@ Applied by extracting six backlog items from the prose into issues #51–#56 (fi
 
 **Consequences.** A rename now fails CI until every page follows, which is the same discipline `mkdocs --strict` applies to links (D100). Same-session fixes: README §Key features and §Architecture (which still described the pre-D77 `archive → dossier → concept` hierarchy) and `sync.md`'s description of the generated instructions block — the code emitted `atlas_overview` correctly, only the doc was stale.
 
+## D102 — Opt-in per-KB MCP tool-name prefix
+
+**Decision.** Every mounted KB registers the same 20 tool names by default; a new opt-in, default-off
+per-KB prefix lets an operator disambiguate them: `kbs[].tool_prefix` (explicit) or the global
+`mcp.tool_prefix_mode: kb-name`/`CARTOGRAPHER_MCP_TOOL_PREFIX_MODE=kb-name` (derives the prefix from
+the KB's own name for any KB without an explicit `tool_prefix`) registers that KB's tools as
+`<prefix>__<tool>` instead of `<tool>` (`Server.SetToolNamePrefix`, applied once, inside
+`RegisterTool`). The raw value is sanitized (lowercased, `[^a-z0-9_]+`→`_`, collapsed,
+leading/trailing `_` trimmed) and validated at startup — empty or digit-leading after sanitisation,
+or a resulting `<prefix>__<tool>` over 48 characters for any tool the KB registers, is a fatal config
+error naming the KB and the offending name (`internal/config.ResolveToolPrefix`,
+`MountKBWithPrefix`). Read/write classification and the `agent`/`full` tools profile strip the
+prefix before matching (`Server.StripToolPrefix`), so scoped tokens and the profile filter are
+unaffected by prefixing. `serverInfo.name` becomes `cartographer:<kb>` once 2+ KBs are mounted
+(`Server.SetDisplayName`); a single-KB deployment keeps the historical bare `cartographer`.
+`cartographer connect`/`sync` warn on stderr whenever the `kiro` provider is configured against 2+
+MCP entries, independent of whether the server has prefixes set (`kiroFlatNamespaceWarning`).
+
+**Rationale.** Claude Code, Codex and OpenCode namespace MCP tools per server, so a second KB's tools
+never collide with the first's under those clients (verified empirically, GitHub issue #62).
+Kiro CLI has one flat tool namespace across every configured server: without a distinguishing
+prefix, mounting a second KB there silently drops its tools rather than erroring. Making the fix
+default-off keeps the byte-identical tool surface for every client already unaffected by the
+problem; making it per-KB (rather than always-on for multi-KB servers) lets an operator prefix only
+the KBs that need it, e.g. to keep short names on the "primary" KB.
+
+**Consequences.** The prefix is applied at exactly one point (`RegisterTool`), so every
+conditionally-registered tool (`artifact_write`, `skill_install`, `sync_*`) is covered without a
+second injection site. The 48-char budget is checked against the actual registered names after
+`setupFn` runs, not computed analytically beforehand, so it naturally accounts for every tool a KB
+ends up registering (including config-gated ones). The client-side warning cannot inspect whether
+the server already mitigated the issue (`GET /health` doesn't expose tool prefixes), so it fires on
+the precondition alone (kiro + 2+ entries) — a false positive (server already prefixed) is a
+one-line stderr note, not a wrong outcome.
+
 ## Known deviations from the specification
 
 - TUI configurator: implemented (D35), opt-in via `--tui`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -58,6 +58,14 @@ kbs:                          # (kbs[]) explicit KBs, local path or remote git (
                                                       # clients will execute — the capability must be
                                                       # granted per-KB by the operator; an rw token alone
                                                       # does not imply it
+    tool_prefix: "team"                              # (kbs[].tool_prefix) opt-in per-KB tool-name prefix
+                                                      # (default "", off): registers this KB's tools as
+                                                      # `team__<tool>` instead of `<tool>`. Wins over
+                                                      # `mcp.tool_prefix_mode` below. See §MCP tool-name prefix.
+mcp:
+  tool_prefix_mode: "off"       # (mcp.tool_prefix_mode) off (default) | kb-name: global default for
+                                # every mounted KB that doesn't set its own kbs[].tool_prefix — kb-name
+                                # derives the prefix from the KB's own name. See §MCP tool-name prefix.
 git:
   autocommit: true            # (git.autocommit) commit after every write
   sync: true                  # (git.sync) read/write fetch/pull-rebase + post-write push if the KB has a remote
@@ -132,6 +140,36 @@ Similarly, `sops.age_key_dir` fixes a directory with a per-KB age key
 (explicit override) → `<sops.age_key_dir>/<name>.age` if the file exists → global
 `sops.age_key_file`.
 
+### MCP tool-name prefix (D102)
+
+Every KB mounted on a multi-KB server exposes the *same* 20 tool names (`concept_read`, `search`,
+...) on its own endpoint (`?kb=<name>` / `/mcp/<name>`). Clients that namespace MCP tools per
+server — Claude Code, Codex, OpenCode — are unaffected by the collision. Kiro's CLI has a single,
+flat tool namespace across every configured MCP server: mounting two KBs there means only one of
+them keeps its tools reachable, silently.
+
+The fix is an **opt-in, default-off** per-KB tool-name prefix: `kbs[].tool_prefix` (or the global
+`mcp.tool_prefix_mode: kb-name`/`CARTOGRAPHER_MCP_TOOL_PREFIX_MODE=kb-name`, which derives the
+prefix from the KB's own name for every KB that doesn't set its own `tool_prefix`) registers that
+KB's tools as `<prefix>__<tool>` instead of `<tool>`. Precedence: `kbs[].tool_prefix` (explicit) >
+`mcp.tool_prefix_mode`/env (global default) > off. It is off by default so that Claude
+Code/Codex/OpenCode deployments, unaffected by the problem, never see a tool rename.
+
+The raw prefix is sanitized before use: lowercased, every run of characters outside `[a-z0-9_]`
+collapsed to a single `_`, leading/trailing `_` stripped. The server fails fast at startup (not at
+first tool call) if, after sanitisation, the result is empty, starts with a digit, or the resulting
+`<prefix>__<tool>` name exceeds 48 characters for any tool the KB registers — the error names the
+KB and the offending tool/prefix. Read/write classification (§Auth) and the `agent`/`full` tools
+profile (D65) both match on the tool name *after* stripping the prefix, so scoped tokens and the
+tools profile behave identically with or without a prefix. When 2+ KBs are mounted, `serverInfo.name`
+also becomes `cartographer:<kb>` (a single-KB deployment keeps the bare `cartographer` it has
+always reported).
+
+`cartographer connect`/`cartographer sync` print a warning on stderr whenever the provider being
+configured is `kiro` and 2+ MCP entries (i.e. 2+ KBs) are about to be written, regardless of
+whether the server actually has prefixes configured (the client has no way to probe that): the
+operator adds `tool_prefix`/`tool_prefix_mode` to the server config as the fix.
+
 ### Environment variables
 
 Every startup option has a corresponding environment variable (the CLI flag takes precedence):
@@ -155,6 +193,7 @@ Every startup option has a corresponding environment variable (the CLI flag take
 | `CARTOGRAPHER_AUDIT_LOG` | — | Path to the audit log's JSONL file (e.g. `/data/audit.log`). If empty, audit is disabled. |
 | `CARTOGRAPHER_AUDIT_KEY` | — | Ed25519 seed (hex, 64 chars) for signing entries. Requires `CARTOGRAPHER_AUDIT_LOG`. |
 | `CARTOGRAPHER_SERVER_URL` | — | **Client** (not server): default server URL for `cartographer connect` on the client machine when no `.cartographer.yaml` exists yet. Precedence: existing yaml > env > `http://localhost:8080/mcp` (D64, `internal/clientconfig.Default`). |
+| `CARTOGRAPHER_MCP_TOOL_PREFIX_MODE` | — | Global default for `mcp.tool_prefix_mode`: `off` (default) \| `kb-name`. Overridden per KB by `kbs[].tool_prefix` (D102, see §MCP tool-name prefix). |
 
 **`CARTOGRAPHER_AUTH`** — three modes:
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,19 @@ type Config struct {
 	// (default) hides the advanced/operator tools, "full" advertises all.
 	// Hidden tools stay callable via tools/call (D65).
 	ToolsProfile string
+	// MCP controls MCP-protocol-level server behaviour that isn't specific
+	// to a single KB (currently: the tool-name prefix default, D102).
+	MCP MCPConfig
+}
+
+// MCPConfig controls MCP-protocol-level server behaviour.
+type MCPConfig struct {
+	// ToolPrefixMode is the default per-KB tool-name prefix policy for KBs
+	// that don't set an explicit KBSpec.ToolPrefix: "off" (default) leaves
+	// tool names unprefixed, byte-identical to pre-D102 behaviour; "kb-name"
+	// derives the prefix from the KB's resolved name (sanitised, see
+	// SanitizeToolPrefix — e.g. "ai-team" → "ai_team__concept_read").
+	ToolPrefixMode string
 }
 
 // AuthConfig controls HTTP bearer-token authentication.
@@ -106,6 +119,15 @@ type KBSpec struct {
 	// capability is opt-in per-KB rather than implied by an rw token alone.
 	// Default false. Propagated to kb.KB.AllowArtifactWrite (see serve.go).
 	AllowArtifactWrite bool `yaml:"allow_artifact_write,omitempty"`
+
+	// ToolPrefix, if set, namespaces every MCP tool this KB registers as
+	// "<prefix>__<tool>" (opt-in per-KB tool-name prefix, D102 — for MCP
+	// clients whose tool namespace is flat across servers, e.g. Kiro CLI).
+	// Wins over the global MCP.ToolPrefixMode. Resolved, sanitised
+	// (SanitizeToolPrefix) and shape-validated (ValidateToolPrefixShape) at
+	// KB-mount time via ResolveToolPrefix — an invalid result is a fail-fast
+	// startup error naming the KB; the KB is not mounted.
+	ToolPrefix string `yaml:"tool_prefix,omitempty"`
 }
 
 // GitConfig controls per-KB git autocommit/sync, the SSH identity used to
@@ -176,6 +198,7 @@ func Default() *Config {
 			OllamaModel: "nomic-embed-text",
 		},
 		ToolsProfile: "agent",
+		MCP:          MCPConfig{ToolPrefixMode: "off"},
 	}
 }
 
@@ -193,10 +216,15 @@ type rawConfig struct {
 	Audit  AuditConfig `yaml:"audit"`
 	Sops   SopsConfig  `yaml:"sops"`
 	Tools  rawTools    `yaml:"tools"`
+	MCP    rawMCP      `yaml:"mcp"`
 }
 
 type rawTools struct {
 	Profile string `yaml:"profile"`
+}
+
+type rawMCP struct {
+	ToolPrefixMode string `yaml:"tool_prefix_mode"`
 }
 
 type rawAuth struct {
@@ -281,6 +309,10 @@ func Load(path string) (*Config, error) {
 		cfg.ToolsProfile = normalizeToolsProfile(raw.Tools.Profile)
 	}
 
+	if raw.MCP.ToolPrefixMode != "" {
+		cfg.MCP.ToolPrefixMode = normalizeToolPrefixMode(raw.MCP.ToolPrefixMode)
+	}
+
 	return cfg, nil
 }
 
@@ -346,6 +378,9 @@ func FromEnv(cfg *Config) {
 	if v := os.Getenv("CARTOGRAPHER_TOOLS_PROFILE"); v != "" {
 		cfg.ToolsProfile = normalizeToolsProfile(v)
 	}
+	if v := os.Getenv("CARTOGRAPHER_MCP_TOOL_PREFIX_MODE"); v != "" {
+		cfg.MCP.ToolPrefixMode = normalizeToolPrefixMode(v)
+	}
 }
 
 // FlagOverrides carries the `cartographer serve` flag values that were
@@ -409,6 +444,16 @@ func normalizeToolsProfile(v string) string {
 		return "full"
 	}
 	return "agent"
+}
+
+// normalizeToolPrefixMode maps a tool_prefix_mode spelling onto the
+// canonical "off"/"kb-name". Anything unrecognized falls back to "off"
+// (fail-closed: no behavioural change for existing deployments/clients).
+func normalizeToolPrefixMode(v string) string {
+	if strings.ToLower(strings.TrimSpace(v)) == "kb-name" {
+		return "kb-name"
+	}
+	return "off"
 }
 
 // normalizeAuthMode maps the legacy boolean-ish spellings (accepted by both

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -151,6 +151,7 @@ func TestLoadFullYAML(t *testing.T) {
 		Audit:        AuditConfig{Log: "/data/audit.log", KeySeed: "deadbeef"},
 		Sops:         SopsConfig{AgeKeyFile: "/etc/cartographer/age.key", AgeKeyDir: "/etc/kb-sops-keys"},
 		ToolsProfile: "full",
+		MCP:          MCPConfig{ToolPrefixMode: "off"},
 	}
 
 	if !reflect.DeepEqual(cfg, want) {

--- a/internal/config/toolprefix.go
+++ b/internal/config/toolprefix.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// toolPrefixInvalidChar matches any run of characters outside [a-z0-9_], the
+// only characters allowed in a sanitised MCP tool-name prefix.
+var toolPrefixInvalidChar = regexp.MustCompile(`[^a-z0-9_]+`)
+
+// toolPrefixRepeatUnderscore collapses runs of underscores left behind by
+// toolPrefixInvalidChar substitutions (e.g. "ai - team" → "ai___team").
+var toolPrefixRepeatUnderscore = regexp.MustCompile(`_+`)
+
+// SanitizeToolPrefix normalises raw into a value safe to combine with "__"
+// and an MCP tool name: lowercase, every run of characters outside
+// [a-z0-9_] collapsed to a single "_", repeated "_" collapsed, then
+// leading/trailing "_" stripped. Mirrors the character rules MCP clients
+// (Kiro) apply to tool names themselves, so "<prefix>__<tool>" stays valid.
+//
+//	SanitizeToolPrefix("ai-team") == "ai_team"
+//	SanitizeToolPrefix("AI Team") == "ai_team"
+//	SanitizeToolPrefix("---")     == ""
+func SanitizeToolPrefix(raw string) string {
+	s := strings.ToLower(raw)
+	s = toolPrefixInvalidChar.ReplaceAllString(s, "_")
+	s = toolPrefixRepeatUnderscore.ReplaceAllString(s, "_")
+	return strings.Trim(s, "_")
+}
+
+// ValidateToolPrefixShape rejects a sanitised prefix that is empty or starts
+// with a digit — either would produce an empty or invalid tool name once
+// combined with "__<tool>". It does not check the resulting tool-name
+// length budget: that needs the KB's actual registered tool names, checked
+// separately at KB-mount time (mcpserver.MultiKBServer.MountKBWithPrefix).
+func ValidateToolPrefixShape(sanitized string) error {
+	if sanitized == "" {
+		return fmt.Errorf("empty after sanitisation")
+	}
+	if sanitized[0] >= '0' && sanitized[0] <= '9' {
+		return fmt.Errorf("starts with a digit after sanitisation: %q", sanitized)
+	}
+	return nil
+}
+
+// ResolveToolPrefix determines the tool-name prefix for one KB:
+// spec.ToolPrefix (explicit, per-KB) wins over mode; mode == "kb-name"
+// derives the prefix from kbName; anything else ("off" or unset) leaves the
+// KB unprefixed ("", nil). A non-empty result is always sanitised
+// (SanitizeToolPrefix) and shape-validated (ValidateToolPrefixShape) before
+// being returned — an error here is a fail-fast config error naming the KB;
+// the caller must not mount the KB.
+func ResolveToolPrefix(spec KBSpec, mode string, kbName string) (string, error) {
+	raw := spec.ToolPrefix
+	if raw == "" {
+		if mode != "kb-name" {
+			return "", nil
+		}
+		raw = kbName
+	}
+	sanitized := SanitizeToolPrefix(raw)
+	if err := ValidateToolPrefixShape(sanitized); err != nil {
+		return "", fmt.Errorf("KB %q: invalid tool_prefix %q: %w", kbName, raw, err)
+	}
+	return sanitized, nil
+}

--- a/internal/config/toolprefix_test.go
+++ b/internal/config/toolprefix_test.go
@@ -1,0 +1,65 @@
+package config
+
+import "testing"
+
+func TestSanitizeToolPrefix(t *testing.T) {
+	cases := map[string]string{
+		"ai-team": "ai_team",
+		"AI Team": "ai_team",
+		"ai_team": "ai_team",
+		"  ai  ":  "ai",
+		"a--b__c": "a_b_c",
+		"---":     "",
+		"":        "",
+		"1kb":     "1kb", // digit-leading is rejected by ValidateToolPrefixShape, not sanitisation
+	}
+	for in, want := range cases {
+		if got := SanitizeToolPrefix(in); got != want {
+			t.Errorf("SanitizeToolPrefix(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestValidateToolPrefixShape(t *testing.T) {
+	cases := map[string]bool{ // sanitized input -> wantErr
+		"ai_team": false,
+		"aiteam":  false,
+		"1kb":     true, // leading digit
+		"":        true, // empty (e.g. sanitized from "---")
+	}
+	for in, wantErr := range cases {
+		err := ValidateToolPrefixShape(in)
+		if (err != nil) != wantErr {
+			t.Errorf("ValidateToolPrefixShape(%q) error = %v, wantErr %v", in, err, wantErr)
+		}
+	}
+}
+
+func TestResolveToolPrefix(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    KBSpec
+		mode    string
+		kbName  string
+		want    string
+		wantErr bool
+	}{
+		{name: "off, no explicit prefix", spec: KBSpec{}, mode: "off", kbName: "ai-team", want: ""},
+		{name: "explicit prefix wins", spec: KBSpec{ToolPrefix: "custom"}, mode: "kb-name", kbName: "ai-team", want: "custom"},
+		{name: "explicit prefix sanitised", spec: KBSpec{ToolPrefix: "AI Team"}, mode: "off", kbName: "ai-team", want: "ai_team"},
+		{name: "kb-name mode derives from kbName", spec: KBSpec{}, mode: "kb-name", kbName: "ai-team", want: "ai_team"},
+		{name: "kb-name mode, digit-leading name fails", spec: KBSpec{}, mode: "kb-name", kbName: "1kb", wantErr: true},
+		{name: "explicit prefix sanitises to empty fails", spec: KBSpec{ToolPrefix: "---"}, mode: "off", kbName: "x", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveToolPrefix(tt.spec, tt.mode, tt.kbName)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ResolveToolPrefix() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil && got != tt.want {
+				t.Errorf("ResolveToolPrefix() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/mcpserver/httpserver.go
+++ b/internal/mcpserver/httpserver.go
@@ -103,7 +103,11 @@ func (s *Server) handleMCPPost(w http.ResponseWriter, r *http.Request) {
 // least the same privilege as a write. The tool-name classification in
 // ToolRequiresWrite can't see arguments, so this per-argument override lives
 // here, at the one place that already parses the JSON-RPC body.
-func mcpAccessGuard(kbName string, next http.Handler) http.Handler {
+//
+// srv is the KB's own *Server: its ToolRequiresWrite method strips this
+// server's tool-name prefix (D102), if any, before classifying — so a
+// prefixed write tool is still correctly rejected for a read-only scope.
+func mcpAccessGuard(kbName string, srv *Server, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		scopes := auth.ScopesFromContext(r.Context())
 		if len(scopes) == 0 {
@@ -131,8 +135,8 @@ func mcpAccessGuard(kbName string, next http.Handler) http.Handler {
 					} `json:"arguments"`
 				}
 				_ = json.Unmarshal(req.Params, &params) // ignore errors: ToolRequiresWrite("") is fail-closed too
-				needWrite = ToolRequiresWrite(params.Name)
-				if params.Name == "service_get" && params.Arguments.ResolveSecrets {
+				needWrite = srv.ToolRequiresWrite(params.Name)
+				if srv.StripToolPrefix(params.Name) == "service_get" && params.Arguments.ResolveSecrets {
 					needWrite = true
 				}
 			}
@@ -252,12 +256,50 @@ func NewMultiKBServer(version string) *MultiKBServer {
 	}
 }
 
-// MountKB registers a KB with the given name. Creates a dedicated MCP server for it.
+// MountKB registers a KB with the given name, tool names unprefixed. Creates
+// a dedicated MCP server for it.
 func (m *MultiKBServer) MountKB(name string, setupFn func(s *Server)) {
+	// prefix == "" never fails MountKBWithPrefix's validation (no tool name
+	// grows), so the error is unreachable here.
+	_ = m.MountKBWithPrefix(name, "", setupFn)
+}
+
+// maxToolNameLen is the conservative per-tool-name budget (D102) enforced
+// once a tool-name prefix is set: Kiro (and MCP clients generally) may
+// reject or exclude a tool whose name is too long, and some clients add
+// their own "@server/" prefix on top — 48 leaves room for that.
+const maxToolNameLen = 48
+
+// MountKBWithPrefix mounts a KB whose tool names are all rewritten to
+// "<prefix>__<tool>" (D102: opt-in per-KB tool-name namespacing for MCP
+// clients with a flat tool namespace, e.g. Kiro CLI — Claude Code, Codex and
+// OpenCode already namespace tools per server and need no prefix). An empty
+// prefix leaves tool names unchanged — the default, byte-identical to
+// pre-D102 behaviour.
+//
+// prefix is assumed already sanitised and shape-validated (see
+// config.ResolveToolPrefix): this only enforces the tool-name length budget
+// (maxToolNameLen), which needs the KB's actual registered tool names and so
+// can only be checked after setupFn runs. On a budget violation the KB is
+// not mounted and an error naming the KB and the offending tool is
+// returned.
+func (m *MultiKBServer) MountKBWithPrefix(name, prefix string, setupFn func(s *Server)) error {
 	srv := New(m.version)
+	if prefix != "" {
+		srv.SetToolNamePrefix(prefix)
+	}
 	setupFn(srv)
+	if prefix != "" {
+		for _, toolName := range srv.toolsOrd {
+			if len(toolName) > maxToolNameLen {
+				return fmt.Errorf("KB %q: tool name %q (%d chars) exceeds the %d-char budget after applying tool_prefix %q; use a shorter prefix",
+					name, toolName, len(toolName), maxToolNameLen, prefix)
+			}
+		}
+	}
 	m.servers[name] = srv
 	m.kbs = append(m.kbs, KBInfo{Name: name, Status: "normal"})
+	return nil
 }
 
 // Handler returns the HTTP handler that routes MCP requests to the correct
@@ -301,7 +343,7 @@ func (m *MultiKBServer) Handler() http.Handler {
 			if kbName == "" && len(m.servers) == 1 {
 				for name, srv := range m.servers {
 					srv := srv
-					mcpAccessGuard(name, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					mcpAccessGuard(name, srv, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 						srv.handleMCP(w, r)
 					})).ServeHTTP(w, r)
 					return
@@ -338,7 +380,7 @@ func (m *MultiKBServer) serveKB(w http.ResponseWriter, r *http.Request, kbName s
 		http.Error(w, fmt.Sprintf("unknown kb %q", kbName), http.StatusNotFound)
 		return
 	}
-	mcpAccessGuard(kbName, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mcpAccessGuard(kbName, srv, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		srv.handleMCP(w, r)
 	})).ServeHTTP(w, r)
 }

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -49,7 +49,18 @@ type Server struct {
 	// so New() keeps its historical behavior; `serve` sets it from
 	// config.ToolsProfile (default "agent").
 	agentProfile bool
-	mu           sync.Mutex
+	// toolPrefix, when non-empty, is prepended (as "<toolPrefix>__") to
+	// every tool name at RegisterTool time (D102: opt-in per-KB tool-name
+	// namespacing for MCP clients with a flat tool namespace, e.g. Kiro).
+	// Zero value = unprefixed, byte-identical to pre-D102 behaviour. Set via
+	// SetToolNamePrefix, before RegisterKBTools/setupFn runs — see
+	// MultiKBServer.MountKBWithPrefix.
+	toolPrefix string
+	// displayName, when non-empty, overrides the "cartographer" literal
+	// reported as serverInfo.name by initialize (D102). Set via
+	// SetDisplayName.
+	displayName string
+	mu          sync.Mutex
 
 	writeMu sync.Mutex    // serializes writes to the shared encoder
 	enc     *json.Encoder // active stdio encoder; nil when not in Run (e.g. HTTP)
@@ -72,6 +83,61 @@ func (s *Server) SetToolsProfile(profile string) {
 	s.agentProfile = profile == "agent"
 }
 
+// SetToolNamePrefix sets the opt-in per-KB tool-name prefix (D102): every
+// tool registered afterwards via RegisterTool is renamed
+// "<prefix>__<name>". Must be called before the tools are registered
+// (RegisterKBTools/setupFn) — it does not rename tools already registered.
+// Empty (the default) leaves tool names unchanged.
+func (s *Server) SetToolNamePrefix(prefix string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.toolPrefix = prefix
+}
+
+// SetDisplayName overrides the serverInfo.name reported by initialize
+// (D102). Empty (the default) keeps the historical "cartographer".
+func (s *Server) SetDisplayName(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.displayName = name
+}
+
+// stripToolPrefixLocked removes this server's tool-name prefix (see
+// SetToolNamePrefix) from name, if name carries it; otherwise returns name
+// unchanged. Callers must already hold s.mu (it does not lock itself, to
+// stay reentrant-safe when called from handleToolsList).
+func (s *Server) stripToolPrefixLocked(name string) string {
+	if s.toolPrefix == "" {
+		return name
+	}
+	p := s.toolPrefix + "__"
+	if strings.HasPrefix(name, p) {
+		return name[len(p):]
+	}
+	return name
+}
+
+// StripToolPrefix removes this server's tool-name prefix (SetToolNamePrefix,
+// D102) from name, if name carries it; otherwise returns name unchanged. Used
+// by mcpAccessGuard to classify a possibly-prefixed tool name against the
+// pre-prefix name tables (ToolRequiresWrite, the service_get/resolve_secrets
+// override).
+func (s *Server) StripToolPrefix(name string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stripToolPrefixLocked(name)
+}
+
+// ToolRequiresWrite reports whether name — which may carry this server's
+// tool-name prefix (SetToolNamePrefix) — requires write access to the KB.
+// It strips the prefix, if any, then delegates to the package-level
+// ToolRequiresWrite classification. Used by mcpAccessGuard so that a
+// read-only ("kb:<name>:r") scope token still rejects every write tool when
+// a prefix is configured.
+func (s *Server) ToolRequiresWrite(name string) bool {
+	return ToolRequiresWrite(s.StripToolPrefix(name))
+}
+
 // Tools returns a snapshot of all registered tools, keyed by name (for
 // introspection/tests, e.g. the ReadOnly golden test).
 func (s *Server) Tools() map[string]Tool {
@@ -84,10 +150,18 @@ func (s *Server) Tools() map[string]Tool {
 	return out
 }
 
-// RegisterTool registers an MCP tool. Overwrites if the same name is already registered.
+// RegisterTool registers an MCP tool. Overwrites if the same name is already
+// registered. If a tool-name prefix is set (SetToolNamePrefix, D102), t.Name
+// is rewritten to "<prefix>__<name>" here — the single injection point that
+// covers every tool, including conditionally-registered ones
+// (skill_install, sync_*, artifact_*), without touching individual toolXxx
+// constructors.
 func (s *Server) RegisterTool(t Tool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.toolPrefix != "" {
+		t.Name = s.toolPrefix + "__" + t.Name
+	}
 	if _, exists := s.tools[t.Name]; !exists {
 		s.toolsOrd = append(s.toolsOrd, t.Name)
 	}
@@ -213,6 +287,13 @@ func (s *Server) handleInitialize(req *Request) Response {
 		negotiated = params.ProtocolVersion
 	}
 
+	s.mu.Lock()
+	name := "cartographer"
+	if s.displayName != "" {
+		name = s.displayName
+	}
+	s.mu.Unlock()
+
 	result := map[string]interface{}{
 		"protocolVersion": negotiated,
 		"capabilities": map[string]interface{}{
@@ -221,7 +302,7 @@ func (s *Server) handleInitialize(req *Request) Response {
 			"skills":    map[string]interface{}{"listChanged": true},
 		},
 		"serverInfo": map[string]interface{}{
-			"name":    "cartographer",
+			"name":    name,
 			"version": s.version,
 		},
 	}
@@ -235,7 +316,7 @@ func (s *Server) handleToolsList(req *Request) Response {
 
 	descriptors := make([]toolDescriptor, 0, len(s.toolsOrd))
 	for _, name := range s.toolsOrd {
-		if s.agentProfile && ToolAdvanced(name) {
+		if s.agentProfile && ToolAdvanced(s.stripToolPrefixLocked(name)) {
 			continue
 		}
 		t := s.tools[name]

--- a/internal/mcpserver/toolprefix_test.go
+++ b/internal/mcpserver/toolprefix_test.go
@@ -1,0 +1,279 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/BeppeTemp/cartographer/internal/auth"
+)
+
+// TestRegisterTool_NoPrefix verifies the byte-identical no-prefix path: a
+// tool registered on a server with no tool-name prefix keeps its bare name.
+func TestRegisterTool_NoPrefix(t *testing.T) {
+	s := New("test")
+	s.RegisterTool(Tool{Name: "atlas_overview"})
+	if _, ok := s.Tools()["atlas_overview"]; !ok {
+		t.Fatalf("expected unprefixed tool name %q to be registered; got %v", "atlas_overview", s.Tools())
+	}
+}
+
+// TestRegisterTool_WithPrefix verifies RegisterTool rewrites the tool name to
+// "<prefix>__<name>" once SetToolNamePrefix has been called (D102).
+func TestRegisterTool_WithPrefix(t *testing.T) {
+	s := New("test")
+	s.SetToolNamePrefix("aiteam")
+	s.RegisterTool(Tool{Name: "atlas_overview"})
+
+	if _, ok := s.Tools()["atlas_overview"]; ok {
+		t.Fatalf("bare tool name %q must not be registered when a prefix is set", "atlas_overview")
+	}
+	if _, ok := s.Tools()["aiteam__atlas_overview"]; !ok {
+		t.Fatalf("expected prefixed tool name %q to be registered; got %v", "aiteam__atlas_overview", s.Tools())
+	}
+}
+
+// TestServer_ToolRequiresWrite_Prefixed verifies that ToolRequiresWrite
+// (the Server method, which strips this server's tool-name prefix) still
+// classifies prefixed tool names correctly against the pre-prefix name
+// tables — the security-critical path flagged by the issue.
+func TestServer_ToolRequiresWrite_Prefixed(t *testing.T) {
+	s := New("test")
+	s.SetToolNamePrefix("aiteam")
+
+	if s.ToolRequiresWrite("aiteam__atlas_overview") {
+		t.Error("aiteam__atlas_overview (read-only tool, prefixed) misclassified as requiring write")
+	}
+	if !s.ToolRequiresWrite("aiteam__concept_write") {
+		t.Error("aiteam__concept_write (write tool, prefixed) misclassified as read-only")
+	}
+	// Unknown names remain fail-closed (require write) whether or not they
+	// carry the server's prefix.
+	if !s.ToolRequiresWrite("aiteam__no_such_tool") {
+		t.Error("unknown prefixed tool name should fail-closed to write-required")
+	}
+}
+
+// TestServer_ToolsProfile_Prefixed verifies the "agent" tools-profile filter
+// (ToolAdvanced) still hides advanced tools under their prefixed name.
+func TestServer_ToolsProfile_Prefixed(t *testing.T) {
+	k := setupTestKB(t)
+	s := New("test")
+	s.SetToolNamePrefix("aiteam")
+	RegisterKBTools(s, k, Deps{})
+	s.SetToolsProfile("agent")
+
+	resps := runMCPSequence(t, s, []string{toolsListBody})
+	if len(resps) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(resps))
+	}
+	names := toolNamesFromToolsList(t, resps[0])
+
+	if _, ok := names["aiteam__validate"]; ok {
+		t.Error("aiteam__validate is an advanced tool and must be hidden under the agent profile, even prefixed")
+	}
+	if _, ok := names["aiteam__atlas_overview"]; !ok {
+		t.Error("aiteam__atlas_overview must be visible under the agent profile")
+	}
+}
+
+// toolNamesFromToolsList decodes a tools/list Response into a name set.
+func toolNamesFromToolsList(t *testing.T, resp Response) map[string]bool {
+	t.Helper()
+	resultBytes, err := json.Marshal(resp.Result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	var result struct {
+		Tools []struct {
+			Name string `json:"name"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(resultBytes, &result); err != nil {
+		t.Fatalf("unmarshal tools/list result: %v", err)
+	}
+	out := make(map[string]bool, len(result.Tools))
+	for _, tl := range result.Tools {
+		out[tl.Name] = true
+	}
+	return out
+}
+
+// TestMountKBWithPrefix_TwoKBs_DisjointNames mounts two KBs, one with a
+// prefix and one without, and asserts tools/list returns disjoint,
+// correctly-prefixed name sets per endpoint.
+func TestMountKBWithPrefix_TwoKBs_DisjointNames(t *testing.T) {
+	multi := NewMultiKBServer("test")
+	kUnprefixed := setupTestKB(t)
+	if err := multi.MountKBWithPrefix("personal-kb", "", func(s *Server) {
+		RegisterKBTools(s, kUnprefixed, Deps{})
+	}); err != nil {
+		t.Fatalf("MountKBWithPrefix(personal-kb): %v", err)
+	}
+	kPrefixed := setupTestKB(t)
+	if err := multi.MountKBWithPrefix("ai-team", "aiteam", func(s *Server) {
+		RegisterKBTools(s, kPrefixed, Deps{})
+	}); err != nil {
+		t.Fatalf("MountKBWithPrefix(ai-team): %v", err)
+	}
+	handler := multi.Handler()
+
+	rrPersonal := doMCP(handler, "personal-kb", "", toolsListBody)
+	if rrPersonal.Code != http.StatusOK {
+		t.Fatalf("personal-kb tools/list: status = %d, body=%s", rrPersonal.Code, rrPersonal.Body.String())
+	}
+	var respPersonal Response
+	if err := json.Unmarshal(rrPersonal.Body.Bytes(), &respPersonal); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	personalNames := toolNamesFromToolsList(t, respPersonal)
+
+	rrAiTeam := doMCP(handler, "ai-team", "", toolsListBody)
+	if rrAiTeam.Code != http.StatusOK {
+		t.Fatalf("ai-team tools/list: status = %d, body=%s", rrAiTeam.Code, rrAiTeam.Body.String())
+	}
+	var respAiTeam Response
+	if err := json.Unmarshal(rrAiTeam.Body.Bytes(), &respAiTeam); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	aiTeamNames := toolNamesFromToolsList(t, respAiTeam)
+
+	if !personalNames["atlas_overview"] {
+		t.Error("personal-kb should expose the bare atlas_overview")
+	}
+	if aiTeamNames["atlas_overview"] {
+		t.Error("ai-team must not expose the bare atlas_overview (it's prefixed)")
+	}
+	if !aiTeamNames["aiteam__atlas_overview"] {
+		t.Error("ai-team should expose aiteam__atlas_overview")
+	}
+	if personalNames["aiteam__atlas_overview"] {
+		t.Error("personal-kb must not expose the ai-team-prefixed name")
+	}
+	for name := range aiTeamNames {
+		if personalNames[name] {
+			t.Errorf("tool name %q collides between the two endpoints", name)
+		}
+	}
+}
+
+// TestMountKBWithPrefix_ToolsCall_HitsCorrectKB verifies a prefixed tool
+// name executes against its own KB, not the other mounted one.
+func TestMountKBWithPrefix_ToolsCall_HitsCorrectKB(t *testing.T) {
+	multi := NewMultiKBServer("test")
+	kA := setupTestKB(t)
+	if err := multi.MountKBWithPrefix("kb-a", "", func(s *Server) {
+		RegisterKBTools(s, kA, Deps{})
+	}); err != nil {
+		t.Fatalf("MountKBWithPrefix(kb-a): %v", err)
+	}
+	kB := setupTestKB(t)
+	if err := multi.MountKBWithPrefix("kb-b", "kbb", func(s *Server) {
+		RegisterKBTools(s, kB, Deps{})
+	}); err != nil {
+		t.Fatalf("MountKBWithPrefix(kb-b): %v", err)
+	}
+	handler := multi.Handler()
+
+	rr := doMCP(handler, "kb-b", "", writeToolCallBody("kbb__atlas_overview"))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("kbb__atlas_overview on kb-b: status = %d, body=%s", rr.Code, rr.Body.String())
+	}
+	var resp Response
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	tr := decodeToolResult(t, resp)
+	if tr.IsError {
+		t.Fatalf("kbb__atlas_overview returned isError=true: %v", tr.Content)
+	}
+
+	// Calling the prefixed name against the wrong (unprefixed) KB endpoint
+	// must fail — that name was never registered there.
+	rr = doMCP(handler, "kb-a", "", writeToolCallBody("kbb__atlas_overview"))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rr.Code, rr.Body.String())
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	tr = decodeToolResult(t, resp)
+	if !tr.IsError || !strings.Contains(tr.Content[0].Text, "not found") {
+		t.Fatalf("expected 'tool not found' calling kbb__atlas_overview on kb-a, got: %+v", tr)
+	}
+}
+
+// TestMountKBWithPrefix_ScopedTokenMatrix verifies a read-only ("kb:<name>:r")
+// scope token still rejects a prefixed write tool, and accepts it with rw —
+// the security-critical matrix from the issue's test plan.
+func TestMountKBWithPrefix_ScopedTokenMatrix(t *testing.T) {
+	multi := NewMultiKBServer("test")
+	k := setupTestKB(t)
+	if err := multi.MountKBWithPrefix("ai-team", "aiteam", func(s *Server) {
+		RegisterKBTools(s, k, Deps{})
+	}); err != nil {
+		t.Fatalf("MountKBWithPrefix: %v", err)
+	}
+	ts := auth.NewScopedTokenStore([]auth.ScopedToken{
+		{Token: "r-tok", Scopes: []auth.KBScope{{KB: "ai-team", Write: false}}},
+		{Token: "rw-tok", Scopes: []auth.KBScope{{KB: "ai-team", Write: true}}},
+	})
+	handler := ts.Middleware(multi.Handler())
+
+	rr := doMCP(handler, "ai-team", "r-tok", writeToolCallBody("aiteam__concept_write"))
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("prefixed write tool with r scope: status = %d, want 403; body=%s", rr.Code, rr.Body.String())
+	}
+
+	rr = doMCP(handler, "ai-team", "r-tok", writeToolCallBody("aiteam__atlas_overview"))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("prefixed read tool with r scope: status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+
+	rr = doMCP(handler, "ai-team", "rw-tok", writeToolCallBody("aiteam__concept_write"))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("prefixed write tool with rw scope: status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestMountKBWithPrefix_BudgetExceeded verifies a tool_prefix that pushes a
+// resulting tool name past maxToolNameLen fails the mount instead of
+// registering an over-budget name.
+func TestMountKBWithPrefix_BudgetExceeded(t *testing.T) {
+	multi := NewMultiKBServer("test")
+	k := setupTestKB(t)
+	longPrefix := strings.Repeat("a", maxToolNameLen)
+	err := multi.MountKBWithPrefix("kb", longPrefix, func(s *Server) {
+		RegisterKBTools(s, k, Deps{})
+	})
+	if err == nil {
+		t.Fatal("expected an error for an over-budget tool name, got nil")
+	}
+	if !strings.Contains(err.Error(), "kb") {
+		t.Errorf("error should name the KB: %v", err)
+	}
+}
+
+// TestServer_DisplayName_ServerInfo verifies SetDisplayName overrides
+// serverInfo.name, and that leaving it unset keeps the historical
+// "cartographer" (single-KB path, asserted verbatim elsewhere too).
+func TestServer_DisplayName_ServerInfo(t *testing.T) {
+	k := setupTestKB(t)
+	s := New("test")
+	s.SetDisplayName("cartographer:ai-team")
+	RegisterKBTools(s, k, Deps{})
+
+	initMsg := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`
+	resps := runMCPSequence(t, s, []string{initMsg})
+	if len(resps) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(resps))
+	}
+	resultBytes, _ := json.Marshal(resps[0].Result)
+	var result map[string]interface{}
+	json.Unmarshal(resultBytes, &result)
+	info, ok := result["serverInfo"].(map[string]interface{})
+	if !ok || info["name"] != "cartographer:ai-team" {
+		t.Errorf("initialize: unexpected serverInfo: %v", result["serverInfo"])
+	}
+}


### PR DESCRIPTION
Closes #62.

## Problema

Su un server multi-KB ogni endpoint espone gli stessi nomi di tool. Verificato sui quattro provider supportati ([dettaglio nella issue](https://github.com/BeppeTemp/cartographer/issues/62#issuecomment-5087862661)):

| Client | Naming | Multi-KB in una sessione |
|---|---|---|
| Claude Code 2.1.212 | `mcp__<server>__<tool>` | ok |
| Codex CLI 0.145.0 | `mcp__<server>__<tool>` | ok |
| OpenCode 1.18.5 | `<server>_<tool>` | ok |
| Kiro CLI 2.14.2 | namespace flat | **collisione silenziosa** |

Solo Kiro è affetto: i tool della seconda KB vengono scartati senza errore.

## Soluzione (D102)

- prefisso opt-in, **default off**: `kbs[].tool_prefix`, oppure `mcp.tool_prefix_mode: kb-name` / `CARTOGRAPHER_MCP_TOOL_PREFIX_MODE`;
- applicato in un punto solo (`RegisterTool`) → copre anche i tool registrati condizionalmente (`artifact_*`, `skill_install`, `sync_*`);
- sanitizzazione + validazione fail-fast all'avvio (vuoto, cifra iniziale, oltre il budget di 48 caratteri → errore che nomina KB e tool, KB non montata);
- read/write classification e filtro tools-profile strippano il prefisso: un token `kb:<n>:r` continua a rifiutare ogni tool di scrittura anche prefissato;
- `serverInfo.name` → `cartographer:<kb>` con 2+ KB montate (single-KB invariato);
- `connect`/`sync` avvisano quando kiro riceve 2+ entry MCP;
- `docs/control-plane.md`: rimossa l'affermazione falsa «every tool accepts a `kb` parameter» (la selezione della KB è per connessione).

## Verifica

`make fmt && make vet && make test && make smoke` verdi. E2E manuale su due KB (una con `tool_prefix: ai-team`):

- `tools/list` su `?kb=kb-alpha` → 22 nomi nudi; su `?kb=ai-team` → 22 nomi `ai_team__*`;
- `tools/call` `ai_team__atlas_overview` → Atlas della KB giusta; nome nudo sulla KB prefissata → `tool not found`;
- matrice token: `:r` + write prefissato → 403, `:r` + read prefissato → 200, `:rw` + write prefissato → 200;
- `tool_prefix: "1bad"` → fatale all'avvio; `tool_prefix_mode: kb-name` → `ai-team` → `ai_team__`.

Non testabile su questa macchina: l'E2E su Kiro (kiro-cli non installato).

🤖 Generated with [Claude Code](https://claude.com/claude-code)