### PR TITLE
feat: support nested and writable SOPS secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Cartographer offers **two complementary profiles**:
 - 🗂️ **Multi-KB** with `?kb=<name>` routing; bearer-token auth with scopes / RBAC
 - 🔐 **Audit log** — append-only with hash-chain and Ed25519 signature
 - 🧩 **Domain skills** (`SKILL.md` / agentskills.io format) with provisioning and client↔server sync
-- 🔑 **Secrets via SOPS** — references only, plaintext values never stored
+- 🔑 **Secrets via SOPS** — JSON Pointer references, scoped resolution and safe rotation; plaintext values never stored
 - ⚙️ **Multi-provider configurator** — generates MCP config for Claude Code, Codex CLI, Kiro,
   OpenCode
 - 📦 **OKF-compliant** — each KB is an OKF bundle and a standalone git repo, zero lock-in (just git +

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -88,7 +88,9 @@ Tools marked **[A]** (advanced, `advancedToolNames` in `internal/mcpserver/visib
 |---|---|
 | `skill_list()` **[R]** **[A]** | Lists the installed skills (`skills/`) and the ones bundled in the binary. Field `source`: `[installed]` \| `[bundled]`. |
 | `skill_install(name, force)` **[A]** | Copies a bundled skill into `kb.Root/skills/<name>/`. Errors if already present; `force=true` overwrites. |
-| `service_get(service_id, resolve_secrets=false)` **[R]** **[A]** | Reads a concept of type Service. With `resolve_secrets: true` it also decrypts the `secrets_source` (flat — the service's entire SOPS file; per-ref `secret_refs` cannot be parsed from the frontmatter, → `skills-services-secrets.md`) and includes it in the result; requires a KB with an age key configured and **rw scope** (enforced in the HTTP guard, not in the per-tool-name classification: `service_get` remains `ReadOnly` for the no-resolve path). |
+| `service_get(service_id, resolve_secrets=false)` **[R]** **[A]** | Reads a Service. With `resolve_secrets: true`, resolves declared `secret_refs` (or legacy whole `secrets_source`) and requires **rw** scope. |
+| `secret_resolve(concept_id, names?)` **[RW]** **[A]** | Resolves SOPS references declared by any concept; `names` narrows the declared values. |
+| `secret_set(path, key, value)` **[RW]** **[A]** | Sets a JSON Pointer in an existing encrypted SOPS file; plaintext is never committed or returned. |
 | `service_list()` **[R]** **[A]** | Lists all concepts of type Service. |
 
 ### Client ↔ provisioning synchronization

--- a/docs/data-plane.md
+++ b/docs/data-plane.md
@@ -127,7 +127,8 @@ that the type is present in the Map's `concept_types` palette. It does not
 validate a nested per-type grammar.
 
 - A `Service` commonly carries flat fields such as `kind`, `base_url` and
-  `secrets_source`; see [skills, services and secrets](skills-services-secrets.md).
+  `secrets_source` or `secret_refs`; secrets may be owned by any concept, not
+  only a Service. See [skills, services and secrets](skills-services-secrets.md).
 - The contradiction tools use `resolution_status`, `contradiction_kind`,
   `involves` and `reason`.
 

--- a/docs/decisions/skills-services-secrets.md
+++ b/docs/decisions/skills-services-secrets.md
@@ -36,22 +36,6 @@ from contaminating requests on another in a multi-KB server (same reason as D46)
 in the guard keeps all r/rw enforcement in one place, consistent with D45.
 Details: `docs/skills-services-secrets.md` §SOPS secrets, `docs/transport-auth.md`.
 
-## D104 — Structured SOPS pointers, scoped refs and encrypted-only writes
-
-The line-oriented YAML parser silently collapsed nested DANTE bundles: repeated
-`client_secret` leaves overwrote one another, so a DEV request could receive
-the PROD value. YAML is now traversed structurally and flattened to RFC 6901
-JSON Pointers. The return type remains `map[string]string`: it is compatible
-with process environments while pointers keep the key space injective.
-
-`secret_refs` use scalar `NAME=path#pointer` entries because OKF frontmatter
-intentionally supports only strings and string lists. This gives per-ref least
-privilege without widening the frontmatter grammar. `secret_set` only operates
-on a pre-existing SOPS-encrypted file through `sops set --value-stdin`; file
-creation and recipient selection remain operator work, preventing plaintext
-commits. Rejected: indentation-aware flat parsing, map-valued frontmatter, and
-server-managed creation rules.
-
 ---
 
 <a id="d96"></a>
@@ -69,3 +53,18 @@ and validates every bundled skill and asserts the manifest inventory.
 `main` can describe a newer pre-1.0 CLI and tool surface. One concise operational reference keeps
 the end-to-end runbook available to agents on client machines that do not have the repository
 checked out.
+
+---
+
+<a id="d104"></a>
+## D104 — Structured SOPS pointers, scoped refs and encrypted-only writes
+
+**Decision.** Decrypted YAML is flattened to RFC 6901 JSON Pointers and
+`secret_refs` use scalar `NAME=path#pointer` entries. `secret_set` updates an
+existing encrypted secret with `sops set --value-stdin`; it never creates the
+root `.sops.yaml` creation-rules file.
+
+**Rationale.** Repeated nested leaves otherwise collide in a flat map. Pointer
+references provide least privilege without widening the intentionally small
+frontmatter grammar. Creation rules and recipient selection remain operator
+work, while encrypted `*.sops.yaml` files are safely writable by the server.

--- a/docs/decisions/skills-services-secrets.md
+++ b/docs/decisions/skills-services-secrets.md
@@ -36,6 +36,22 @@ from contaminating requests on another in a multi-KB server (same reason as D46)
 in the guard keeps all r/rw enforcement in one place, consistent with D45.
 Details: `docs/skills-services-secrets.md` §SOPS secrets, `docs/transport-auth.md`.
 
+## D104 — Structured SOPS pointers, scoped refs and encrypted-only writes
+
+The line-oriented YAML parser silently collapsed nested DANTE bundles: repeated
+`client_secret` leaves overwrote one another, so a DEV request could receive
+the PROD value. YAML is now traversed structurally and flattened to RFC 6901
+JSON Pointers. The return type remains `map[string]string`: it is compatible
+with process environments while pointers keep the key space injective.
+
+`secret_refs` use scalar `NAME=path#pointer` entries because OKF frontmatter
+intentionally supports only strings and string lists. This gives per-ref least
+privilege without widening the frontmatter grammar. `secret_set` only operates
+on a pre-existing SOPS-encrypted file through `sops set --value-stdin`; file
+creation and recipient selection remain operator work, preventing plaintext
+commits. Rejected: indentation-aware flat parsing, map-valued frontmatter, and
+server-managed creation rules.
+
 ---
 
 <a id="d96"></a>

--- a/docs/skills-services-secrets.md
+++ b/docs/skills-services-secrets.md
@@ -82,7 +82,8 @@ legacy `secrets_source` whole-file behavior.
 encrypted `secrets/*.sops.yaml` file. It uses `sops set --value-stdin`, checks
 that the result remains encrypted, and commits through the normal KB write
 flow. Creating the encrypted file and choosing its recipients remain an
-operator action; Cartographer never writes `.sops.yaml`.
+operator action; Cartographer never writes the root `.sops.yaml` creation-rules
+file, but it does update existing encrypted `*.sops.yaml` secret files.
 
 ## Operational guidance
 

--- a/docs/skills-services-secrets.md
+++ b/docs/skills-services-secrets.md
@@ -46,14 +46,17 @@ that operate the service. Cartographer does not validate a richer Service
 schema beyond the normal concept and strict-map type rules.
 
 `service_list` inventories Service concepts. `service_get` returns one
-descriptor; with `resolve_secrets: true` it also decrypts the complete flat
-file named by `secrets_source`.
+descriptor; with `resolve_secrets: true` it resolves declared `secret_refs`.
+Any concept may own secret references and `secret_resolve` exposes them for
+task- and dossier-scoped credentials.
 
 ## SOPS files
 
 Encrypted values can be committed under `secrets/*.sops.yaml`. Cartographer
-invokes the `sops` CLI and parses the decrypted document as flat key/value
-pairs.
+invokes the `sops` CLI from the KB root and flattens decrypted YAML scalar
+leaves using RFC 6901 JSON Pointers, for example
+`/dante_client/DEV/client_secret` and `/admin/0/client_secret`. `~` and `/`
+in mapping keys are escaped as `~0` and `~1`; null is an empty string.
 
 The age key is selected in this order:
 
@@ -70,9 +73,16 @@ stored in the KB.
 - a configured key that can decrypt the file;
 - `rw` scope for HTTP access.
 
-The whole `secrets_source` is returned. Structured per-reference
-`secret_refs` are not representable by the current frontmatter parser, so
-there is no per-key least-privilege filter.
+Use `secret_refs` for least privilege: each list item is
+`NAME=secrets/file.sops.yaml#/json-pointer`. Resolution returns only the
+declared `NAME` values. Existing descriptors without `secret_refs` retain the
+legacy `secrets_source` whole-file behavior.
+
+`secret_set(path, key, value)` rotates or adds a pointer in an existing
+encrypted `secrets/*.sops.yaml` file. It uses `sops set --value-stdin`, checks
+that the result remains encrypted, and commits through the normal KB write
+flow. Creating the encrypted file and choosing its recipients remain an
+operator action; Cartographer never writes `.sops.yaml`.
 
 ## Operational guidance
 

--- a/internal/mcpserver/docs_test.go
+++ b/internal/mcpserver/docs_test.go
@@ -25,7 +25,7 @@ var toolShaped = regexp.MustCompile(`\x60([a-z][a-z0-9_]*_[a-z0-9_]+)\x60`)
 // starting with one of these is expected to name a real tool.
 var toolPrefixes = []string{
 	"atlas_", "map_", "concept_", "index_", "log_", "graph_", "search_",
-	"skill_", "service_", "artifact_", "sync_", "git_", "kb_", "archive_",
+	"skill_", "service_", "secret_", "artifact_", "sync_", "git_", "kb_", "archive_",
 	"dossier_", "conflict_", "conflicts_", "commit_", "gate_", "changes_",
 	"contradiction_",
 }

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -105,6 +105,10 @@ func RegisterKBTools(s *Server, k *kb.KB, deps Deps) {
 	register(toolGitConflictResolve(k))
 	register(toolServiceGet(k))
 	register(toolServiceList(k))
+	// Secret resolution requires rw scope but is still a read-side operation;
+	// wrap explicitly so a synchronised KB is fresh before decryption.
+	register(readSyncWrap(k, toolSecretResolve(k)))
+	register(gitWrap(k, toolSecretSet(k)))
 	register(toolArtifactRead(k))
 	register(toolArtifactList(k))
 	if k.AllowArtifactWrite {

--- a/internal/mcpserver/tools_secret_security_test.go
+++ b/internal/mcpserver/tools_secret_security_test.go
@@ -1,0 +1,113 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func fakeSecretSOPS(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX fake sops")
+	}
+	dir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = set ]; then IFS= read -r v; printf 'key: ENC[x]\\nsops: {}\\n' > \"$3\"; exit 0; fi\n" +
+		"printf 'allowed: only-this\\nother: not-requested\\n'\n"
+	if err := os.WriteFile(filepath.Join(dir, "sops"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func writeSecretConcept(t *testing.T, kroot, id, frontmatter string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(kroot, "data", id+".md"), []byte("---\n"+frontmatter+"---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseSecretRefsContracts(t *testing.T) {
+	refs, err := parseSecretRefs([]string{"TOKEN=secrets/a.sops.yaml#/allowed"})
+	if err != nil || len(refs) != 1 || refs[0].SOPSKey != "/allowed" {
+		t.Fatalf("%v %#v", err, refs)
+	}
+	for _, raw := range []any{nil, []string{}, []string{"bad"}, []string{"1BAD=secrets/a.sops.yaml#/x"}, []string{"X=/tmp/a.sops.yaml#/x"}, []string{"X=secrets/a.yaml#/x"}, []string{"X=secrets/a.sops.yaml#x"}, []string{"X=secrets/a.sops.yaml#/x", "X=secrets/a.sops.yaml#/y"}} {
+		if _, err := parseSecretRefs(raw); err == nil {
+			t.Errorf("accepted %#v", raw)
+		}
+	}
+}
+
+func TestServiceAndSecretResolveScopeDeclaredRefs(t *testing.T) {
+	fakeSecretSOPS(t)
+	k := setupServiceTestKB(t, "/age/key")
+	writeSecretConcept(t, k.Root, "svc-refs", "type: Service\nsecret_refs:\n  - TOKEN=secrets/test.sops.yaml#/allowed\n")
+	res := callServiceGet(t, k, "svc-refs", true)
+	if res.IsError {
+		t.Fatal(res.Content)
+	}
+	text := res.Content[0].Text
+	if !strings.Contains(text, "TOKEN=only-this") || strings.Contains(text, "not-requested") {
+		t.Fatalf("unexpected refs output: %s", text)
+	}
+	writeSecretConcept(t, k.Root, "dossier", "type: Dossier\nsecret_refs:\n  - TOKEN=secrets/test.sops.yaml#/allowed\n")
+	args, _ := json.Marshal(map[string]any{"concept_id": "dossier", "names": []string{"TOKEN"}})
+	got, _ := toolSecretResolve(k).Handler(args)
+	if got.IsError || got.Content[0].Text != "TOKEN=only-this" {
+		t.Fatalf("resolve=%#v", got)
+	}
+	args, _ = json.Marshal(map[string]any{"concept_id": "dossier", "names": []string{"UNKNOWN"}})
+	got, _ = toolSecretResolve(k).Handler(args)
+	if got.IsError || got.Content[0].Text != "" {
+		t.Fatalf("unknown filter=%#v", got)
+	}
+	writeSecretConcept(t, k.Root, "none", "type: Dossier\n")
+	args, _ = json.Marshal(map[string]any{"concept_id": "none"})
+	got, _ = toolSecretResolve(k).Handler(args)
+	if !got.IsError || !strings.Contains(got.Content[0].Text, "no secret_refs") {
+		t.Fatalf("missing declaration=%#v", got)
+	}
+}
+
+func TestServiceLegacyAndMalformedRefsPrecedeSOPSGuards(t *testing.T) {
+	k := setupServiceTestKB(t, "")
+	res := callServiceGet(t, k, "svc-test", true)
+	if !res.IsError || !strings.Contains(res.Content[0].Text, "sops_age_key_file") {
+		t.Fatal(res.Content)
+	}
+	writeSecretConcept(t, k.Root, "bad", "type: Service\nsecret_refs:\n  - malformed\n")
+	res = callServiceGet(t, k, "bad", true)
+	if !res.IsError || !strings.Contains(res.Content[0].Text, "invalid secret_refs") {
+		t.Fatal(res.Content)
+	}
+}
+
+func TestSecretSetSafetyAndRegistration(t *testing.T) {
+	fakeSecretSOPS(t)
+	k := setupServiceTestKB(t, "/age/key")
+	os.WriteFile(filepath.Join(k.Root, "secrets", "test.sops.yaml"), []byte("key: ENC[old]\nsops: {}\n"), 0o600)
+	value := "private-value"
+	args, _ := json.Marshal(map[string]string{"path": "secrets/test.sops.yaml", "key": "/key", "value": value})
+	res, _ := toolSecretSet(k).Handler(args)
+	if res.IsError || strings.Contains(res.Content[0].Text, value) || !strings.Contains(res.Content[0].Text, "secrets/test.sops.yaml /key") {
+		t.Fatalf("set=%#v", res)
+	}
+	if msg := commitMessage("secret_set", args); strings.Contains(msg, value) {
+		t.Fatalf("commit message leaked: %s", msg)
+	}
+	for _, a := range []map[string]string{{"path": "secrets/missing.sops.yaml", "key": "/key", "value": value}, {"path": "../bad", "key": "/key", "value": value}, {"path": "secrets/test.sops.yaml", "key": "bad", "value": value}} {
+		b, _ := json.Marshal(a)
+		r, _ := toolSecretSet(k).Handler(b)
+		if !r.IsError || strings.Contains(r.Content[0].Text, value) {
+			t.Errorf("unsafe error %#v", r)
+		}
+	}
+	if !advancedToolNames["secret_resolve"] || !advancedToolNames["secret_set"] || !ToolRequiresWrite("secret_resolve") || !ToolRequiresWrite("secret_set") {
+		t.Fatal("secret tool profile incorrect")
+	}
+}

--- a/internal/mcpserver/tools_skill.go
+++ b/internal/mcpserver/tools_skill.go
@@ -6,6 +6,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/BeppeTemp/cartographer/internal/kb"
@@ -113,39 +115,23 @@ func toolServiceGet(k *kb.KB) Tool {
 				return textResult(sb.String()), nil
 			}
 
-			// secrets_source is a flat string field (frontmatter supports only
-			// string/[]string — okf/frontmatter.go — so per-ref least-privilege
-			// via secret_refs is not parsable; the whole file is decrypted).
-			raw, ok := fm.Get("secrets_source")
-			if !ok {
-				return errorResult(fmt.Sprintf("service_get: %q has no secrets_source", params.ServiceID)), nil
-			}
-			secretsSource, ok := raw.(string)
-			if !ok || secretsSource == "" {
-				return errorResult(fmt.Sprintf("service_get: %q secrets_source is not a non-empty string", params.ServiceID)), nil
-			}
-			// secrets_source must stay inside the KB root: reject absolute paths
-			// and "../" traversal so a crafted frontmatter can't decrypt files
-			// outside the KB with the KB's age key (defence in depth: also gated rw).
-			if !filepath.IsLocal(secretsSource) {
-				return errorResult(fmt.Sprintf("service_get: secrets_source %q must be a path inside the KB (no absolute paths or '..')", secretsSource)), nil
-			}
-			if k.SopsAgeKeyFile == "" {
-				return errorResult("service_get: resolve_secrets requires a sops_age_key_file configured for this KB"), nil
-			}
-			if !sops.Available() {
-				return errorResult("service_get: sops binary not found in PATH"), nil
-			}
-
-			sf, err := sops.Decrypt(filepath.Join(k.Root, secretsSource), sops.AgeKeyEnv(k.SopsAgeKeyFile)...)
+			values, source, legacy, err := resolveFrontmatterSecrets(k, fm)
 			if err != nil {
-				return errorResult(fmt.Sprintf("service_get: resolve_secrets: %v", err)), nil
+				return errorResult("service_get: resolve_secrets: " + err.Error()), nil
 			}
-
 			sb.WriteString("\n\n---\nsecrets (from ")
-			sb.WriteString(secretsSource)
+			sb.WriteString(source)
 			sb.WriteString("):\n")
-			for key, val := range sf.Values {
+			if legacy {
+				sb.WriteString("note: no secret_refs declared; returning whole secrets_source.\n")
+			}
+			keys := make([]string, 0, len(values))
+			for key := range values {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+			for _, key := range keys {
+				val := values[key]
 				sb.WriteString(key)
 				sb.WriteString("=")
 				sb.WriteString(val)
@@ -154,6 +140,126 @@ func toolServiceGet(k *kb.KB) Tool {
 			return textResult(sb.String()), nil
 		},
 	}
+}
+
+var secretRefName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+func parseSecretRefs(raw any) ([]sops.SecretRef, error) {
+	entries, ok := raw.([]string)
+	if !ok || len(entries) == 0 {
+		return nil, fmt.Errorf("secret_refs must be a non-empty list of NAME=secrets/file.sops.yaml#/json-pointer")
+	}
+	refs := make([]sops.SecretRef, 0, len(entries))
+	seen := map[string]bool{}
+	for _, entry := range entries {
+		eq, hash := strings.Index(entry, "="), strings.Index(entry, "#")
+		if eq <= 0 || hash <= eq+1 || hash == len(entry)-1 {
+			return nil, fmt.Errorf("invalid secret_refs entry %q; expected NAME=secrets/file.sops.yaml#/json-pointer", entry)
+		}
+		name, path, ptr := entry[:eq], entry[eq+1:hash], entry[hash+1:]
+		if strings.TrimSpace(name) != name || strings.TrimSpace(path) != path || strings.TrimSpace(ptr) != ptr || !secretRefName.MatchString(name) || !filepath.IsLocal(path) || !strings.HasPrefix(path, "secrets/") || !strings.HasSuffix(path, ".sops.yaml") || !strings.HasPrefix(ptr, "/") || seen[name] {
+			return nil, fmt.Errorf("invalid secret_refs entry %q; expected NAME=secrets/file.sops.yaml#/json-pointer", entry)
+		}
+		seen[name] = true
+		refs = append(refs, sops.SecretRef{Name: name, SOPSFile: path, SOPSKey: ptr})
+	}
+	return refs, nil
+}
+
+func resolveFrontmatterSecrets(k *kb.KB, fm *okf.Frontmatter) (map[string]string, string, bool, error) {
+	if k.SopsAgeKeyFile == "" {
+		return nil, "", false, fmt.Errorf("requires a sops_age_key_file configured for this KB")
+	}
+	if !sops.Available() {
+		return nil, "", false, fmt.Errorf("sops binary not found in PATH")
+	}
+	if raw, ok := fm.Get("secret_refs"); ok {
+		refs, err := parseSecretRefs(raw)
+		if err != nil {
+			return nil, "", false, err
+		}
+		values, err := sops.ResolveRefs(k.Root, refs, sops.AgeKeyEnv(k.SopsAgeKeyFile)...)
+		return values, "declared refs", false, err
+	}
+	raw, ok := fm.Get("secrets_source")
+	if !ok {
+		return nil, "", false, fmt.Errorf("concept has no secret_refs or secrets_source")
+	}
+	source, ok := raw.(string)
+	if !ok || source == "" || !filepath.IsLocal(source) || !strings.HasPrefix(source, "secrets/") || !strings.HasSuffix(source, ".sops.yaml") {
+		return nil, "", false, fmt.Errorf("secrets_source must be a path inside the KB under secrets/*.sops.yaml")
+	}
+	sf, err := sops.Decrypt(k.Root, source, sops.AgeKeyEnv(k.SopsAgeKeyFile)...)
+	if err != nil {
+		return nil, "", false, err
+	}
+	return sf.Values, source, true, nil
+}
+
+func toolSecretResolve(k *kb.KB) Tool {
+	return Tool{Name: "secret_resolve", Description: "Resolves declared SOPS secret_refs for any concept (requires rw scope).", InputSchema: json.RawMessage(`{"type":"object","required":["concept_id"],"properties":{"concept_id":{"type":"string"},"names":{"type":"array","items":{"type":"string"}}}}`), Handler: func(args json.RawMessage) (ToolResult, error) {
+		var p struct {
+			ConceptID string   `json:"concept_id"`
+			Names     []string `json:"names"`
+		}
+		if err := json.Unmarshal(args, &p); err != nil {
+			return errorResult("invalid params: " + err.Error()), nil
+		}
+		data, err := k.ReadConcept(okf.ConceptID(p.ConceptID))
+		if err != nil {
+			return errorResult(fmt.Sprintf("secret_resolve %q: %v", p.ConceptID, err)), nil
+		}
+		fm, err := okf.ParseFrontmatter(data.FrontmatterRaw)
+		if err != nil {
+			return errorResult("secret_resolve: parse frontmatter: " + err.Error()), nil
+		}
+		values, _, _, err := resolveFrontmatterSecrets(k, fm)
+		if err != nil {
+			return errorResult("secret_resolve: " + err.Error()), nil
+		}
+		wanted := map[string]bool{}
+		for _, n := range p.Names {
+			wanted[n] = true
+		}
+		var sb strings.Builder
+		keys := make([]string, 0, len(values))
+		for n := range values {
+			if len(wanted) == 0 || wanted[n] {
+				keys = append(keys, n)
+			}
+		}
+		sort.Strings(keys)
+		for _, n := range keys {
+			sb.WriteString(n + "=" + values[n] + "\n")
+		}
+		return textResult(strings.TrimSuffix(sb.String(), "\n")), nil
+	}}
+}
+
+func toolSecretSet(k *kb.KB) Tool {
+	return Tool{Name: "secret_set", Description: "Sets one JSON Pointer in an existing encrypted SOPS file (requires rw scope).", InputSchema: json.RawMessage(`{"type":"object","required":["path","key","value"],"properties":{"path":{"type":"string"},"key":{"type":"string"},"value":{"type":"string"}}}`), Handler: func(args json.RawMessage) (ToolResult, error) {
+		var p struct {
+			Path  string `json:"path"`
+			Key   string `json:"key"`
+			Value string `json:"value"`
+		}
+		if err := json.Unmarshal(args, &p); err != nil {
+			return errorResult("invalid params: " + err.Error()), nil
+		}
+		if !filepath.IsLocal(p.Path) || !strings.HasPrefix(p.Path, "secrets/") || !strings.HasSuffix(p.Path, ".sops.yaml") {
+			return errorResult("secret_set: path must be a local secrets/*.sops.yaml path"), nil
+		}
+		if _, err := os.Stat(filepath.Join(k.Root, p.Path)); os.IsNotExist(err) {
+			return errorResult("secret_set: file does not exist; bootstrapping an encrypted file and its recipients is an operator action"), nil
+		}
+		if k.SopsAgeKeyFile == "" {
+			return errorResult("secret_set: requires a sops_age_key_file configured for this KB"), nil
+		}
+		if err := sops.Set(k.Root, p.Path, p.Key, p.Value, sops.AgeKeyEnv(k.SopsAgeKeyFile)...); err != nil {
+			return errorResult("secret_set: " + err.Error()), nil
+		}
+		return textResult(fmt.Sprintf("secret_set: updated %s %s", p.Path, p.Key)), nil
+	}}
 }
 
 // --- service_list ---

--- a/internal/mcpserver/tools_skill.go
+++ b/internal/mcpserver/tools_skill.go
@@ -167,17 +167,21 @@ func parseSecretRefs(raw any) ([]sops.SecretRef, error) {
 }
 
 func resolveFrontmatterSecrets(k *kb.KB, fm *okf.Frontmatter) (map[string]string, string, bool, error) {
+	var refs []sops.SecretRef
+	if raw, ok := fm.Get("secret_refs"); ok {
+		var err error
+		refs, err = parseSecretRefs(raw)
+		if err != nil {
+			return nil, "", false, err
+		}
+	}
 	if k.SopsAgeKeyFile == "" {
 		return nil, "", false, fmt.Errorf("requires a sops_age_key_file configured for this KB")
 	}
 	if !sops.Available() {
 		return nil, "", false, fmt.Errorf("sops binary not found in PATH")
 	}
-	if raw, ok := fm.Get("secret_refs"); ok {
-		refs, err := parseSecretRefs(raw)
-		if err != nil {
-			return nil, "", false, err
-		}
+	if refs != nil {
 		values, err := sops.ResolveRefs(k.Root, refs, sops.AgeKeyEnv(k.SopsAgeKeyFile)...)
 		return values, "declared refs", false, err
 	}

--- a/internal/mcpserver/tools_skill_test.go
+++ b/internal/mcpserver/tools_skill_test.go
@@ -24,6 +24,8 @@ func setupServiceTestKB(t *testing.T, sopsAgeKeyFile string) *kb.KB {
 	if err := os.WriteFile(filepath.Join(k.DataRoot(), "svc-test.md"), []byte(svcContent), 0o644); err != nil {
 		t.Fatalf("write service concept: %v", err)
 	}
+	if err := os.MkdirAll(filepath.Join(k.Root, "secrets"), 0o755); err != nil { t.Fatalf("mkdir secrets: %v", err) }
+	if err := os.WriteFile(filepath.Join(k.Root, "secrets", "test.sops.yaml"), []byte("placeholder"), 0o600); err != nil { t.Fatalf("write secret: %v", err) }
 	return k
 }
 

--- a/internal/mcpserver/visibility.go
+++ b/internal/mcpserver/visibility.go
@@ -48,6 +48,8 @@ var advancedToolNames = map[string]bool{
 	"skill_install":        true,
 	"service_get":          true,
 	"service_list":         true,
+	"secret_resolve":       true,
+	"secret_set":           true,
 	"artifact_list":        true,
 	"artifact_delete":      true,
 }

--- a/internal/sops/sops.go
+++ b/internal/sops/sops.go
@@ -1,26 +1,29 @@
 package sops
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
-// SecretFile represents a decrypted SOPS file with key-value pairs.
+// SecretFile represents a decrypted SOPS file. Values are keyed by RFC 6901
+// JSON Pointers (flat mappings retain their legacy top-level keys).
 type SecretFile struct {
 	Path   string
 	Values map[string]string
 }
 
-// Available checks whether the sops CLI binary is available in PATH.
-func Available() bool {
-	_, err := exec.LookPath("sops")
-	return err == nil
-}
+func Available() bool { _, err := exec.LookPath("sops"); return err == nil }
 
-// Version returns the sops version string, or error if not available.
 func Version() (string, error) {
 	out, err := exec.Command("sops", "--version").CombinedOutput()
 	if err != nil {
@@ -29,52 +32,54 @@ func Version() (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// Decrypt decrypts a SOPS-encrypted YAML file using the sops CLI binary.
-// The optional env vars (e.g. from AgeKeyEnv) are layered onto the
-// subprocess environment, taking precedence over the process environment on
-// key collision (same pattern as gitx.runGitEnv, D46) — a caller-provided
-// value always wins.
-func Decrypt(filePath string, env ...string) (*SecretFile, error) {
+// Decrypt decrypts relativePath from kbRoot. SOPS always runs from kbRoot so
+// repository-relative creation rules have deterministic semantics.
+func Decrypt(kbRoot, relativePath string, env ...string) (*SecretFile, error) {
 	if !Available() {
 		return nil, fmt.Errorf("sops binary not found in PATH")
 	}
-	cmd := exec.Command("sops", "decrypt", "--output-type", "yaml", filePath)
+	if err := validatePath(kbRoot, relativePath, false); err != nil {
+		return nil, err
+	}
+	cmd := exec.Command("sops", "decrypt", "--output-type", "yaml", relativePath)
+	cmd.Dir = kbRoot
 	if len(env) > 0 {
 		cmd.Env = append(os.Environ(), env...)
 	}
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("sops decrypt %s: %w: %s", filePath, err, string(out))
+		return nil, fmt.Errorf("sops decrypt %s: %w: %s", relativePath, err, string(out))
 	}
 	values, err := parseYAMLFlat(out)
 	if err != nil {
-		return nil, fmt.Errorf("parse decrypted %s: %w", filePath, err)
+		return nil, fmt.Errorf("parse decrypted %s: %w", relativePath, err)
 	}
-	return &SecretFile{Path: filePath, Values: values}, nil
+	return &SecretFile{Path: relativePath, Values: values}, nil
 }
 
-// DecryptAll decrypts all *.sops.yaml files under the given directory (non-recursive).
-func DecryptAll(dir string, env ...string) ([]SecretFile, []error) {
-	matches, err := filepath.Glob(filepath.Join(dir, "*.sops.yaml"))
+// DecryptAll decrypts all *.sops.yaml files in a relative directory.
+func DecryptAll(kbRoot, dir string, env ...string) ([]SecretFile, []error) {
+	if err := validatePath(kbRoot, dir, false); err != nil {
+		return nil, []error{err}
+	}
+	matches, err := filepath.Glob(filepath.Join(kbRoot, dir, "*.sops.yaml"))
 	if err != nil {
 		return nil, []error{err}
 	}
 	var files []SecretFile
 	var errs []error
 	for _, m := range matches {
-		sf, err := Decrypt(m, env...)
+		rel, _ := filepath.Rel(kbRoot, m)
+		sf, err := Decrypt(kbRoot, rel, env...)
 		if err != nil {
 			errs = append(errs, err)
-			continue
+		} else {
+			files = append(files, *sf)
 		}
-		files = append(files, *sf)
 	}
 	return files, errs
 }
 
-// AgeKeyEnv returns the "SOPS_AGE_KEY_FILE=<path>" env entry for path, or
-// nil if path is empty. Meant to be passed straight into Decrypt/DecryptAll/
-// ResolveRefs to scope the age key used for decryption to a specific KB.
 func AgeKeyEnv(path string) []string {
 	if path == "" {
 		return nil
@@ -82,38 +87,119 @@ func AgeKeyEnv(path string) []string {
 	return []string{"SOPS_AGE_KEY_FILE=" + path}
 }
 
-// SecretRef maps a logical secret name to a SOPS file path and key.
 type SecretRef struct {
-	Name     string // env var name
-	SOPSFile string // path to *.sops.yaml
-	SOPSKey  string // key within the SOPS file
+	Name     string
+	SOPSFile string
+	SOPSKey  string
 }
 
-// ResolveRefs resolves SecretRefs by decrypting needed SOPS files and extracting values.
 func ResolveRefs(kbRoot string, refs []SecretRef, env ...string) (map[string]string, error) {
 	cache := map[string]*SecretFile{}
 	result := make(map[string]string)
+	names := map[string]bool{}
 	for _, ref := range refs {
-		sopsPath := filepath.Join(kbRoot, ref.SOPSFile)
-		sf, ok := cache[sopsPath]
-		if !ok {
+		if ref.Name == "" || names[ref.Name] {
+			return nil, fmt.Errorf("duplicate or empty secret ref name %q", ref.Name)
+		}
+		names[ref.Name] = true
+		if err := validatePath(kbRoot, ref.SOPSFile, false); err != nil {
+			return nil, fmt.Errorf("resolve %s: %w", ref.Name, err)
+		}
+		sf := cache[ref.SOPSFile]
+		if sf == nil {
 			var err error
-			sf, err = Decrypt(sopsPath, env...)
+			sf, err = Decrypt(kbRoot, ref.SOPSFile, env...)
 			if err != nil {
 				return nil, fmt.Errorf("resolve %s: %w", ref.Name, err)
 			}
-			cache[sopsPath] = sf
+			cache[ref.SOPSFile] = sf
 		}
 		val, ok := sf.Values[ref.SOPSKey]
 		if !ok {
-			return nil, fmt.Errorf("key %q not found in %s", ref.SOPSKey, ref.SOPSFile)
+			keys := make([]string, 0, len(sf.Values))
+			for k := range sf.Values {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			if len(keys) > 10 {
+				keys = keys[:10]
+			}
+			return nil, fmt.Errorf("key %q not found in %s (available: %s)", ref.SOPSKey, ref.SOPSFile, strings.Join(keys, ", "))
 		}
 		result[ref.Name] = val
 	}
 	return result, nil
 }
 
-// EnvForSkill converts resolved refs into "NAME=value" strings for os/exec.Cmd.Env.
+// Set changes one pointer on a pre-existing encrypted file without ever
+// exposing value in argv or the result. It returns only the selected path/key.
+func Set(kbRoot, relativePath, pointer, value string, env ...string) error {
+	if !Available() {
+		return fmt.Errorf("sops binary not found in PATH")
+	}
+	if err := validatePath(kbRoot, relativePath, false); err != nil {
+		return err
+	}
+	if !strings.HasPrefix(pointer, "/") {
+		return fmt.Errorf("key must be a JSON Pointer starting with /")
+	}
+	original := filepath.Join(kbRoot, relativePath)
+	raw, err := os.ReadFile(original)
+	if err != nil {
+		return err
+	}
+	if !bytes.Contains(raw, []byte("sops:")) {
+		return fmt.Errorf("%s is not SOPS-encrypted (missing sops metadata)", relativePath)
+	}
+	mode := os.FileMode(0o600)
+	if info, err := os.Stat(original); err == nil {
+		mode = info.Mode()
+	}
+	dir := filepath.Dir(original)
+	tmp, err := os.CreateTemp(dir, ".sops-set-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err = tmp.Write(raw); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err = tmp.Close(); err != nil {
+		return err
+	}
+	if err = os.Chmod(tmpName, mode); err != nil {
+		return err
+	}
+	selector, err := selectorForPointer(pointer)
+	if err != nil {
+		return err
+	}
+	encoded, _ := json.Marshal(value)
+	cmd := exec.Command("sops", "set", "--value-stdin", selector, filepath.Base(tmpName))
+	cmd.Dir = dir
+	cmd.Stdin = bytes.NewReader(encoded)
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("sops set %s: %w: %s", relativePath, err, redact(string(out), value))
+	}
+	updated, err := os.ReadFile(tmpName)
+	if err != nil {
+		return err
+	}
+	if err := verifyEncryptedPointer(updated, pointer); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, mode); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, original)
+}
+
 func EnvForSkill(resolved map[string]string) []string {
 	env := make([]string, 0, len(resolved))
 	for k, v := range resolved {
@@ -122,24 +208,126 @@ func EnvForSkill(resolved map[string]string) []string {
 	return env
 }
 
-func parseYAMLFlat(data []byte) (map[string]string, error) {
-	result := make(map[string]string)
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		idx := strings.Index(line, ": ")
-		if idx < 0 {
-			if strings.HasSuffix(line, ":") {
-				continue
+func validatePath(root, rel string, allowMissing bool) error {
+	if !filepath.IsLocal(rel) || rel == "." {
+		return fmt.Errorf("path %q must be relative and inside the KB", rel)
+	}
+	parts := strings.Split(filepath.Clean(rel), string(filepath.Separator))
+	current := root
+	for i, p := range parts {
+		current = filepath.Join(current, p)
+		info, err := os.Lstat(current)
+		if err != nil {
+			if allowMissing && os.IsNotExist(err) && i == len(parts)-1 {
+				return nil
 			}
-			continue
+			return fmt.Errorf("path %q: %w", rel, err)
 		}
-		key := strings.TrimSpace(line[:idx])
-		val := strings.TrimSpace(line[idx+2:])
-		val = strings.Trim(val, `"'`)
-		result[key] = val
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("path %q must not contain symlinks", rel)
+		}
+	}
+	return nil
+}
+
+func parseYAMLFlat(data []byte) (map[string]string, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, err
+	}
+	if len(doc.Content) != 1 || doc.Content[0].Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("root must be a mapping")
+	}
+	result := map[string]string{}
+	if err := flatten(doc.Content[0], "", result); err != nil {
+		return nil, err
 	}
 	return result, nil
 }
+func flatten(n *yaml.Node, ptr string, out map[string]string) error {
+	if n.Kind == yaml.AliasNode {
+		return fmt.Errorf("aliases are not supported")
+	}
+	switch n.Kind {
+	case yaml.MappingNode:
+		seen := map[string]bool{}
+		for i := 0; i < len(n.Content); i += 2 {
+			k, v := n.Content[i], n.Content[i+1]
+			if k.Kind != yaml.ScalarNode {
+				return fmt.Errorf("map keys must be strings")
+			}
+			if seen[k.Value] {
+				return fmt.Errorf("duplicate key %q", k.Value)
+			}
+			seen[k.Value] = true
+			if err := flatten(v, ptr+"/"+escape(k.Value), out); err != nil {
+				return err
+			}
+		}
+	case yaml.SequenceNode:
+		for i, v := range n.Content {
+			if err := flatten(v, ptr+"/"+strconv.Itoa(i), out); err != nil {
+				return err
+			}
+		}
+	case yaml.ScalarNode:
+		key := ptr
+		if strings.Count(ptr, "/") == 1 {
+			key = strings.TrimPrefix(ptr, "/")
+		}
+		if n.Tag == "!!null" {
+			out[key] = ""
+		} else {
+			out[key] = n.Value
+		}
+	default:
+		return fmt.Errorf("unsupported YAML node")
+	}
+	return nil
+}
+func escape(s string) string { return strings.ReplaceAll(strings.ReplaceAll(s, "~", "~0"), "/", "~1") }
+func unescape(s string) (string, error) {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '~' {
+			if i+1 >= len(s) || (s[i+1] != '0' && s[i+1] != '1') {
+				return "", fmt.Errorf("invalid JSON Pointer escape")
+			}
+			i++
+		}
+	}
+	return strings.ReplaceAll(strings.ReplaceAll(s, "~1", "/"), "~0", "~"), nil
+}
+func selectorForPointer(pointer string) (string, error) {
+	parts := strings.Split(strings.TrimPrefix(pointer, "/"), "/")
+	var b strings.Builder
+	for _, p := range parts {
+		p, err := unescape(p)
+		if err != nil {
+			return "", err
+		}
+		if n, err := strconv.Atoi(p); err == nil {
+			b.WriteString("[")
+			b.WriteString(strconv.Itoa(n))
+			b.WriteString("]")
+		} else {
+			q, _ := json.Marshal(p)
+			b.WriteString("[")
+			b.Write(q)
+			b.WriteString("]")
+		}
+	}
+	return b.String(), nil
+}
+func verifyEncryptedPointer(data []byte, pointer string) error {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("parse encrypted result: %w", err)
+	}
+	if !bytes.Contains(data, []byte("ENC[")) {
+		return fmt.Errorf("sops result left target cleartext")
+	}
+	return nil
+}
+func redact(s, value string) string { return strings.ReplaceAll(s, value, "[REDACTED]") }
+
+var _ io.Reader

--- a/internal/sops/sops.go
+++ b/internal/sops/sops.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -148,7 +147,11 @@ func Set(kbRoot, relativePath, pointer, value string, env ...string) error {
 	if err != nil {
 		return err
 	}
-	if !bytes.Contains(raw, []byte("sops:")) {
+	originalNode, err := yamlDocument(raw)
+	if err != nil {
+		return fmt.Errorf("parse encrypted %s: %w", relativePath, err)
+	}
+	if !hasSOPSMetadata(originalNode) {
 		return fmt.Errorf("%s is not SOPS-encrypted (missing sops metadata)", relativePath)
 	}
 	mode := os.FileMode(0o600)
@@ -172,20 +175,27 @@ func Set(kbRoot, relativePath, pointer, value string, env ...string) error {
 	if err = os.Chmod(tmpName, mode); err != nil {
 		return err
 	}
-	selector, err := selectorForPointer(pointer)
+	selector, err := selectorForPointer(originalNode, pointer)
 	if err != nil {
 		return err
 	}
 	encoded, _ := json.Marshal(value)
-	cmd := exec.Command("sops", "set", "--value-stdin", selector, filepath.Base(tmpName))
-	cmd.Dir = dir
+	tmpRel, err := filepath.Rel(kbRoot, tmpName)
+	if err != nil || !filepath.IsLocal(tmpRel) {
+		return fmt.Errorf("temporary secret path must stay inside the KB")
+	}
+	// SOPS 3.13 expects file before the selector. Keep the root cwd so its
+	// repository-relative creation_rules/path_regex matching is unchanged.
+	cmd := exec.Command("sops", "set", "--value-stdin", tmpRel, selector)
+	cmd.Dir = kbRoot
 	cmd.Stdin = bytes.NewReader(encoded)
 	if len(env) > 0 {
 		cmd.Env = append(os.Environ(), env...)
 	}
-	out, err := cmd.CombinedOutput()
+	_, err = cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("sops set %s: %w: %s", relativePath, err, redact(string(out), value))
+		// SOPS may include decrypted material in diagnostics. Never surface it.
+		return fmt.Errorf("sops set %s: %w", relativePath, err)
 	}
 	updated, err := os.ReadFile(tmpName)
 	if err != nil {
@@ -253,7 +263,7 @@ func flatten(n *yaml.Node, ptr string, out map[string]string) error {
 		seen := map[string]bool{}
 		for i := 0; i < len(n.Content); i += 2 {
 			k, v := n.Content[i], n.Content[i+1]
-			if k.Kind != yaml.ScalarNode {
+			if k.Kind != yaml.ScalarNode || k.Tag != "!!str" {
 				return fmt.Errorf("map keys must be strings")
 			}
 			if seen[k.Value] {
@@ -297,37 +307,113 @@ func unescape(s string) (string, error) {
 	}
 	return strings.ReplaceAll(strings.ReplaceAll(s, "~1", "/"), "~0", "~"), nil
 }
-func selectorForPointer(pointer string) (string, error) {
+func selectorForPointer(root *yaml.Node, pointer string) (string, error) {
+	if !strings.HasPrefix(pointer, "/") {
+		return "", fmt.Errorf("key must be a JSON Pointer starting with /")
+	}
 	parts := strings.Split(strings.TrimPrefix(pointer, "/"), "/")
+	n := root
 	var b strings.Builder
-	for _, p := range parts {
-		p, err := unescape(p)
+	for i, raw := range parts {
+		part, err := unescape(raw)
 		if err != nil {
 			return "", err
 		}
-		if n, err := strconv.Atoi(p); err == nil {
-			b.WriteString("[")
-			b.WriteString(strconv.Itoa(n))
-			b.WriteString("]")
-		} else {
-			q, _ := json.Marshal(p)
-			b.WriteString("[")
+		switch n.Kind {
+		case yaml.MappingNode:
+			q, _ := json.Marshal(part)
+			b.WriteByte('[')
 			b.Write(q)
-			b.WriteString("]")
+			b.WriteByte(']')
+			child, ok := mappingValue(n, part)
+			if !ok {
+				if i == len(parts)-1 {
+					return b.String(), nil
+				}
+				return "", fmt.Errorf("JSON Pointer %q: missing mapping key %q", pointer, part)
+			}
+			n = child
+		case yaml.SequenceNode:
+			idx, err := strconv.Atoi(part)
+			if err != nil || idx < 0 || idx >= len(n.Content) {
+				return "", fmt.Errorf("JSON Pointer %q: invalid sequence index %q", pointer, part)
+			}
+			b.WriteString("[")
+			b.WriteString(strconv.Itoa(idx))
+			b.WriteByte(']')
+			n = n.Content[idx]
+		default:
+			return "", fmt.Errorf("JSON Pointer %q: cannot descend through scalar", pointer)
 		}
 	}
 	return b.String(), nil
 }
 func verifyEncryptedPointer(data []byte, pointer string) error {
-	var doc yaml.Node
-	if err := yaml.Unmarshal(data, &doc); err != nil {
+	n, err := yamlDocument(data)
+	if err != nil {
 		return fmt.Errorf("parse encrypted result: %w", err)
 	}
-	if !bytes.Contains(data, []byte("ENC[")) {
-		return fmt.Errorf("sops result left target cleartext")
+	target, err := nodeAtPointer(n, pointer)
+	if err != nil {
+		return err
+	}
+	if target.Kind != yaml.ScalarNode {
+		return fmt.Errorf("sops result target %q is not a scalar", pointer)
+	}
+	if !strings.HasPrefix(target.Value, "ENC[") {
+		return fmt.Errorf("sops result left target %q cleartext", pointer)
 	}
 	return nil
 }
-func redact(s, value string) string { return strings.ReplaceAll(s, value, "[REDACTED]") }
 
-var _ io.Reader
+func yamlDocument(data []byte) (*yaml.Node, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, err
+	}
+	if len(doc.Content) != 1 || doc.Content[0].Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("root must be a mapping")
+	}
+	return doc.Content[0], nil
+}
+func mappingValue(n *yaml.Node, key string) (*yaml.Node, bool) {
+	for i := 0; i < len(n.Content); i += 2 {
+		if n.Content[i].Kind == yaml.ScalarNode && n.Content[i].Value == key {
+			return n.Content[i+1], true
+		}
+	}
+	return nil, false
+}
+func hasSOPSMetadata(root *yaml.Node) bool {
+	n, ok := mappingValue(root, "sops")
+	return ok && n.Kind == yaml.MappingNode
+}
+func nodeAtPointer(root *yaml.Node, pointer string) (*yaml.Node, error) {
+	if !strings.HasPrefix(pointer, "/") {
+		return nil, fmt.Errorf("key must be a JSON Pointer starting with /")
+	}
+	n := root
+	for _, raw := range strings.Split(strings.TrimPrefix(pointer, "/"), "/") {
+		part, err := unescape(raw)
+		if err != nil {
+			return nil, err
+		}
+		switch n.Kind {
+		case yaml.MappingNode:
+			var ok bool
+			n, ok = mappingValue(n, part)
+			if !ok {
+				return nil, fmt.Errorf("sops result target %q is missing", pointer)
+			}
+		case yaml.SequenceNode:
+			idx, err := strconv.Atoi(part)
+			if err != nil || idx < 0 || idx >= len(n.Content) {
+				return nil, fmt.Errorf("sops result target %q has invalid index %q", pointer, part)
+			}
+			n = n.Content[idx]
+		default:
+			return nil, fmt.Errorf("sops result target %q cannot descend through scalar", pointer)
+		}
+	}
+	return n, nil
+}

--- a/internal/sops/sops.go
+++ b/internal/sops/sops.go
@@ -114,6 +114,11 @@ func ResolveRefs(kbRoot string, refs []SecretRef, env ...string) (map[string]str
 			cache[ref.SOPSFile] = sf
 		}
 		val, ok := sf.Values[ref.SOPSKey]
+		// Flat legacy YAML keeps top-level keys unprefixed for compatibility,
+		// while secret_refs always use JSON Pointer syntax.
+		if !ok && strings.HasPrefix(ref.SOPSKey, "/") && !strings.Contains(strings.TrimPrefix(ref.SOPSKey, "/"), "/") {
+			val, ok = sf.Values[strings.TrimPrefix(ref.SOPSKey, "/")]
+		}
 		if !ok {
 			keys := make([]string, 0, len(sf.Values))
 			for k := range sf.Values {

--- a/internal/sops/sops_security_test.go
+++ b/internal/sops/sops_security_test.go
@@ -1,0 +1,172 @@
+package sops
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func recordingSOPS(t *testing.T, decrypt, result string, exit int) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX fake sops")
+	}
+	dir, log := t.TempDir(), filepath.Join(t.TempDir(), "sops.log")
+	script := "#!/bin/sh\n" +
+		"printf 'cwd=%s\\n' \"$PWD\" >> \"$FAKE_SOPS_LOG\"\n" +
+		"printf 'env=%s\\n' \"$SOPS_AGE_KEY_FILE\" >> \"$FAKE_SOPS_LOG\"\n" +
+		"printf 'argv=' >> \"$FAKE_SOPS_LOG\"; for x in \"$@\"; do printf '<%s>' \"$x\" >> \"$FAKE_SOPS_LOG\"; done; printf '\\n' >> \"$FAKE_SOPS_LOG\"\n" +
+		"if [ \"$1\" = set ]; then IFS= read -r stdin; printf 'stdin=%s\\n' \"$stdin\" >> \"$FAKE_SOPS_LOG\"; [ \"$FAKE_SOPS_EXIT\" = 0 ] || exit \"$FAKE_SOPS_EXIT\"; printf '%s' \"$FAKE_SOPS_RESULT\" > \"$3\"; exit 0; fi\n" +
+		"[ \"$FAKE_SOPS_EXIT\" = 0 ] || exit \"$FAKE_SOPS_EXIT\"\n" +
+		"printf '%s' \"$FAKE_SOPS_DECRYPT\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "sops"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("FAKE_SOPS_LOG", log)
+	t.Setenv("FAKE_SOPS_DECRYPT", decrypt)
+	t.Setenv("FAKE_SOPS_RESULT", result)
+	t.Setenv("FAKE_SOPS_EXIT", fmt.Sprint(exit))
+	return log
+}
+
+func encrypted() []byte { return []byte("nested:\n  old: ENC[old]\nlist:\n  - ENC[list]\nsops: {}\n") }
+
+func TestSetSecurityContract(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "secrets", "a.sops.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, encrypted(), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	secret := "raw secret \\\" newline\n"
+	log := recordingSOPS(t, "", "nested:\n  old: ENC[new]\nlist:\n  - ENC[list]\nsops: {}\n", 0)
+	if err := Set(root, "secrets/a.sops.yaml", "/nested/old", secret, AgeKeyEnv("/age/key")...); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := os.ReadFile(log)
+	text := string(b)
+	resolvedRoot, _ := filepath.EvalSymlinks(root)
+	if !strings.Contains(text, "cwd="+resolvedRoot) || !strings.Contains(text, "env=/age/key") || !strings.Contains(text, "argv=<set><--value-stdin><secrets/.sops-set-") || !strings.Contains(text, "><[\"nested\"][\"old\"]>") {
+		t.Fatalf("wrong invocation: %s", text)
+	}
+	if !strings.Contains(text, "stdin=\"raw secret") || strings.Contains(text, "argv=<"+secret+">") || strings.Contains(text, "env="+secret) {
+		t.Fatalf("secret leaked outside stdin: %s", text)
+	}
+	if info, _ := os.Stat(path); info.Mode().Perm() != 0o640 {
+		t.Errorf("mode = %o", info.Mode().Perm())
+	}
+}
+
+func TestSetSelectorsAndFailuresAreAtomic(t *testing.T) {
+	cases := []struct {
+		name, pointer, result string
+		exit                  int
+	}{{"new-leaf", "/nested/new", "nested:\n  old: ENC[old]\n  new: ENC[new]\nlist:\n  - ENC[list]\nsops: {}\n", 0}, {"sequence", "/list/0", "nested:\n  old: ENC[old]\nlist:\n  - ENC[new]\nsops: {}\n", 0}, {"subprocess", "/nested/old", "", 3}, {"clear", "/nested/old", "nested:\n  old: clear\nsops: {}\n", 0}, {"missing", "/nested/old", "nested: {}\nsops: {}\n", 0}, {"non-scalar", "/nested/old", "nested:\n  old: {}\nsops: {}\n", 0}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			p := filepath.Join(root, "secrets", "a.sops.yaml")
+			os.MkdirAll(filepath.Dir(p), 0o755)
+			os.WriteFile(p, encrypted(), 0o640)
+			before, _ := os.ReadFile(p)
+			log := recordingSOPS(t, "", tc.result, tc.exit)
+			err := Set(root, "secrets/a.sops.yaml", tc.pointer, "never-report-me")
+			if tc.exit == 0 && (tc.name == "new-leaf" || tc.name == "sequence") {
+				if err != nil {
+					t.Fatal(err)
+				}
+				b, _ := os.ReadFile(log)
+				want := "[\"nested\"][\"new\"]"
+				if tc.name == "sequence" {
+					want = "[\"list\"][0]"
+				}
+				if !strings.Contains(string(b), "<"+want+">") {
+					t.Errorf("selector missing: %s", b)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected failure")
+			}
+			after, _ := os.ReadFile(p)
+			if string(before) != string(after) {
+				t.Error("failure changed original bytes")
+			}
+			if strings.Contains(err.Error(), "never-report-me") {
+				t.Errorf("secret leaked in %v", err)
+			}
+		})
+	}
+}
+
+func TestSetRejectsUnsafeInputs(t *testing.T) {
+	root := t.TempDir()
+	os.MkdirAll(filepath.Join(root, "secrets"), 0o755)
+	os.WriteFile(filepath.Join(root, "secrets", "a.sops.yaml"), encrypted(), 0o600)
+	recordingSOPS(t, "", "", 0)
+	for _, p := range []string{"../a.sops.yaml", filepath.Join(root, "secrets/a.sops.yaml")} {
+		if err := Set(root, p, "/x", "v"); err == nil {
+			t.Errorf("accepted %q", p)
+		}
+	}
+	if err := Set(root, "secrets/missing.sops.yaml", "/x", "v"); err == nil {
+		t.Error("accepted missing file")
+	}
+	os.WriteFile(filepath.Join(root, "secrets", "plain.sops.yaml"), []byte("x: y\n"), 0o600)
+	if err := Set(root, "secrets/plain.sops.yaml", "/x", "v"); err == nil {
+		t.Error("accepted plaintext")
+	}
+	if runtime.GOOS != "windows" {
+		os.Symlink(filepath.Join(root, "secrets"), filepath.Join(root, "link"))
+		os.Symlink(filepath.Join(root, "secrets", "a.sops.yaml"), filepath.Join(root, "secrets", "final.sops.yaml"))
+		for _, p := range []string{"link/a.sops.yaml", "secrets/final.sops.yaml"} {
+			if err := Set(root, p, "/nested/old", "v"); err == nil {
+				t.Errorf("accepted symlink %q", p)
+			}
+		}
+	}
+}
+
+func TestFlattenAndResolveRefsSafety(t *testing.T) {
+	vals, err := parseYAMLFlat([]byte("a/b: one\na~b: two\nleft: {same: x}\nright: {same: y}\nlist: [{k: true}, {k: 42}, {k: 1.5}, {k: null}]\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, want := range map[string]string{"a~1b": "one", "a~0b": "two", "/left/same": "x", "/right/same": "y", "/list/0/k": "true", "/list/1/k": "42", "/list/2/k": "1.5", "/list/3/k": ""} {
+		if vals[key] != want {
+			t.Errorf("%s = %q", key, vals[key])
+		}
+	}
+	for _, input := range []string{"[x]", "a: 1\na: 2", "a: [", "a: &x x\nb: *x", "1: x"} {
+		if _, err := parseYAMLFlat([]byte(input)); err == nil {
+			t.Errorf("accepted %q", input)
+		}
+	}
+	root := t.TempDir()
+	os.MkdirAll(filepath.Join(root, "secrets"), 0o755)
+	os.WriteFile(filepath.Join(root, "secrets", "a.sops.yaml"), []byte("x"), 0o600)
+	log := recordingSOPS(t, "one: value-one\ntwo: value-two\n", "", 0)
+	got, err := ResolveRefs(root, []SecretRef{{Name: "ONE", SOPSFile: "secrets/a.sops.yaml", SOPSKey: "one"}, {Name: "TWO", SOPSFile: "secrets/a.sops.yaml", SOPSKey: "two"}})
+	if err != nil || len(got) != 2 {
+		t.Fatalf("%v %#v", err, got)
+	}
+	b, _ := os.ReadFile(log)
+	if strings.Count(string(b), "argv=<decrypt>") != 1 {
+		t.Error("decrypted file more than once")
+	}
+	_, err = ResolveRefs(root, []SecretRef{{Name: "X", SOPSFile: "secrets/a.sops.yaml", SOPSKey: "nope"}})
+	if err == nil || strings.Contains(err.Error(), "value-one") || !strings.Contains(err.Error(), "one") {
+		t.Errorf("unsafe missing error: %v", err)
+	}
+	for _, refs := range [][]SecretRef{{{Name: "X", SOPSFile: "../a", SOPSKey: "/x"}}, {{Name: "X", SOPSFile: "secrets/a.sops.yaml", SOPSKey: "/x"}, {Name: "X", SOPSFile: "secrets/a.sops.yaml", SOPSKey: "/x"}}} {
+		if _, err := ResolveRefs(root, refs); err == nil {
+			t.Error("accepted invalid refs")
+		}
+	}
+}

--- a/internal/sops/sops_test.go
+++ b/internal/sops/sops_test.go
@@ -14,7 +14,7 @@ token: "quoted-value"
 # comment
 empty_line:
 
-nested_key: value-with-colon: in-it
+nested_key: "value-with-colon: in-it"
 `)
 	vals, err := parseYAMLFlat(input)
 	if err != nil {
@@ -61,7 +61,7 @@ func TestDecryptMissingSops(t *testing.T) {
 	if Available() {
 		t.Skip("sops is available, skipping missing-sops test")
 	}
-	_, err := Decrypt("/nonexistent/file.sops.yaml")
+	_, err := Decrypt(t.TempDir(), "nonexistent/file.sops.yaml")
 	if err == nil {
 		t.Error("expected error when sops not available")
 	}
@@ -103,7 +103,14 @@ echo "resolved_key: ${SOPS_AGE_KEY_FILE}"
 func TestDecrypt_WithEnv_FakeSops(t *testing.T) {
 	fakeSopsInPath(t)
 
-	sf, err := Decrypt("/any/path.sops.yaml", AgeKeyEnv("/tmp/age-key.txt")...)
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "secrets"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "secrets", "test.sops.yaml"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sf, err := Decrypt(root, "secrets/test.sops.yaml", AgeKeyEnv("/tmp/age-key.txt")...)
 	if err != nil {
 		t.Fatalf("Decrypt: %v", err)
 	}
@@ -119,7 +126,14 @@ func TestDecrypt_NoEnv_FakeSops(t *testing.T) {
 	fakeSopsInPath(t)
 	t.Setenv("SOPS_AGE_KEY_FILE", "") // ensure no ambient value leaks in
 
-	sf, err := Decrypt("/any/path.sops.yaml")
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "secrets"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "secrets", "test.sops.yaml"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sf, err := Decrypt(root, "secrets/test.sops.yaml")
 	if err != nil {
 		t.Fatalf("Decrypt: %v", err)
 	}

--- a/internal/sops/sops_test.go
+++ b/internal/sops/sops_test.go
@@ -141,3 +141,42 @@ func TestDecrypt_NoEnv_FakeSops(t *testing.T) {
 		t.Errorf("resolved_key = %q, want empty when no env passed", sf.Values["resolved_key"])
 	}
 }
+
+func TestParseYAMLFlat_NestedPointersAndTypes(t *testing.T) {
+	values, err := parseYAMLFlat([]byte("a:\n  b:\n    c:\n      leaf: one\nlist:\n  - false\n  - null\n  - nested: two\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, want := range map[string]string{"/a/b/c/leaf": "one", "/list/0": "false", "/list/1": "", "/list/2/nested": "two"} {
+		if got := values[key]; got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestParseYAMLFlatRejectsAliasAndNonStringKey(t *testing.T) {
+	for _, input := range []string{"a: &x value\nb: *x\n", "1: value\n"} {
+		if _, err := parseYAMLFlat([]byte(input)); err == nil {
+			t.Errorf("parseYAMLFlat(%q) succeeded", input)
+		}
+	}
+}
+
+func TestSelectorAndVerifyEncryptedPointerRespectNodeKinds(t *testing.T) {
+	root, err := yamlDocument([]byte("map:\n  \"0\": ENC[x]\nlist:\n  - ENC[y]\nsops: {}\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, err := selectorForPointer(root, "/map/0"); err != nil || got != `["map"]["0"]` {
+		t.Errorf("map numeric selector = %q, %v", got, err)
+	}
+	if got, err := selectorForPointer(root, "/list/0"); err != nil || got != `["list"][0]` {
+		t.Errorf("list selector = %q, %v", got, err)
+	}
+	if err := verifyEncryptedPointer([]byte("map:\n  \"0\": clear\nsops: {}\n"), "/map/0"); err == nil {
+		t.Error("clear target accepted")
+	}
+	if err := verifyEncryptedPointer([]byte("map:\n  \"0\": ENC[x]\nsops: {}\n"), "/map/missing"); err == nil {
+		t.Error("missing target accepted")
+	}
+}


### PR DESCRIPTION
## Summary
- Parse nested SOPS YAML into RFC 6901 pointers and resolve scoped secret references.
- Add secret_resolve and encrypted-only secret_set MCP tools.
- Document SOPS pointer, least-privilege, and rotation behavior.

## Tests
- make vet
- make test
- make smoke-http
- make e2e

Generated with Codex

Closes #67
Closes #56