### PR TITLE
feat: add declarative lint contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Cartographer offers **two complementary profiles**:
 - 🔍 **Search** — keyword (pure-Go inverted index) plus optional hybrid semantic search via Ollama
 - ✍️ **Validated writes** with optimistic concurrency (`if_match` / content-hash)
 - 📎 **Concept assets** — read, write, list, and delete binary or text dossier files inside expanded concepts
-- 🛡️ **Governance** — deterministic `lint` (broken link, stale claim, orphan), `commit_gate`,
+- 🛡️ **Governance** — deterministic `lint` (broken link, stale claim, orphan, map contracts), `commit_gate`,
   `gate_check`, `supersede`, contradiction tracking
 - 🧬 **Transactional git** — one commit per write operation; optional synchronization to a remote
   (fetch/pull-rebase before and push after every write) — git as a sync layer across multiple

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -57,7 +57,7 @@ Tools marked **[A]** (advanced, `advancedToolNames` in `internal/mcpserver/visib
 
 | Tool | Purpose |
 |---|---|
-| `map_create(name, title, [kind], [concept_types], [ontology_mode])` | Creates a map (`kind: map`, default) or a journal (`kind: journal`): a directory with `_map.md`, `index.md`, `log.md`. |
+| `map_create(name, title, [kind], [concept_types], [ontology_mode], [required_fields], [required_fields_by_type], [require_index_entry])` | Creates a map (`kind: map`, default) or a journal (`kind: journal`): a directory with `_map.md`, `index.md`, `log.md`. The optional contract fields are serialized deterministically in its descriptor. |
 | `map_delete(map)` | Deletes a map/journal directory, but only if it holds nothing beyond the `map_create` scaffold (`_map.md`, `index.md`, `log.md`); if any concept remains, errors listing them — move them out with `concept_move` first, then retry (D88). |
 | `concept_expand(id)` | Promotes a concept to an expanded concept: `map/name.md` → `map/name/index.md`, **same ConceptID** (no backlink rewrite), from which it can grow with `map/name/child` satellites. Requires a 2-segment id; errors `not_found` / `already_expanded`. No inverse operation (D77). |
 | `asset_read(concept_id, path, [encoding])` **[R]** | Reads a non-Markdown asset inside an expanded concept. Returns content (`text` or base64; invalid UTF-8 is always base64), raw-byte `sha256`, size and executable mode. |
@@ -77,7 +77,7 @@ Tools marked **[A]** (advanced, `advancedToolNames` in `internal/mcpserver/visib
 | Tool | Purpose |
 |---|---|
 | `validate(scope)` **[R]** **[A]** | OKF compliance (frontmatter, `type`, reserved files). |
-| `lint([scope], [scope_neighbors])` **[R]** **[A]** | Runs deterministic broken-link, stale-claim, orphan and structural checks. `scope_neighbors=true` adds one-hop graph neighbors. There is no model-backed/deep mode. |
+| `lint([scope], [scope_neighbors])` **[R]** **[A]** | Runs deterministic broken-link, stale-claim, orphan, contract and structural checks. `scope_neighbors=true` adds one-hop graph neighbors. There is no model-backed/deep mode. |
 | `commit_gate()` **[A]** | Blocks when open `Contradiction`s are involved in the diff. |
 | `gate_check()` **[R]** **[A]** | Combines validate + lint + commit_gate in a single tool (lightweight local gate). |
 | `conflict_resolve(contradiction_id, resolution, [reason])` **[A]** | Closes an open `Contradiction`. |
@@ -147,6 +147,9 @@ opt-in and active only when an Ollama endpoint is configured.
   layout/depth rules and the allowed type palette of strict Maps.
 - `lint` reports deterministic findings. It does not generate typed graph
   edges or Contradiction concepts.
+- Contract findings are `missing_required_field` (error), `index_incomplete`
+  (warning), and `contract_malformed` (info). A lint error makes `gate_check`
+  fail; `commit_gate` remains contradiction-only.
 - `commit_gate` inspects existing `type: Contradiction` concepts with
   `resolution_status: open` and blocks a supplied set of changed concept IDs
   when they are involved.

--- a/docs/data-plane.md
+++ b/docs/data-plane.md
@@ -71,11 +71,14 @@ title: Smart Home
 kind: map                      # map (thematic) | journal (chronological log)
 concept_types: [Entity, Topic, Runbook]
 ontology_mode: strict          # strict | emergent | off
+required_fields: [timestamp]  # optional, required on every concept by lint
+required_fields.Runbook: [provenance] # optional, additive for this exact type
+require_index_entry: true      # optional, require curated index membership
 timestamp: 2026-06-25T10:00:00Z
 ---
 ```
 
-A **map** groups by theme, with mixed types (an Entity and a Topic from the same domain coexist: the type is a frontmatter attribute, not a position). A **journal** groups by chronology (dated concepts `YYYY-MM-DD-slug`, append-oriented). `ontology_mode`: `strict` (only `type`s in the palette), `emergent` (new types get registered in a manifest), `off` (no check). The system does not ship any predefined palettes.
+A **map** groups by theme, with mixed types (an Entity and a Topic from the same domain coexist: the type is a frontmatter attribute, not a position). A **journal** groups by chronology (dated concepts `YYYY-MM-DD-slug`, append-oriented). `ontology_mode`: `strict` (only `type`s in the palette), `emergent` (new types get registered in a manifest), `off` (no check). `required_fields` is a map-wide lint contract; `required_fields.<Type>` adds fields for an exact, case-sensitive type. `require_index_entry` requires every map concept in the map `index.md` and every satellite in its expanded owner's `index.md`. The server ships no default contract or domain vocabulary.
 
 Read-compat (D77): the legacy `_archive.md` descriptor (`type: Archive`, `archive_type`) remains readable and is treated as a Map with `kind: map`; it is never written again, and lint flags it (`legacy_archive_descriptor`) as a migration backlog item.
 

--- a/docs/decisions/data-plane.md
+++ b/docs/decisions/data-plane.md
@@ -274,3 +274,12 @@ Each absent destination map is created through `CreateMap`, adding the same `_ma
 **Rationale.** Expanded concepts already establish a stable owner directory without changing their ConceptID. Keeping attached evidence in that directory lets git preserve it across moves while the concept graph remains exclusively Markdown-to-Markdown, avoiding false search and lint results from binary or generated files.
 
 **Alternative rejected.** Widening the provisioning `artifact_*` whitelist to `data/**` was rejected: provisioning artifacts and concept evidence have different validation, ownership, lifecycle, visibility, and `allow_artifact_write` semantics. A separate data-plane API preserves both boundaries.
+
+---
+
+<a id="d107"></a>
+## D107 — Declarative lint contracts in map descriptors
+
+**Decision.** A map may declare `required_fields`, additive `required_fields.<Type>`, and `require_index_entry` in `_map.md`. Lint reports a missing required field as an error and an incomplete curated index as a warning; malformed recognized entries are informational. The contract is optional, so no server-default vocabulary or schema is imposed. `gate_check` fails on the error, while `validate` and contradiction-only `commit_gate` retain their existing responsibilities.
+
+**Rationale.** A descriptor is versioned, local to the map it governs, and uses the existing string/list frontmatter grammar. It gives deterministic, auditable enforcement without executable plugins, which would make lint arbitrary-code execution and undermine its no-LLM guarantee. Required field contracts belong to governance rather than the read-path validator so legacy KBs remain consumable. Domain-specific rules (for example, required section prose or naming conventions) remain KB skill policy: generalising them would require a rule language outside this data-plane contract. `index_incomplete` deliberately complements, rather than replaces, `expanded_as_category`: the former reports each missing curated entry; the latter detects a broader filesystem-taxonomy smell.

--- a/docs/loop.md
+++ b/docs/loop.md
@@ -31,8 +31,10 @@ Remote synchronization is handled around writes when configured. See
 
 - `validate` checks KB and frontmatter invariants.
 - `lint(scope, scope_neighbors)` runs deterministic checks over a scope and,
-  optionally, its graph neighbors.
-- `gate_check` combines the repository's deterministic validation checks.
+  optionally, its graph neighbors, including any declarative map contract for
+  required frontmatter and curated-index membership.
+- `gate_check` combines the repository's deterministic validation checks; lint
+  errors (including missing required fields) make it fail.
 
 Reasoning checks such as factual grounding, PII review or semantic
 contradiction analysis are agent/human policy. Cartographer does not currently

--- a/internal/kb/kb.go
+++ b/internal/kb/kb.go
@@ -1052,13 +1052,50 @@ func (kb *KB) mapDescriptorRelPath(archive string) (string, error) {
 	return filepath.Join(archive, mapDescriptorCandidates[0]), nil
 }
 
+// MapContract declares the optional deterministic lint contract of a map.
+// RequiredFields apply to every concept; RequiredFieldsByType are additive.
+type MapContract struct {
+	RequiredFields       []string
+	RequiredFieldsByType map[string][]string
+	RequireIndexEntry    bool
+	Malformed            []ContractMalformed
+}
+
+// ContractMalformed identifies a tolerated malformed contract entry.
+type ContractMalformed struct {
+	Descriptor string
+	Key        string
+}
+
+// RequiredFor returns the map-wide fields plus fields for conceptType.
+func (c MapContract) RequiredFor(conceptType string) []string {
+	seen := map[string]bool{}
+	var fields []string
+	for _, group := range [][]string{c.RequiredFields, c.RequiredFieldsByType[conceptType]} {
+		for _, field := range group {
+			if !seen[field] {
+				seen[field] = true
+				fields = append(fields, field)
+			}
+		}
+	}
+	sort.Strings(fields)
+	return fields
+}
+
 // CreateMap creates a map or journal with minimal structure: _map.md,
 // index.md, log.md (D77 WP1 — replaces the former CreateArchive/
 // "_archive.md" pair, which is now read-compat only, never written).
 // name must be a kebab-case segment; the map must not already exist.
 // kind must be "map" or "journal"; empty defaults to "map". If ontologyMode
-// is empty, defaults to "flexible".
+// is empty, defaults to "flexible". It creates no optional lint contract.
 func (kb *KB) CreateMap(name, title, kind string, conceptTypes []string, ontologyMode string) error {
+	return kb.CreateMapWithContract(name, title, kind, conceptTypes, ontologyMode, MapContract{})
+}
+
+// CreateMapWithContract creates a map or journal with its optional lint
+// contract serialized deterministically in _map.md.
+func (kb *KB) CreateMapWithContract(name, title, kind string, conceptTypes []string, ontologyMode string, contract MapContract) error {
 	if _, err := okf.PathToID(name + ".md"); err != nil {
 		return fmt.Errorf("%w: invalid map name %q", okf.ErrInvalidPath, name)
 	}
@@ -1091,6 +1128,23 @@ func (kb *KB) CreateMap(name, title, kind string, conceptTypes []string, ontolog
 		mapFM.WriteString("concept_types: [" + strings.Join(conceptTypes, ", ") + "]\n")
 	}
 	mapFM.WriteString("ontology_mode: " + ontologyMode + "\n")
+	if len(contract.RequiredFields) > 0 {
+		mapFM.WriteString("required_fields: [" + strings.Join(sortedUnique(contract.RequiredFields), ", ") + "]\n")
+	}
+	types := make([]string, 0, len(contract.RequiredFieldsByType))
+	for typ := range contract.RequiredFieldsByType {
+		types = append(types, typ)
+	}
+	sort.Strings(types)
+	for _, typ := range types {
+		fields := sortedUnique(contract.RequiredFieldsByType[typ])
+		if len(fields) > 0 {
+			mapFM.WriteString("required_fields." + typ + ": [" + strings.Join(fields, ", ") + "]\n")
+		}
+	}
+	if contract.RequireIndexEntry {
+		mapFM.WriteString("require_index_entry: true\n")
+	}
 	mapMD := "---\n" + strings.TrimRight(mapFM.String(), "\n") + "\n---\n# " + title + "\n"
 	if err := writeFileAtomic(filepath.Join(mapAbs, "_map.md"), []byte(mapMD)); err != nil {
 		return fmt.Errorf("CreateMap: write _map.md: %w", err)
@@ -1106,6 +1160,19 @@ func (kb *KB) CreateMap(name, title, kind string, conceptTypes []string, ontolog
 	}
 
 	return nil
+}
+
+func sortedUnique(values []string) []string {
+	seen := map[string]bool{}
+	var result []string
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" && !seen[value] {
+			seen[value] = true
+			result = append(result, value)
+		}
+	}
+	sort.Strings(result)
+	return result
 }
 
 // DeleteMap removes a map or journal directory, but only if it is empty —
@@ -1197,6 +1264,77 @@ func (kb *KB) ReadArchiveMeta(archive string) (*okf.Frontmatter, error) {
 		parsed.Set("kind", "map")
 	}
 	return parsed, nil
+}
+
+// ReadMapContract reads a map's optional lint contract. Unknown descriptor
+// keys remain ignored for permissive consumption; malformed recognized keys
+// are returned as findings for lint to surface without blocking reads.
+func (kb *KB) ReadMapContract(archive string) (MapContract, error) {
+	relPath, err := kb.mapDescriptorRelPath(archive)
+	if err != nil {
+		return MapContract{}, fmt.Errorf("ReadMapContract %s: %w", archive, err)
+	}
+	meta, err := kb.ReadArchiveMeta(archive)
+	if err != nil {
+		return MapContract{}, err
+	}
+	contract := MapContract{RequiredFieldsByType: map[string][]string{}}
+	malformedKeys := map[string]bool{}
+	bad := func(key string) {
+		if malformedKeys[key] {
+			return
+		}
+		malformedKeys[key] = true
+		contract.Malformed = append(contract.Malformed, ContractMalformed{Descriptor: relPath, Key: key})
+	}
+	for _, key := range meta.Keys() {
+		if key != "required_fields" && !strings.HasPrefix(key, "required_fields.") && key != "require_index_entry" {
+			continue
+		}
+		value, _ := meta.Get(key)
+		switch {
+		case key == "require_index_entry":
+			v, ok := value.(string)
+			if !ok || (v != "true" && v != "false") {
+				bad(key)
+				continue
+			}
+			contract.RequireIndexEntry = v == "true"
+		case key == "required_fields" || strings.HasPrefix(key, "required_fields."):
+			fields, ok := value.([]string)
+			if !ok {
+				bad(key)
+				continue
+			}
+			seen := map[string]bool{}
+			valid := make([]string, 0, len(fields))
+			malformed := false
+			for _, field := range fields {
+				field = strings.TrimSpace(field)
+				if field == "" || seen[field] {
+					malformed = true
+					continue
+				}
+				seen[field] = true
+				valid = append(valid, field)
+			}
+			if malformed {
+				bad(key)
+			}
+			sort.Strings(valid)
+			if key == "required_fields" {
+				contract.RequiredFields = valid
+				continue
+			}
+			typ := strings.TrimPrefix(key, "required_fields.")
+			if strings.TrimSpace(typ) == "" {
+				bad(key)
+				continue
+			}
+			contract.RequiredFieldsByType[typ] = valid
+		}
+	}
+	return contract, nil
 }
 
 // Validate validates .md files in the scope (path relative to the KB; if empty, the entire KB).

--- a/internal/kb/kb_test.go
+++ b/internal/kb/kb_test.go
@@ -867,6 +867,41 @@ func TestCreateMap_ErroreSeEsiste(t *testing.T) {
 	}
 }
 
+func TestCreateMap_ContractRoundTrip(t *testing.T) {
+	dir := tempKB(t)
+	k, _ := Init(dir)
+	contract := MapContract{
+		RequiredFields:       []string{"timestamp", "provenance", "timestamp"},
+		RequiredFieldsByType: map[string][]string{"Runbook": {"owner", "provenance"}},
+		RequireIndexEntry:    true,
+	}
+	if err := k.CreateMapWithContract("ops", "Ops", "map", nil, "", contract); err != nil {
+		t.Fatalf("CreateMapWithContract: %v", err)
+	}
+	got, err := k.ReadMapContract("ops")
+	if err != nil {
+		t.Fatalf("ReadMapContract: %v", err)
+	}
+	if !got.RequireIndexEntry || strings.Join(got.RequiredFor("Runbook"), ",") != "owner,provenance,timestamp" || strings.Join(got.RequiredFor("Note"), ",") != "provenance,timestamp" {
+		t.Fatalf("unexpected contract: %#v", got)
+	}
+}
+
+func TestReadMapContract_LegacyDescriptorIsEmpty(t *testing.T) {
+	dir := tempKB(t)
+	k, _ := Init(dir)
+	if err := os.MkdirAll(filepath.Join(k.DataRoot(), "legacy"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(k.DataRoot(), "legacy", "_archive.md"), []byte("---\ntype: Archive\ntitle: Legacy\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	contract, err := k.ReadMapContract("legacy")
+	if err != nil || contract.RequireIndexEntry || len(contract.RequiredFor("Note")) != 0 || len(contract.Malformed) != 0 {
+		t.Fatalf("legacy contract = %#v, %v", contract, err)
+	}
+}
+
 func TestDeleteMap_RefusesAssetOnlyEntry(t *testing.T) {
 	dir := tempKB(t)
 	k, err := Init(dir)

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -142,6 +142,26 @@ func Run(k *kb.KB, scope string, scopeNeighbors bool) ([]Finding, error) {
 	}
 
 	var findings []Finding
+	// Contracts are descriptor-level data. Cache them once per map for this
+	// run, so a map with many concepts does not repeatedly parse _map.md.
+	contracts := make(map[string]kb.MapContract, len(archives))
+	for _, archive := range archives {
+		contract, contractErr := k.ReadMapContract(archive)
+		if contractErr != nil {
+			continue // A non-map directory has no descriptor/contract.
+		}
+		contracts[archive] = contract
+		if scopeMatchesDir(scopeNorm, archive) {
+			for _, malformed := range contract.Malformed {
+				findings = append(findings, Finding{
+					Path:     malformed.Descriptor,
+					Check:    "contract_malformed",
+					Severity: SevInfo,
+					Message:  fmt.Sprintf("malformed lint contract key %q", malformed.Key),
+				})
+			}
+		}
+	}
 
 	for id, content := range toCheck {
 		relPath := okf.IDToPath(id)
@@ -181,10 +201,13 @@ func Run(k *kb.KB, scope string, scopeNeighbors bool) ([]Finding, error) {
 			})
 		}
 
-		// --- stale_claim / imported_draft (warning) ---
+		// --- stale_claim / imported_draft / missing_required_field ---
+		// services/ concepts are rooted outside data/ and therefore have no map
+		// descriptor to contract against.
+		var parsed *okf.Frontmatter
 		if hasFM {
-			parsed, fmErr := okf.ParseFrontmatter(fmRaw)
-			if fmErr == nil {
+			parsed, _ = okf.ParseFrontmatter(fmRaw)
+			if parsed != nil {
 				if raVal, ok := parsed.Get("review_after"); ok {
 					if dateStr, ok := raVal.(string); ok {
 						t, parseErr := time.Parse("2006-01-02", dateStr)
@@ -212,6 +235,30 @@ func Run(k *kb.KB, scope string, scopeNeighbors bool) ([]Finding, error) {
 							Message:  "imported concept awaiting curation",
 						})
 					}
+				}
+			}
+		}
+		parts := strings.Split(string(id), "/")
+		if len(parts) > 1 && archiveSet[parts[0]] {
+			contract := contracts[parts[0]]
+			for _, field := range contract.RequiredFor(func() string {
+				if parsed == nil {
+					return ""
+				}
+				return parsed.Type()
+			}()) {
+				missing := parsed == nil
+				if !missing {
+					value, exists := parsed.Get(field)
+					missing = !exists || emptyFrontmatterValue(value)
+				}
+				if missing {
+					findings = append(findings, Finding{
+						Path:     relPath,
+						Check:    "missing_required_field",
+						Severity: SevError,
+						Message:  fmt.Sprintf("missing required field %q required by map %q", field, parts[0]),
+					})
 				}
 			}
 		}
@@ -267,6 +314,23 @@ func Run(k *kb.KB, scope string, scopeNeighbors bool) ([]Finding, error) {
 			}
 		}
 
+		// --- index_incomplete / curated-index broken_link (D107) ---
+		// Only candidates in toCheck participate, which keeps a scoped lint
+		// actionable instead of reporting unrelated map siblings.
+		contract, hasContract := contracts[archiveName]
+		if hasContract && contract.RequireIndexEntry {
+			var direct []okf.ConceptID
+			for id := range toCheck {
+				parts := strings.Split(string(id), "/")
+				if len(parts) == 2 && parts[0] == archiveName {
+					direct = append(direct, id)
+				}
+			}
+			if len(direct) > 0 {
+				checkCuratedIndex(k, archiveName, archiveName+"/index.md", direct, &findings)
+			}
+		}
+
 		expandedDirs, err := k.ListExpanded(archiveName)
 		if err != nil {
 			continue
@@ -275,6 +339,17 @@ func Run(k *kb.KB, scope string, scopeNeighbors bool) ([]Finding, error) {
 			expandedID := okf.ConceptID(archiveName + "/" + d)
 			if !scopeMatchesDir(scopeNorm, string(expandedID)) {
 				continue
+			}
+			if contract, ok := contracts[archiveName]; ok && contract.RequireIndexEntry {
+				var satellites []okf.ConceptID
+				for id := range toCheck {
+					if strings.HasPrefix(string(id), string(expandedID)+"/") {
+						satellites = append(satellites, id)
+					}
+				}
+				if len(satellites) > 0 {
+					checkCuratedIndex(k, string(expandedID), string(expandedID)+"/index.md", satellites, &findings)
+				}
 			}
 
 			// --- expanded_missing_index (warning) ---
@@ -395,6 +470,58 @@ func Run(k *kb.KB, scope string, scopeNeighbors bool) ([]Finding, error) {
 	}
 
 	return findings, nil
+}
+
+func emptyFrontmatterValue(value interface{}) bool {
+	switch v := value.(type) {
+	case nil:
+		return true
+	case string:
+		return strings.TrimSpace(v) == ""
+	case []string:
+		return len(v) == 0
+	default:
+		return false
+	}
+}
+
+// checkCuratedIndex verifies both directions of an opted-in curated index.
+// folder is passed to ReadIndex; indexPath is the exact physical base used by
+// ExtractLinks so relative Markdown links resolve from the right directory.
+func checkCuratedIndex(k *kb.KB, folder, indexPath string, candidates []okf.ConceptID, findings *[]Finding) {
+	content, err := k.ReadIndex(folder)
+	if err != nil {
+		*findings = append(*findings, Finding{
+			Path:     indexPath,
+			Check:    "index_incomplete",
+			Severity: SevWarning,
+			Message:  "curated index is missing or unreadable",
+		})
+		return
+	}
+	_, body, _ := okf.SplitFrontmatter(content)
+	targets := map[okf.ConceptID]bool{}
+	for _, target := range kb.ExtractLinks(body, indexPath) {
+		targets[target] = true
+		if _, readErr := k.ReadConcept(target); errors.Is(readErr, okf.ErrNotFound) {
+			*findings = append(*findings, Finding{
+				Path:     indexPath,
+				Check:    "broken_link",
+				Severity: SevWarning,
+				Message:  fmt.Sprintf("broken link to %s", okf.IDToPath(target)),
+			})
+		}
+	}
+	for _, candidate := range candidates {
+		if !targets[candidate] {
+			*findings = append(*findings, Finding{
+				Path:     indexPath,
+				Check:    "index_incomplete",
+				Severity: SevWarning,
+				Message:  fmt.Sprintf("missing curated index entry for %s", candidate),
+			})
+		}
+	}
 }
 
 // scopeMatchesDir reports whether a directory path (a map or an expanded

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -326,8 +327,11 @@ func Run(k *kb.KB, scope string, scopeNeighbors bool) ([]Finding, error) {
 					direct = append(direct, id)
 				}
 			}
-			if len(direct) > 0 {
-				checkCuratedIndex(k, archiveName, archiveName+"/index.md", direct, &findings)
+			// A full lint or an explicit map scope also validates the map index
+			// when it has no direct concepts. A scope inside an expanded concept
+			// must not surface unrelated map-index content.
+			if len(direct) > 0 || scopeNorm == "" || scopeNorm == archiveName {
+				checkCuratedIndex(k, archiveName, archiveName+"/index.md", direct, true, &findings)
 			}
 		}
 
@@ -348,7 +352,9 @@ func Run(k *kb.KB, scope string, scopeNeighbors bool) ([]Finding, error) {
 					}
 				}
 				if len(satellites) > 0 {
-					checkCuratedIndex(k, string(expandedID), string(expandedID)+"/index.md", satellites, &findings)
+					// Expanded indexes are emitted by WalkConcepts, so their link
+					// targets are already covered by the general broken_link pass.
+					checkCuratedIndex(k, string(expandedID), string(expandedID)+"/index.md", satellites, false, &findings)
 				}
 			}
 
@@ -479,7 +485,15 @@ func emptyFrontmatterValue(value interface{}) bool {
 	case string:
 		return strings.TrimSpace(v) == ""
 	case []string:
-		return len(v) == 0
+		if len(v) == 0 {
+			return true
+		}
+		for _, item := range v {
+			if strings.TrimSpace(item) != "" {
+				return false
+			}
+		}
+		return true
 	default:
 		return false
 	}
@@ -488,7 +502,7 @@ func emptyFrontmatterValue(value interface{}) bool {
 // checkCuratedIndex verifies both directions of an opted-in curated index.
 // folder is passed to ReadIndex; indexPath is the exact physical base used by
 // ExtractLinks so relative Markdown links resolve from the right directory.
-func checkCuratedIndex(k *kb.KB, folder, indexPath string, candidates []okf.ConceptID, findings *[]Finding) {
+func checkCuratedIndex(k *kb.KB, folder, indexPath string, candidates []okf.ConceptID, validateLinks bool, findings *[]Finding) {
 	content, err := k.ReadIndex(folder)
 	if err != nil {
 		*findings = append(*findings, Finding{
@@ -503,15 +517,18 @@ func checkCuratedIndex(k *kb.KB, folder, indexPath string, candidates []okf.Conc
 	targets := map[okf.ConceptID]bool{}
 	for _, target := range kb.ExtractLinks(body, indexPath) {
 		targets[target] = true
-		if _, readErr := k.ReadConcept(target); errors.Is(readErr, okf.ErrNotFound) {
-			*findings = append(*findings, Finding{
-				Path:     indexPath,
-				Check:    "broken_link",
-				Severity: SevWarning,
-				Message:  fmt.Sprintf("broken link to %s", okf.IDToPath(target)),
-			})
+		if validateLinks {
+			if _, readErr := k.ReadConcept(target); errors.Is(readErr, okf.ErrNotFound) {
+				*findings = append(*findings, Finding{
+					Path:     indexPath,
+					Check:    "broken_link",
+					Severity: SevWarning,
+					Message:  fmt.Sprintf("broken link to %s", okf.IDToPath(target)),
+				})
+			}
 		}
 	}
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i] < candidates[j] })
 	for _, candidate := range candidates {
 		if !targets[candidate] {
 			*findings = append(*findings, Finding{

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -384,6 +384,91 @@ func TestRun_AssetsOnlyProduceOrphanAsset(t *testing.T) {
 	}
 }
 
+// --- declarative lint contracts (D107) ---
+
+func TestRun_MissingRequiredFieldContract(t *testing.T) {
+	k := tempKB(t)
+	writeFile(t, k.DataRoot(), "ops/_map.md", "---\ntype: Map\nrequired_fields: [timestamp, provenance]\nrequired_fields.Runbook: [owner]\n---\n")
+	writeFile(t, k.DataRoot(), "ops/a.md", "---\ntype: Runbook\ntimestamp: 2026-01-01\nprovenance:\nowner: Alice\n---\n")
+	writeFile(t, k.DataRoot(), "ops/b.md", "---\ntype: Note\ntimestamp: 2026-01-01\n---\n")
+	findings, err := Run(k, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var missing []Finding
+	for _, f := range findings {
+		if f.Check == "missing_required_field" {
+			missing = append(missing, f)
+		}
+	}
+	if len(missing) != 2 || missing[0].Severity != SevError {
+		t.Fatalf("required-field findings = %#v", missing)
+	}
+}
+
+func TestRun_ContractMalformedAndServicesSkipped(t *testing.T) {
+	k := tempKB(t)
+	writeFile(t, k.DataRoot(), "ops/_map.md", "---\ntype: Map\nrequired_fields: [timestamp, timestamp, ]\nrequire_index_entry: maybe\n---\n")
+	writeFile(t, k.Root, "services/demo.md", "---\ntype: Service\n---\n")
+	findings, err := Run(k, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	malformed := 0
+	for _, f := range findings {
+		if f.Check == "contract_malformed" {
+			malformed++
+		}
+		if f.Check == "missing_required_field" && strings.HasPrefix(f.Path, "services/") {
+			t.Fatalf("service matched a map contract: %#v", f)
+		}
+	}
+	if malformed != 2 {
+		t.Fatalf("contract_malformed = %d, findings=%#v", malformed, findings)
+	}
+}
+
+func TestRun_IndexContract_MapAndExpanded(t *testing.T) {
+	k := tempKB(t)
+	writeFile(t, k.DataRoot(), "ops/_map.md", "---\ntype: Map\nrequire_index_entry: true\n---\n")
+	writeFile(t, k.DataRoot(), "ops/index.md", "---\ntype: Index\n---\n[alpha](alpha.md)\n[[ops/owner]]\n[missing](missing.md)\n")
+	writeFile(t, k.DataRoot(), "ops/alpha.md", "---\ntype: Note\n---\n")
+	writeFile(t, k.DataRoot(), "ops/owner/index.md", "---\ntype: Note\n---\n")
+	writeFile(t, k.DataRoot(), "ops/owner/child.md", "---\ntype: Note\n---\n")
+	findings, err := Run(k, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasCheck(findings, "ops/index.md", "broken_link") || !hasCheck(findings, "ops/owner/index.md", "index_incomplete") {
+		t.Fatalf("index contract findings = %#v", findings)
+	}
+	if hasCheck(findings, "ops/index.md", "index_incomplete") {
+		t.Fatalf("map index should include alpha and expanded owner: %#v", findings)
+	}
+}
+
+func TestRun_IndexContract_ScopedOnlyOwnMembership(t *testing.T) {
+	k := tempKB(t)
+	writeFile(t, k.DataRoot(), "ops/_map.md", "---\ntype: Map\nrequire_index_entry: true\n---\n")
+	writeFile(t, k.DataRoot(), "ops/index.md", "---\ntype: Index\n---\n[[ops/a]]\n")
+	writeFile(t, k.DataRoot(), "ops/a.md", "---\ntype: Note\n---\n")
+	writeFile(t, k.DataRoot(), "ops/b.md", "---\ntype: Note\n---\n")
+	findings, err := Run(k, "ops/a", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasCheck(findings, "ops/index.md", "index_incomplete") {
+		t.Fatalf("scoped lint reported unrelated sibling: %#v", findings)
+	}
+	findings, err = Run(k, "ops/b", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasCheck(findings, "ops/index.md", "index_incomplete") {
+		t.Fatalf("scoped lint missed own membership: %#v", findings)
+	}
+}
+
 // --- expanded_ambiguous (D77 WP4) ---
 
 func TestRun_ExpandedAmbiguous_Detected(t *testing.T) {

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -47,6 +47,16 @@ func hasCheck(findings []Finding, path, check string) bool {
 	return false
 }
 
+func countCheck(findings []Finding, path, check string) int {
+	count := 0
+	for _, f := range findings {
+		if f.Path == path && f.Check == check {
+			count++
+		}
+	}
+	return count
+}
+
 // --- broken_link ---
 
 func TestRun_BrokenLink_Detected(t *testing.T) {
@@ -389,7 +399,7 @@ func TestRun_AssetsOnlyProduceOrphanAsset(t *testing.T) {
 func TestRun_MissingRequiredFieldContract(t *testing.T) {
 	k := tempKB(t)
 	writeFile(t, k.DataRoot(), "ops/_map.md", "---\ntype: Map\nrequired_fields: [timestamp, provenance]\nrequired_fields.Runbook: [owner]\n---\n")
-	writeFile(t, k.DataRoot(), "ops/a.md", "---\ntype: Runbook\ntimestamp: 2026-01-01\nprovenance:\nowner: Alice\n---\n")
+	writeFile(t, k.DataRoot(), "ops/a.md", "---\ntype: Runbook\ntimestamp: 2026-01-01\nprovenance: [, ]\nowner: Alice\n---\n")
 	writeFile(t, k.DataRoot(), "ops/b.md", "---\ntype: Note\ntimestamp: 2026-01-01\n---\n")
 	findings, err := Run(k, "", false)
 	if err != nil {
@@ -403,6 +413,19 @@ func TestRun_MissingRequiredFieldContract(t *testing.T) {
 	}
 	if len(missing) != 2 || missing[0].Severity != SevError {
 		t.Fatalf("required-field findings = %#v", missing)
+	}
+}
+
+func TestRun_MissingRequiredFieldsWithoutFrontmatter(t *testing.T) {
+	k := tempKB(t)
+	writeFile(t, k.DataRoot(), "ops/_map.md", "---\ntype: Map\nrequired_fields: [timestamp, provenance]\n---\n")
+	writeFile(t, k.DataRoot(), "ops/no-frontmatter.md", "plain body\n")
+	findings, err := Run(k, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if countCheck(findings, "ops/no-frontmatter.md", "missing_required_field") != 2 {
+		t.Fatalf("no-frontmatter findings = %#v", findings)
 	}
 }
 
@@ -425,6 +448,18 @@ func TestRun_ContractMalformedAndServicesSkipped(t *testing.T) {
 	}
 	if malformed != 2 {
 		t.Fatalf("contract_malformed = %d, findings=%#v", malformed, findings)
+	}
+}
+
+func TestRun_EmptyPerTypeContractSuffixMalformedOnce(t *testing.T) {
+	k := tempKB(t)
+	writeFile(t, k.DataRoot(), "ops/_map.md", "---\ntype: Map\nrequired_fields.: [owner]\n---\n")
+	findings, err := Run(k, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if countCheck(findings, "ops/_map.md", "contract_malformed") != 1 {
+		t.Fatalf("empty type suffix findings = %#v", findings)
 	}
 }
 
@@ -466,6 +501,73 @@ func TestRun_IndexContract_ScopedOnlyOwnMembership(t *testing.T) {
 	}
 	if !hasCheck(findings, "ops/index.md", "index_incomplete") {
 		t.Fatalf("scoped lint missed own membership: %#v", findings)
+	}
+}
+
+func TestRun_IndexContract_EmptyMapStillValidatesMapIndex(t *testing.T) {
+	for _, tc := range []struct {
+		name, index string
+		check       string
+	}{
+		{"dangling", "---\ntype: Index\n---\n[[ops/missing]]\n", "broken_link"},
+		{"missing", "", "index_incomplete"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			k := tempKB(t)
+			writeFile(t, k.DataRoot(), "ops/_map.md", "---\ntype: Map\nrequire_index_entry: true\n---\n")
+			if tc.index != "" {
+				writeFile(t, k.DataRoot(), "ops/index.md", tc.index)
+			}
+			findings, err := Run(k, "", false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if countCheck(findings, "ops/index.md", tc.check) != 1 {
+				t.Fatalf("empty map findings = %#v", findings)
+			}
+			findings, err = Run(k, "ops", false)
+			if err != nil || countCheck(findings, "ops/index.md", tc.check) != 1 {
+				t.Fatalf("explicit map scope findings = %#v, %v", findings, err)
+			}
+		})
+	}
+}
+
+func TestRun_IndexContract_ExpandedIndexBrokenLinkOnceAndScopedMapIsolation(t *testing.T) {
+	k := tempKB(t)
+	writeFile(t, k.DataRoot(), "ops/_map.md", "---\ntype: Map\nrequire_index_entry: true\n---\n")
+	writeFile(t, k.DataRoot(), "ops/index.md", "---\ntype: Index\n---\n[[ops/missing-map-target]]\n")
+	writeFile(t, k.DataRoot(), "ops/owner/index.md", "---\ntype: Note\n---\n[[ops/missing-owner-target]]\n[[ops/owner/child]]\n")
+	writeFile(t, k.DataRoot(), "ops/owner/child.md", "---\ntype: Note\n---\n")
+	findings, err := Run(k, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if countCheck(findings, "ops/owner.md", "broken_link") != 1 {
+		t.Fatalf("expanded-index broken links = %#v", findings)
+	}
+	findings, err = Run(k, "ops/owner/child", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasCheck(findings, "ops/index.md", "broken_link") || hasCheck(findings, "ops/index.md", "index_incomplete") {
+		t.Fatalf("expanded scope leaked map-index findings: %#v", findings)
+	}
+}
+
+func TestRun_IndexContractFalseDoesNothingAndMissingIndexIsOneFinding(t *testing.T) {
+	k := tempKB(t)
+	writeFile(t, k.DataRoot(), "off/_map.md", "---\ntype: Map\nrequire_index_entry: false\n---\n")
+	writeFile(t, k.DataRoot(), "off/a.md", "---\ntype: Note\n---\n")
+	writeFile(t, k.DataRoot(), "on/_map.md", "---\ntype: Map\nrequire_index_entry: true\n---\n")
+	writeFile(t, k.DataRoot(), "on/a.md", "---\ntype: Note\n---\n")
+	writeFile(t, k.DataRoot(), "on/b.md", "---\ntype: Note\n---\n")
+	findings, err := Run(k, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasCheck(findings, "off/index.md", "index_incomplete") || countCheck(findings, "on/index.md", "index_incomplete") != 1 {
+		t.Fatalf("index contract enablement findings = %#v", findings)
 	}
 }
 

--- a/internal/mcpserver/docs_test.go
+++ b/internal/mcpserver/docs_test.go
@@ -40,6 +40,7 @@ var docsNonTools = map[string]bool{
 	"expanded_missing_index": true, "legacy_archive_descriptor": true,
 	"imported_draft": true, "broken_link": true, "stale_claim": true,
 	"orphan_asset": true,
+	"index_incomplete": true,
 	// frontmatter fields and schema keys
 	"concept_id": true, "concept_types": true, "archive_type": true,
 	"contradiction_kind": true, "service_ref": true, "secret_refs": true,

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -781,6 +781,24 @@ func TestServer_MapCreate_Journal(t *testing.T) {
 	}
 }
 
+func TestServer_MapCreate_Contract(t *testing.T) {
+	k := setupTestKB(t)
+	s := New("test")
+	RegisterKBTools(s, k, Deps{})
+	resps := runMCPSequence(t, s, []string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"map_create","arguments":{"name":"contract-map","title":"Contract","required_fields":["timestamp","timestamp"],"required_fields_by_type":{"Runbook":["provenance"]},"require_index_entry":true}}}`,
+	})
+	tr := decodeToolResult(t, resps[1])
+	if tr.IsError {
+		t.Fatalf("map_create: %v", tr.Content)
+	}
+	content, err := k.ReadRaw("contract-map/_map.md")
+	if err != nil || !strings.Contains(content, "required_fields: [timestamp]") || !strings.Contains(content, "required_fields.Runbook: [provenance]") || !strings.Contains(content, "require_index_entry: true") {
+		t.Fatalf("contract descriptor = %q, %v", content, err)
+	}
+}
+
 // TestServer_MapDelete_NonEmpty verifies that map_delete refuses to remove a
 // map that still holds concepts, and the error lists them (D88 WP2).
 func TestServer_MapDelete_NonEmpty(t *testing.T) {
@@ -1471,6 +1489,21 @@ func TestServer_GateCheck_Blocked(t *testing.T) {
 	}
 	if !strings.Contains(tr.Content[0].Text, "factual") {
 		t.Errorf("gate_check: expected factual blocker: %s", tr.Content[0].Text)
+	}
+}
+
+func TestServer_GateCheck_BlockedByRequiredField(t *testing.T) {
+	k := setupTestKB(t)
+	os.WriteFile(filepath.Join(k.DataRoot(), "manutenzione", "_map.md"), []byte("---\ntype: Map\nrequired_fields: [provenance]\n---\n"), 0o644)
+	s := New("test")
+	RegisterKBTools(s, k, Deps{})
+	resps := runMCPSequence(t, s, []string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"gate_check","arguments":{"changed_ids":["manutenzione/test-runbook"]}}}`,
+	})
+	tr := decodeToolResult(t, resps[1])
+	if tr.IsError || !strings.Contains(tr.Content[0].Text, `"pass": false`) || !strings.Contains(tr.Content[0].Text, "missing_required_field") {
+		t.Fatalf("gate_check contract result: %#v", tr)
 	}
 }
 

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -799,6 +799,22 @@ func TestServer_MapCreate_Contract(t *testing.T) {
 	}
 }
 
+func TestServer_MapCreate_RejectsEmptyContractNames(t *testing.T) {
+	k := setupTestKB(t)
+	s := New("test")
+	RegisterKBTools(s, k, Deps{})
+	resps := runMCPSequence(t, s, []string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"map_create","arguments":{"name":"bad-field","title":"Bad","required_fields":[" "]}}}`,
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"map_create","arguments":{"name":"bad-type","title":"Bad","required_fields_by_type":{" ":["owner"]}}}}`,
+	})
+	for _, response := range resps[1:] {
+		if result := decodeToolResult(t, response); !result.IsError {
+			t.Fatalf("map_create accepted an empty contract name: %#v", result)
+		}
+	}
+}
+
 // TestServer_MapDelete_NonEmpty verifies that map_delete refuses to remove a
 // map that still holds concepts, and the error lists them (D88 WP2).
 func TestServer_MapDelete_NonEmpty(t *testing.T) {

--- a/internal/mcpserver/tools_write.go
+++ b/internal/mcpserver/tools_write.go
@@ -365,16 +365,33 @@ func toolMapCreate(k *kb.KB) Tool {
 				"ontology_mode": {
 					"type": "string",
 					"description": "strict or flexible (default: flexible)"
+				},
+				"required_fields": {
+					"type": "array",
+					"items": {"type": "string"},
+					"description": "Frontmatter fields required for every concept in this map"
+				},
+				"required_fields_by_type": {
+					"type": "object",
+					"additionalProperties": {"type": "array", "items": {"type": "string"}},
+					"description": "Additional required fields keyed by exact concept type"
+				},
+				"require_index_entry": {
+					"type": "boolean",
+					"description": "Require each concept to be linked from its curated index"
 				}
 			}
 		}`),
 		Handler: func(args json.RawMessage) (ToolResult, error) {
 			var params struct {
-				Name         string   `json:"name"`
-				Title        string   `json:"title"`
-				Kind         string   `json:"kind"`
-				ConceptTypes []string `json:"concept_types"`
-				OntologyMode string   `json:"ontology_mode"`
+				Name                 string              `json:"name"`
+				Title                string              `json:"title"`
+				Kind                 string              `json:"kind"`
+				ConceptTypes         []string            `json:"concept_types"`
+				OntologyMode         string              `json:"ontology_mode"`
+				RequiredFields       []string            `json:"required_fields"`
+				RequiredFieldsByType map[string][]string `json:"required_fields_by_type"`
+				RequireIndexEntry    bool                `json:"require_index_entry"`
 			}
 			if err := json.Unmarshal(args, &params); err != nil {
 				return errorResult("invalid params: " + err.Error()), nil
@@ -385,8 +402,28 @@ func toolMapCreate(k *kb.KB) Tool {
 			if params.Title == "" {
 				return errorResult("'title' is required"), nil
 			}
+			for _, field := range params.RequiredFields {
+				if strings.TrimSpace(field) == "" {
+					return errorResult("'required_fields' must not contain empty field names"), nil
+				}
+			}
+			for typ, fields := range params.RequiredFieldsByType {
+				if strings.TrimSpace(typ) == "" {
+					return errorResult("'required_fields_by_type' must not contain an empty type name"), nil
+				}
+				for _, field := range fields {
+					if strings.TrimSpace(field) == "" {
+						return errorResult("'required_fields_by_type' must not contain empty field names"), nil
+					}
+				}
+			}
 
-			if err := k.CreateMap(params.Name, params.Title, params.Kind, params.ConceptTypes, params.OntologyMode); err != nil {
+			contract := kb.MapContract{
+				RequiredFields:       params.RequiredFields,
+				RequiredFieldsByType: params.RequiredFieldsByType,
+				RequireIndexEntry:    params.RequireIndexEntry,
+			}
+			if err := k.CreateMapWithContract(params.Name, params.Title, params.Kind, params.ConceptTypes, params.OntologyMode, contract); err != nil {
 				return errorResult(fmt.Sprintf("map_create %q: %v", params.Name, err)), nil
 			}
 


### PR DESCRIPTION
## Summary

- add declarative map lint contracts for required frontmatter and curated indexes
- surface contract findings through lint and gate_check
- document the descriptor contract and D107 decision

## Validation

- `make vet`
- `make test`
- `make smoke-http`
- `make e2e`

Generated with Codex

Closes #70
