### PR TITLE
fix: move local defaults off port 8080

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ make test            # go test ./...
 make vet             # go vet ./...
 make fmt             # gofmt -w .
 make run             # stdio with demo KB
-make run-http        # HTTP on :8080 with demo KB
+make run-http        # HTTP on :39273 with demo KB
 make smoke           # build + quick stdio test
 make smoke-http      # operator-level HTTP smoke test (creates temp KBs via curl)
 make e2e             # deterministic HTTP/CLI end-to-end scenarios

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ fmt: ## Format the code with gofmt
 run: build ## Start the stdio server with a demo KB
 	./bin/cartographer serve --kb ./demo-kb --init
 
-run-http: build ## Start the HTTP server on :8080 with a demo KB
-	./bin/cartographer serve --kb ./demo-kb --init --http :8080
+run-http: build ## Start the HTTP server on :39273 with a demo KB
+	./bin/cartographer serve --kb ./demo-kb --init --http :39273
 
 smoke-http: build ## HTTP flow smoke test: creates KB, archives, dossiers via MCP
 	@./test/smoke/http.sh

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ covers everyday use.
 |---|---|---|
 | `CARTOGRAPHER_KB` | — | KB path(s) (single, or multiple comma-separated) |
 | `CARTOGRAPHER_DATA` | — | Directory whose subfolders are auto-discovered KBs |
-| `CARTOGRAPHER_HTTP` | — | HTTP address (e.g. `:8080`). Absent = stdio only |
+| `CARTOGRAPHER_HTTP` | — | HTTP address (e.g. `:39273`). Absent = stdio only |
 | `CARTOGRAPHER_AUTH` | auto | `true` / `false` / unset (auto on HTTP) |
 | `CARTOGRAPHER_TOKENS` | — | Comma-separated bearer tokens |
 | `CARTOGRAPHER_GIT_AUTOCOMMIT` | `true` | One git commit per write operation |

--- a/cmd/cartographer/connect.go
+++ b/cmd/cartographer/connect.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/BeppeTemp/cartographer/internal/client"
 	"github.com/BeppeTemp/cartographer/internal/clientconfig"
+	"github.com/BeppeTemp/cartographer/internal/defaults"
 	"github.com/BeppeTemp/cartographer/internal/provisioning"
 	"github.com/BeppeTemp/cartographer/internal/service"
 )
@@ -93,13 +94,18 @@ func shouldOfferServiceInstall(loopback bool, running bool) bool {
 	return loopback && !running
 }
 
+var installService = func(mgr *service.Manager, opts service.InstallOptions) error {
+	_, err := mgr.Install(opts)
+	return err
+}
+
 // installServiceAndWaitHealthy installs+starts the local cartographer
 // service with default options (mirroring `cartographer service install`
 // with no flags) and polls its /health endpoint until it responds or
 // timeout elapses. Returns the first error encountered (install failure, or
 // "still unhealthy after timeout").
 func installServiceAndWaitHealthy(mgr *service.Manager, timeout time.Duration) error {
-	if _, err := mgr.Install(service.InstallOptions{DataDir: defaultDataDir(), HTTPAddr: "127.0.0.1:8080"}); err != nil {
+	if err := installService(mgr, service.InstallOptions{DataDir: defaultDataDir(), HTTPAddr: defaults.DefaultListenAddress}); err != nil {
 		return fmt.Errorf("service install: %w", err)
 	}
 
@@ -182,7 +188,7 @@ type connectSettings struct {
 // (absent from passed) inherits the value already in existing rather than the
 // hard-coded flag default — so a bare `connect <agent>` on a machine already
 // pointed at a remote server never silently rewrites server_url/auth/token_env
-// to http://localhost:8080 / auth:false. existing is nil on a first-ever
+// to the local default / auth:false. existing is nil on a first-ever
 // connect, where the flag defaults (and Name "cartographer", Trust from
 // clientconfig.Default) apply as-is. The interactive form, when opened,
 // overrides ServerURL/Auth/TokenEnv/Trust afterwards with the user's input.
@@ -231,7 +237,7 @@ func cmdConnect(args []string) int {
 	target, rest := splitPositional(args, "")
 
 	fs := flag.NewFlagSet("connect", flag.ExitOnError)
-	serverURL := fs.String("server-url", "http://localhost:8080/mcp", "Cartographer server URL")
+	serverURL := fs.String("server-url", defaults.DefaultMCPURL, "Cartographer server URL")
 	auth := fs.Bool("auth", false, "Enable bearer-token auth in generated configs")
 	tokenEnv := fs.String("token-env", "CARTOGRAPHER_TOKENS", "Env var holding the bearer token")
 	dryRun := fs.Bool("dry-run", false, "Print what would be written without writing")

--- a/cmd/cartographer/connect_test.go
+++ b/cmd/cartographer/connect_test.go
@@ -9,14 +9,17 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/BeppeTemp/cartographer/internal/client"
 	"github.com/BeppeTemp/cartographer/internal/clientconfig"
+	"github.com/BeppeTemp/cartographer/internal/defaults"
+	"github.com/BeppeTemp/cartographer/internal/service"
 )
 
 // TestResolveConnectSettings_InheritsPersisted pins the fix for the footgun
 // where a bare `connect <agent>` rewrote server_url/auth/token_env of an
-// already-configured machine to the flag defaults (http://localhost:8080,
+// already-configured machine to the flag defaults,
 // auth:false). Flags not passed explicitly must inherit the persisted config.
 func TestResolveConnectSettings_InheritsPersisted(t *testing.T) {
 	existing := &clientconfig.Config{
@@ -28,7 +31,7 @@ func TestResolveConnectSettings_InheritsPersisted(t *testing.T) {
 	}
 
 	// No form flag passed → inherit everything from existing, ignoring defaults.
-	got := resolveConnectSettings(map[string]bool{}, "http://localhost:8080/mcp", false, "DEFAULT_ENV", existing)
+	got := resolveConnectSettings(map[string]bool{}, defaults.DefaultMCPURL, false, "DEFAULT_ENV", existing)
 	if got.ServerURL != existing.ServerURL {
 		t.Errorf("ServerURL = %q, want inherited %q", got.ServerURL, existing.ServerURL)
 	}
@@ -46,8 +49,8 @@ func TestResolveConnectSettings_InheritsPersisted(t *testing.T) {
 	}
 
 	// First-ever connect (existing nil) → flag defaults apply as-is.
-	got = resolveConnectSettings(map[string]bool{}, "http://localhost:8080/mcp", false, "DEFAULT_ENV", nil)
-	if got.ServerURL != "http://localhost:8080/mcp" || got.Auth || got.TokenEnv != "DEFAULT_ENV" {
+	got = resolveConnectSettings(map[string]bool{}, defaults.DefaultMCPURL, false, "DEFAULT_ENV", nil)
+	if got.ServerURL != defaults.DefaultMCPURL || got.Auth || got.TokenEnv != "DEFAULT_ENV" {
 		t.Errorf("first connect: got %+v, want flag defaults", got)
 	}
 	if got.Name != "cartographer" {
@@ -69,7 +72,7 @@ func withTTY(t *testing.T, tty bool) {
 func newParsedConnectFlagSet(t *testing.T, args ...string) (*flag.FlagSet, bool) {
 	t.Helper()
 	fs := flag.NewFlagSet("connect", flag.ContinueOnError)
-	fs.String("server-url", "http://localhost:8080/mcp", "")
+	fs.String("server-url", defaults.DefaultMCPURL, "")
 	fs.Bool("auth", false, "")
 	fs.String("token-env", "CARTOGRAPHER_TOKENS", "")
 	fs.Bool("dry-run", false, "")
@@ -236,9 +239,9 @@ func TestProbeErrorMessage_NoKBGuidance(t *testing.T) {
 
 func TestIsLoopbackURL(t *testing.T) {
 	cases := map[string]bool{
-		"http://localhost:8080/mcp":    true,
-		"http://127.0.0.1:8080/mcp":    true,
-		"http://[::1]:8080/mcp":        true,
+		"http://localhost:39273/mcp":   true,
+		"http://127.0.0.1:39273/mcp":   true,
+		"http://[::1]:39273/mcp":       true,
 		"https://wiki.example.com/mcp": false,
 		"not a url \x7f":               false,
 		"":                             false,
@@ -263,5 +266,24 @@ func TestShouldOfferServiceInstall(t *testing.T) {
 		if got := shouldOfferServiceInstall(tc.loopback, tc.running); got != tc.want {
 			t.Errorf("shouldOfferServiceInstall(%v, %v) = %v, want %v", tc.loopback, tc.running, got, tc.want)
 		}
+	}
+}
+
+func TestInstallServiceAndWaitHealthy_UsesDefaultListenAddress(t *testing.T) {
+	previous := installService
+	var got service.InstallOptions
+	stop := errors.New("stop after recording options")
+	installService = func(_ *service.Manager, opts service.InstallOptions) error {
+		got = opts
+		return stop
+	}
+	t.Cleanup(func() { installService = previous })
+
+	err := installServiceAndWaitHealthy(nil, time.Second)
+	if !errors.Is(err, stop) {
+		t.Fatalf("installServiceAndWaitHealthy error = %v, want %v", err, stop)
+	}
+	if got.HTTPAddr != defaults.DefaultListenAddress {
+		t.Errorf("automatic service HTTPAddr = %q, want %q", got.HTTPAddr, defaults.DefaultListenAddress)
 	}
 }

--- a/cmd/cartographer/connectform.go
+++ b/cmd/cartographer/connectform.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/BeppeTemp/cartographer/internal/defaults"
 )
 
 // connectField identifies the focused field of the connect form.
@@ -115,7 +117,7 @@ type connectFormModel struct {
 // own tea.Program (see the standalone field doc).
 func newConnectFormModel(title string, prefill connectOptions, standalone bool) connectFormModel {
 	url := textinput.New()
-	url.Placeholder = "http://localhost:8080/mcp"
+	url.Placeholder = defaults.DefaultMCPURL
 	url.SetValue(prefill.ServerURL)
 
 	tokenEnv := textinput.New()
@@ -197,7 +199,7 @@ func (m connectFormModel) Cancelled() bool { return m.cancelled }
 func (m connectFormModel) Values() connectOptions {
 	url := m.url.Value()
 	if url == "" {
-		url = "http://localhost:8080/mcp"
+		url = defaults.DefaultMCPURL
 	}
 	name := m.serverName
 	if name == "" {

--- a/cmd/cartographer/connectform_test.go
+++ b/cmd/cartographer/connectform_test.go
@@ -145,7 +145,7 @@ func TestConnectFormModel_ValuesDefaultsBlankFields(t *testing.T) {
 	m := newConnectFormModel("Connect claude", connectOptions{}, false)
 
 	got := m.Values()
-	want := connectOptions{ServerURL: "http://localhost:8080/mcp", Name: "cartographer", TokenEnv: "CARTOGRAPHER_TOKENS"}
+	want := connectOptions{ServerURL: "http://localhost:39273/mcp", Name: "cartographer", TokenEnv: "CARTOGRAPHER_TOKENS"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Values() = %+v, want %+v", got, want)
 	}

--- a/cmd/cartographer/disconnect.go
+++ b/cmd/cartographer/disconnect.go
@@ -162,7 +162,7 @@ func doDisconnect(opts disconnectOptions) (disconnectResult, error) {
 	// cfg (server_url/server_name/auth/token_env/trust/kbs) is preserved even
 	// when Agents ends up empty (D64): it seeds the next `connect` — server_url
 	// in particular, so a disconnect-then-reconnect doesn't fall back to
-	// http://localhost:8080/mcp when the user was pointed at a real server. Only
+	// the local default when the user was pointed at a real server. Only
 	// the agents list is zeroed; the file itself is never deleted.
 	cfg.Agents = removeStrings(cfg.Agents, opts.Providers)
 	if err := clientconfig.Save(opts.Dir, cfg); err != nil {

--- a/cmd/cartographer/disconnect_test.go
+++ b/cmd/cartographer/disconnect_test.go
@@ -24,7 +24,8 @@ var testSkillDir = map[string]string{
 // `cartographer connect` would have left behind for each provider: the MCP
 // config file (via configurator.Emit/Apply), a v2 lockfile with one managed
 // skill file per provider, the skill file itself on disk, and
-// .cartographer.yaml listing every provider as connected.
+// .cartographer.yaml listing every provider as connected. Its explicit 8080
+// endpoint represents a configuration created before D112 and must survive.
 func setupDisconnectFixture(t *testing.T, providers ...string) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/cmd/cartographer/kbcmd.go
+++ b/cmd/cartographer/kbcmd.go
@@ -260,7 +260,7 @@ func fetchHealth(baseURL string) (*healthInfo, error) {
 // If that config doesn't exist or has no http: set (stdio-only, or not
 // installed as a service yet), fall back to deriving it the way the client
 // does: .cartographer.yaml server_url, defaulting to
-// http://localhost:8080/mcp (clientconfig.Default), with the /mcp path
+// the local client default (clientconfig.Default), with the /mcp path
 // stripped.
 func serverBaseURL() string {
 	if cfgPath, err := service.ConfigPath(); err == nil {
@@ -280,8 +280,8 @@ func serverBaseURL() string {
 	return strings.TrimSuffix(serverURL, "/mcp")
 }
 
-// httpAddrToBaseURL turns a server http listen address (e.g. ":8080" or
-// "127.0.0.1:8080") into a base URL ("http://127.0.0.1:8080"), normalizing a
+// httpAddrToBaseURL turns a server http listen address (e.g. ":39273" or
+// "127.0.0.1:39273") into a base URL ("http://127.0.0.1:39273"), normalizing a
 // bare port to loopback the same way internal/service's healthURL does.
 // Returns "" if addr does not parse as host:port.
 func httpAddrToBaseURL(addr string) string {

--- a/cmd/cartographer/resolve_test.go
+++ b/cmd/cartographer/resolve_test.go
@@ -13,7 +13,7 @@ import (
 // resolves the config dir via clientconfig.TargetDir() (os.UserHomeDir()).
 func writeClientConfig(t *testing.T, home, extra string) {
 	t.Helper()
-	content := "server_url: http://localhost:8080/mcp\nserver_name: cartographer\n" + extra
+	content := "server_url: https://existing.example.test/mcp\nserver_name: cartographer\n" + extra
 	if err := os.WriteFile(filepath.Join(home, ".cartographer.yaml"), []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/cartographer/serve.go
+++ b/cmd/cartographer/serve.go
@@ -42,7 +42,7 @@ func cmdServe(args []string) int {
 	kbFlag := fs.String("kb", "", "Path(s) to KB(s), comma-separated (or CARTOGRAPHER_KB)")
 	dataFlag := fs.String("data", "", "Directory whose direct subdirs are each a separate KB (or CARTOGRAPHER_DATA)")
 	initFlag := fs.Bool("init", false, "Initialize KB(s) if they do not exist")
-	httpFlag := fs.String("http", "", "HTTP listen address, e.g. :8080 (or CARTOGRAPHER_HTTP)")
+	httpFlag := fs.String("http", "", "HTTP listen address, e.g. :39273 (or CARTOGRAPHER_HTTP)")
 	tokensFlag := fs.String("tokens", "", "Comma-separated bearer tokens (or CARTOGRAPHER_TOKENS)")
 	ollamaFlag := fs.String("ollama", "", "Ollama base URL for semantic search, e.g. http://localhost:11434 (or CARTOGRAPHER_OLLAMA)")
 	gitAutoCommitFlag := fs.Bool("git-autocommit", true, "Create a git commit after each successful write operation (default true; or CARTOGRAPHER_GIT_AUTOCOMMIT=false to disable)")

--- a/cmd/cartographer/service.go
+++ b/cmd/cartographer/service.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/BeppeTemp/cartographer/internal/config"
+	"github.com/BeppeTemp/cartographer/internal/defaults"
 	"github.com/BeppeTemp/cartographer/internal/service"
 )
 
@@ -49,7 +50,7 @@ func cmdServiceInstall(args []string) int {
 	defaultConfig, _ := service.ConfigPath()
 	configFlag := fs.String("config", defaultConfig, "Path to the generated server config YAML")
 	dataFlag := fs.String("data", defaultDataDir(), "KB data directory (only used when generating a new config)")
-	httpFlag := fs.String("http", "127.0.0.1:8080", "HTTP listen address (only used when generating a new config)")
+	httpFlag := fs.String("http", defaults.DefaultListenAddress, "HTTP listen address (only used when generating a new config)")
 	fs.Parse(args)
 
 	passed := map[string]bool{}

--- a/cmd/cartographer/status_test.go
+++ b/cmd/cartographer/status_test.go
@@ -38,7 +38,7 @@ func TestCmdStatus_VersionReport(t *testing.T) {
 		},
 		{
 			name:             "loopback installed service",
-			serverURL:        "http://127.0.0.1:8080/mcp",
+			serverURL:        "http://127.0.0.1:39273/mcp",
 			clientVersion:    "v1.2.3",
 			serverVersion:    "v1.2.2",
 			serviceInstalled: true,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,7 +3,7 @@
 # variables, then to the built-in defaults. See internal/config for the
 # full precedence rules (flag > env > YAML > default).
 
-http: ":8080"
+http: ":39273"
 init: true
 auth:
   mode: "on"            # on | off | auto (default auto: on if tokens are present)

--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -49,7 +49,7 @@ cartographer service install
 ```
 
 Expected output: the native user service is installed and started. It listens on
-`http://127.0.0.1:8080` and its data directory is ready for KBs.
+`http://127.0.0.1:39273` and its data directory is ready for KBs.
 
 ## 3. Mount the first KB
 
@@ -92,7 +92,7 @@ With two or more mounted KBs, Cartographer automatically creates one MCP entry p
 
 ```bash
 cartographer version
-curl -fsS http://127.0.0.1:8080/health
+curl -fsS http://127.0.0.1:39273/health
 cartographer status
 ```
 
@@ -108,6 +108,6 @@ operations, diagnosis, upgrades, and synchronization after installation.
 | Observed symptom | Next action |
 |---|---|
 | `command -v brew` has no output | Run the `install.sh` command in step 1. |
-| The service reports that port 8080 is busy | Stop or reconfigure the process using the port, then rerun `cartographer service install`. |
+| The service reports that port 39273 is busy | Stop or reconfigure the process using the port, then rerun `cartographer service install`. |
 | `kb clone` reports a git authentication failure | Configure ambient credentials (an SSH agent for SSH remotes or a git credential helper for HTTPS), then rerun the same `kb clone` command. |
 | `kb clone` says `not an OKF KB` | Use the `kb-import` skill to import the remote into an OKF KB, push it, then rerun `kb clone`. |

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -67,7 +67,7 @@ cartographer connect all --auto-trust --dry-run
 |------|---------|-------------|
 | (positional) | `all` | `claude` \| `opencode` \| `codex` \| `kiro` \| `all` (all detected agents) |
 | `--agents` | *(unset)* | Comma-separated subset (`claude,codex`); cannot be combined with the positional provider |
-| `--server-url` | `http://localhost:8080/mcp` | Cartographer server URL |
+| `--server-url` | `http://localhost:39273/mcp` | Cartographer server URL |
 | `--auth` | `false` | Enables the Bearer header in generated configs |
 | `--token-env` | `CARTOGRAPHER_TOKENS` | Env var holding the Bearer token |
 | `--dry-run` | `false` | Prints without writing |
@@ -82,7 +82,7 @@ TUI opens (`connectform.go`): each field shows a contextual hint below it when f
 itself is never written to disk; with Auth off the field is rendered secondary and the hint says it is
 ignored). In the standalone `connect` form, the four provider checkboxes are pre-selected from the
 installed-agent set; select one or more with Space or Enter. The Server URL prefill follows the precedence existing `.cartographer.yaml` >
-`CARTOGRAPHER_SERVER_URL` (client env) > `http://localhost:8080/mcp`. On submit a **probe** runs
+`CARTOGRAPHER_SERVER_URL` (client env) > `http://localhost:39273/mcp`. On submit a **probe** runs
 (`client.Health`, `GET /health`, 5s timeout, token from env only if Auth is enabled) before writing
 any file: a reachable server with no mounted KB explains the `kb create` then service-restart path;
 otherwise on failure the form is re-shown with the entered values and an inline error
@@ -113,7 +113,7 @@ managed files, never untracked ones), then removes the provider from the lockfil
 `.cartographer.yaml`. If the lockfile ends up with no providers it is removed; `.cartographer.yaml`,
 on the other hand, is **never deleted** (D64): with zero agents it stays on disk with `agents: []`,
 preserving `server_url`/`server_name`/`auth`/`token_env`/`trust`/`kbs` as defaults for the next
-`connect` (a disconnect→connect restarts from the previous server, not from `http://localhost:8080/mcp`).
+`connect` (a disconnect→connect restarts from the previous server, not from `http://localhost:39273/mcp`).
 
 ```bash
 cartographer disconnect                # every connected provider
@@ -258,7 +258,7 @@ stderr with the full form to use), `2` usage error (missing argument or not in t
 {
   "mcpServers": {
     "cartographer": {
-      "url": "http://localhost:8080/mcp",
+      "url": "http://localhost:39273/mcp",
       "type": "http",
       "headers": { "Authorization": "Bearer ${CARTOGRAPHER_TOKENS}" }
     }
@@ -271,7 +271,7 @@ only the text between the markers is touched, via `internal/blocktext`):
 ```toml
 # cartographer:mcp:begin
 [mcp_servers.cartographer]
-url = "http://localhost:8080/mcp"
+url = "http://localhost:39273/mcp"
 bearer_token_env_var = "CARTOGRAPHER_TOKENS"
 # cartographer:mcp:end
 ```
@@ -289,7 +289,7 @@ unrelated tables, Codex's own `[hooks.state."…"]` bookkeeping — is left as i
 {
   "mcpServers": {
     "cartographer": {
-      "url": "http://localhost:8080/mcp",
+      "url": "http://localhost:39273/mcp",
       "type": "http",
       "autoApprove": []
     }
@@ -304,7 +304,7 @@ unrelated tables, Codex's own `[hooks.state."…"]` bookkeeping — is left as i
   "mcp": {
     "cartographer": {
       "type": "remote",
-      "url": "http://localhost:8080/mcp",
+      "url": "http://localhost:39273/mcp",
       "enabled": true
     }
   }
@@ -318,7 +318,7 @@ unrelated tables, Codex's own `[hooks.state."…"]` bookkeeping — is left as i
   "mcp": {
     "cartographer": {
       "type": "remote",
-      "url": "http://localhost:8080/mcp",
+      "url": "http://localhost:39273/mcp",
       "enabled": true,
       "headers": { "Authorization": "Bearer {env:CARTOGRAPHER_TOKENS}" }
     }
@@ -346,7 +346,7 @@ providers are connected. One file per machine, not per project: this avoids drif
 connected in one repo but not another.
 
 ```yaml
-server_url: http://localhost:8080/mcp
+server_url: http://localhost:39273/mcp
 server_name: cartographer  # name under which the server is registered in the MCP configs (no longer a flag: always "cartographer", override only by editing this file)
 auth: false
 token_env: CARTOGRAPHER_TOKENS

--- a/docs/decisions/deployment-release.md
+++ b/docs/decisions/deployment-release.md
@@ -270,3 +270,27 @@ provider connection, and verification; README exposes it as a copy-paste prompt 
 invariants that make a directory mountable by the service. Keeping the bootstrap runbook separate
 from the human tutorial gives an agent a raw-URL-safe, imperative procedure before Cartographer or
 its provisioned `cartographer-ops` skill exists locally.
+
+---
+
+<a id="d112"></a>
+## D112 — Reserved local endpoint defaults
+
+**Status: implemented (2026-07-28).**
+
+**Decision.** New local service configurations listen on `127.0.0.1:39273`,
+and a new client uses `http://localhost:39273/mcp`. The dependency-light
+`internal/defaults` package owns the port, listen address, and MCP URL so the
+native-service and client first-run paths cannot drift. `cartographer serve`
+without an explicit HTTP setting remains stdio.
+
+**Compatibility.** Existing server YAML and `.cartographer.yaml` values,
+including an explicit port 8080, remain authoritative and are never rewritten.
+The normal precedence rules continue to apply: server flag > environment >
+YAML > default; client existing YAML > `CARTOGRAPHER_SERVER_URL` > local
+default.
+
+**Rationale.** Port 8080 is frequently occupied by local development servers
+and infrastructure. Reserving one project-local default avoids that collision
+without making the endpoint a protocol requirement or migrating an operator's
+chosen configuration.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -35,7 +35,7 @@ Full annotated example: [`config.example.yaml`](https://github.com/BeppeTemp/car
 Schema (`internal/config.Config`, YAML tags in parentheses):
 
 ```yaml
-http: ":8080"                 # (http) listen address; absent = stdio
+http: ":39273"                # (http) listen address; absent = stdio
 init: true                    # (init) initialize missing KBs
 auth:
   mode: "on"                  # (auth.mode) on | off | auto (default auto: on if tokens are present)
@@ -192,7 +192,7 @@ Every startup option has a corresponding environment variable (the CLI flag take
 | `CARTOGRAPHER_KB` | `--kb` | Path(s) to the KB(s), comma-separated |
 | `CARTOGRAPHER_KB_REMOTES` | — | Git remotes to clone into `--data` at startup, comma-separated (see §Bootstrapping a KB) |
 | `CARTOGRAPHER_DATA` | `--data` | Directory whose direct subfolders are separate KBs (auto-discovery) |
-| `CARTOGRAPHER_HTTP` | `--http` | HTTP listen address, e.g. `:8080` |
+| `CARTOGRAPHER_HTTP` | `--http` | HTTP listen address, e.g. `:39273` |
 | `CARTOGRAPHER_TOKENS` | `--tokens` | Bearer tokens, comma/whitespace-separated. Each entry is either a bare `token` (admin, full access to every KB) or `token\|scope1;scope2` with per-KB scopes `kb:<name>:r\|rw` (scopes separated by `;`, never by spaces/commas, to avoid colliding with the between-entry separator). E.g. `admintok, readtok\|kb:wiki:r, writetok\|kb:wiki:rw;kb:notes:r` (D44). |
 | `CARTOGRAPHER_AUTH` | — | Explicit auth toggle (see §Auth) |
 | `CARTOGRAPHER_GIT_AUTOCOMMIT` | `--git-autocommit` | Enables the git commit after every write. Default `true`; set to `false` or `0` to disable. |
@@ -204,7 +204,7 @@ Every startup option has a corresponding environment variable (the CLI flag take
 | `CARTOGRAPHER_TOOLS_PROFILE` | `--tools-profile` | `tools/list` tool profile: `agent` (default, only the core set for the LLM agent) \| `full` (all of them). Hidden tools remain callable via `tools/call` (D65, → `control-plane.md` §MCP API). |
 | `CARTOGRAPHER_AUDIT_LOG` | — | Path to the audit log's JSONL file (e.g. `/data/audit.log`). If empty, audit is disabled. |
 | `CARTOGRAPHER_AUDIT_KEY` | — | Ed25519 seed (hex, 64 chars) for signing entries. Requires `CARTOGRAPHER_AUDIT_LOG`. |
-| `CARTOGRAPHER_SERVER_URL` | — | **Client** (not server): default server URL for `cartographer connect` on the client machine when no `.cartographer.yaml` exists yet. Precedence: existing yaml > env > `http://localhost:8080/mcp` (D64, `internal/clientconfig.Default`). |
+| `CARTOGRAPHER_SERVER_URL` | — | **Client** (not server): default server URL for `cartographer connect` on the client machine when no `.cartographer.yaml` exists yet. Precedence: existing yaml > env > `http://localhost:39273/mcp` (D64, `internal/clientconfig.Default`). |
 | `CARTOGRAPHER_MCP_TOOL_PREFIX_MODE` | — | Global default for `mcp.tool_prefix_mode`: `off` (default) \| `kb-name`. Overridden per KB by `kbs[].tool_prefix` (D102, see §MCP tool-name prefix). |
 
 **`CARTOGRAPHER_AUTH`** — three modes:
@@ -229,12 +229,12 @@ cartographer kb clone <remote>               # mounts an existing remote KB in t
 ```
 
 `service install` (idempotent: re-running it rewrites the plist/unit and restarts):
-- generates `~/.config/cartographer/server.yaml` **only if it doesn't exist** (`--config` for a different path; `--data`, default `~/cartographer-data`, and `--http`, default `127.0.0.1:8080`, are only used at generation time — if the config already exists they are ignored with a warning: edit the file and run `service restart`);
+- generates `~/.config/cartographer/server.yaml` **only if it doesn't exist** (`--config` for a different path; `--data`, default `~/cartographer-data`, and `--http`, default `127.0.0.1:39273`, are only used at generation time — if the config already exists they are ignored with a warning: edit the file and run `service restart`);
 - creates the configured data dir if it doesn't exist yet (D83), so a fresh install never leaves `serve` pointed at a missing directory;
 - macOS: LaunchAgent `~/Library/LaunchAgents/com.cartographer.serve.plist` (`KeepAlive`, logging to `~/Library/Logs/cartographer/server.log`). The plist's binary path prefers a stable Homebrew symlink (`/opt/homebrew/bin/cartographer` or `/usr/local/bin/cartographer`) over the versioned Caskroom path, so it survives `brew upgrade` without a re-install (D83);
 - Linux: systemd user unit `~/.config/systemd/user/cartographer.service` (log via `journalctl --user -u cartographer`; on a headless host, `loginctl enable-linger <user>` is needed for the service to survive logout).
 
-Binds to **loopback** by default (`127.0.0.1:8080`) → auth stays in auto-off mode without exposing anything on the network. With an empty (or missing — D83: `serve` creates it and treats it as empty rather than failing) data dir the server starts with 0 KBs — `/health` is still up (liveness: `status:"ok"`) but `/ready` reports `503 {"ready":false}` (D84, §Observability): `cartographer kb create <name>` scaffolds a subfolder KB the same way `serve --kb <path> --init` would (D85), while `cartographer kb clone <remote>` mounts an existing OKF remote there (D97; `service install` itself prints a hint pointing at creation if it starts with 0 KBs mounted), or add `kbs:` entries to clone remotes (§Bootstrapping a KB) — either way, `service restart` (or `kb create --restart` / `kb clone --restart`, which do this for you and wait for the server to report healthy again) is what makes the new KB visible.
+Binds to **loopback** by default (`127.0.0.1:39273`) → auth stays in auto-off mode without exposing anything on the network. With an empty (or missing — D83: `serve` creates it and treats it as empty rather than failing) data dir the server starts with 0 KBs — `/health` is still up (liveness: `status:"ok"`) but `/ready` reports `503 {"ready":false}` (D84, §Observability): `cartographer kb create <name>` scaffolds a subfolder KB the same way `serve --kb <path> --init` would (D85), while `cartographer kb clone <remote>` mounts an existing OKF remote there (D97; `service install` itself prints a hint pointing at creation if it starts with 0 KBs mounted), or add `kbs:` entries to clone remotes (§Bootstrapping a KB) — either way, `service restart` (or `kb create --restart` / `kb clone --restart`, which do this for you and wait for the server to report healthy again) is what makes the new KB visible.
 
 `service status` uses systemctl-like exit codes: `0` running, `3` installed but stopped, `4` not installed — this is what lets `install.sh update` automatically restart only a running service (see §Client installation).
 
@@ -256,7 +256,7 @@ metadata:
   name: cartographer-config
 data:
   config.yaml: |
-    http: ":8080"
+    http: ":39273"
     auth:
       mode: "on"
     data: /data

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,7 +27,7 @@ imperative [agent-driven installation runbook](agent-install.md) instead of this
 ## 2. Run the server and create your first KB
 
 Install it as a native service (launchd on macOS, systemd user unit on Linux),
-so the server survives reboots and listens on `127.0.0.1:8080`:
+so the server survives reboots and listens on `127.0.0.1:39273`:
 
 ```bash
 cartographer service install    # generates the config, installs and starts the service
@@ -42,7 +42,7 @@ folder of Markdown you can open in any editor or in Obsidian.
 
 > **Running it by hand instead.** For development you can skip the service and
 > run a one-off server on a KB of your choice:
-> `cartographer serve --kb ~/my-kb --init --http :8080` (`--init` scaffolds
+> `cartographer serve --kb ~/my-kb --init --http :39273` (`--init` scaffolds
 > it). The service path above is the one to use daily.
 
 ## 3. Connect your agent

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -24,7 +24,7 @@ var ErrUnauthorized = errors.New("unauthorized (401): check the bearer token/env
 
 // MCPClient is a minimal JSON-RPC 2.0 client for the MCP `tools/call` method.
 type MCPClient struct {
-	ServerURL string // e.g. "http://localhost:8080/mcp"
+	ServerURL string // e.g. "http://localhost:39273/mcp"
 	Token     string // bearer token, empty = no Authorization header
 	KB        string // optional KB name; appended as ?kb=<KB> (multi-KB server routing, see httpserver.go)
 	HTTP      *http.Client

--- a/internal/clientconfig/clientconfig.go
+++ b/internal/clientconfig/clientconfig.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/BeppeTemp/cartographer/internal/defaults"
 	"gopkg.in/yaml.v3"
 )
 
@@ -83,12 +84,12 @@ func Default() *Config {
 // machine, or right after `disconnect` zeroed out agents but kept the file
 // (see doDisconnect) — CARTOGRAPHER_SERVER_URL, if set, seeds the connect
 // form/CLI default instead of the hardcoded localhost (D64): precedence is
-// yaml > env > localhost.
+// yaml > env > local default.
 func defaultServerURL() string {
 	if v := os.Getenv("CARTOGRAPHER_SERVER_URL"); v != "" {
 		return v
 	}
-	return "http://localhost:8080/mcp"
+	return defaults.DefaultMCPURL
 }
 
 // Path returns the full path to the client config file inside dir.

--- a/internal/clientconfig/clientconfig_test.go
+++ b/internal/clientconfig/clientconfig_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/BeppeTemp/cartographer/internal/clientconfig"
+	"github.com/BeppeTemp/cartographer/internal/defaults"
 )
 
 func TestLoad_NotExist(t *testing.T) {
@@ -69,7 +70,7 @@ func TestDefault_TrustIsTrue(t *testing.T) {
 func TestLoad_TrustAbsent_DefaultsTrue(t *testing.T) {
 	dir := t.TempDir()
 	// Config file written before the `trust` field existed: no `trust` key at all.
-	data := "server_url: http://localhost:8080/mcp\nserver_name: cartographer\nauth: false\ntoken_env: CARTOGRAPHER_TOKENS\nagents: [claude]\n"
+	data := "server_url: https://saved.example.test/mcp\nserver_name: cartographer\nauth: false\ntoken_env: CARTOGRAPHER_TOKENS\nagents: [claude]\n"
 	if err := os.WriteFile(filepath.Join(dir, clientconfig.FileName), []byte(data), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
@@ -84,7 +85,7 @@ func TestLoad_TrustAbsent_DefaultsTrue(t *testing.T) {
 
 func TestLoad_TrustExplicitFalse_StaysFalse(t *testing.T) {
 	dir := t.TempDir()
-	data := "server_url: http://localhost:8080/mcp\ntrust: false\n"
+	data := "server_url: https://saved.example.test/mcp\ntrust: false\n"
 	if err := os.WriteFile(filepath.Join(dir, clientconfig.FileName), []byte(data), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
@@ -113,10 +114,10 @@ func TestSaveAndLoad_TrustRoundTrip(t *testing.T) {
 	}
 }
 
-func TestDefault_ServerURLFallsBackToLocalhost(t *testing.T) {
+func TestDefault_ServerURLFallsBackToLocalDefault(t *testing.T) {
 	cfg := clientconfig.Default()
-	if cfg.ServerURL != "http://localhost:8080/mcp" {
-		t.Errorf("ServerURL = %q, want http://localhost:8080/mcp with no env set", cfg.ServerURL)
+	if cfg.ServerURL != defaults.DefaultMCPURL {
+		t.Errorf("ServerURL = %q, want %q with no env set", cfg.ServerURL, defaults.DefaultMCPURL)
 	}
 }
 
@@ -143,6 +144,22 @@ func TestLoad_ExistingYAMLWinsOverServerURLEnv(t *testing.T) {
 	}
 	if loaded.ServerURL != "https://yaml.example.com/mcp" {
 		t.Errorf("ServerURL = %q, want the persisted yaml value (yaml > env precedence)", loaded.ServerURL)
+	}
+}
+
+func TestLoad_Existing8080ServerURLIsPreserved(t *testing.T) {
+	dir := t.TempDir()
+	const existing = "http://localhost:8080/mcp"
+	if err := os.WriteFile(filepath.Join(dir, clientconfig.FileName), []byte("server_url: "+existing+"\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	loaded, err := clientconfig.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.ServerURL != existing {
+		t.Errorf("ServerURL = %q, want preserved %q", loaded.ServerURL, existing)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -53,7 +53,7 @@ func TestToolsProfileEnvAndNormalization(t *testing.T) {
 }
 
 const fullYAML = `
-http: ":8080"
+http: ":39273"
 init: true
 auth:
   mode: "on"
@@ -111,7 +111,7 @@ func TestLoadFullYAML(t *testing.T) {
 	}
 
 	want := &Config{
-		HTTP: ":8080",
+		HTTP: ":39273",
 		Init: true,
 		Auth: AuthConfig{Mode: "on", Tokens: []TokenSpec{
 			{Token: "tok-a"},
@@ -290,7 +290,7 @@ func TestFromEnvUnsetLeavesDefaults(t *testing.T) {
 func TestApplyFlagsPrecedenceOverEnvAndYAML(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(path, []byte(`http: ":8080"`+"\n"), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(`http: ":39273"`+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	cfg, err := Load(path)
@@ -313,9 +313,9 @@ func TestApplyFlagsPrecedenceOverEnvAndYAML(t *testing.T) {
 
 func TestApplyFlagsNilLeavesCfgUntouched(t *testing.T) {
 	cfg := Default()
-	cfg.HTTP = ":8080"
+	cfg.HTTP = ":39273"
 	ApplyFlags(cfg, FlagOverrides{})
-	if cfg.HTTP != ":8080" {
+	if cfg.HTTP != ":39273" {
 		t.Errorf("HTTP changed with nil overrides: %q", cfg.HTTP)
 	}
 }

--- a/internal/configurator/configurator.go
+++ b/internal/configurator/configurator.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/BeppeTemp/cartographer/internal/blocktext"
+	"github.com/BeppeTemp/cartographer/internal/defaults"
 )
 
 // ServerConfig holds the MCP server configuration. The client always talks to the
@@ -27,7 +28,7 @@ type ServerConfig struct {
 func DefaultConfig() *ServerConfig {
 	return &ServerConfig{
 		Name:        "cartographer",
-		URL:         "http://localhost:8080/mcp",
+		URL:         defaults.DefaultMCPURL,
 		AuthEnabled: false,
 		TokenEnv:    "CARTOGRAPHER_TOKENS",
 	}

--- a/internal/configurator/configurator_codex_test.go
+++ b/internal/configurator/configurator_codex_test.go
@@ -16,7 +16,7 @@ import (
 func TestEmitCodex_TOML(t *testing.T) {
 	cfg := &configurator.ServerConfig{
 		Name:        "cartographer",
-		URL:         "http://localhost:8080/mcp",
+		URL:         "https://mcp.example.test/mcp",
 		AuthEnabled: true,
 		TokenEnv:    "CARTOGRAPHER_TOKENS",
 	}
@@ -31,7 +31,7 @@ func TestEmitCodex_TOML(t *testing.T) {
 	if !strings.Contains(content, `[mcp_servers.cartographer]`) {
 		t.Errorf("missing [mcp_servers.cartographer] section header: %s", content)
 	}
-	if !strings.Contains(content, `url = "http://localhost:8080/mcp"`) {
+	if !strings.Contains(content, `url = "https://mcp.example.test/mcp"`) {
 		t.Errorf("missing url key: %s", content)
 	}
 	if !strings.Contains(content, `bearer_token_env_var = "CARTOGRAPHER_TOKENS"`) {
@@ -40,7 +40,7 @@ func TestEmitCodex_TOML(t *testing.T) {
 }
 
 func TestEmitCodex_TOML_NoAuth(t *testing.T) {
-	cfg := &configurator.ServerConfig{Name: "cartographer", URL: "http://localhost:8080/mcp"}
+	cfg := &configurator.ServerConfig{Name: "cartographer", URL: "https://mcp.example.test/mcp"}
 	r, err := configurator.Emit(cfg, configurator.ProviderCodex)
 	if err != nil {
 		t.Fatal(err)
@@ -61,7 +61,7 @@ func TestApplyCodex_PreservesUserTOML(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cfg := &configurator.ServerConfig{Name: "cartographer", URL: "http://localhost:8080/mcp"}
+	cfg := &configurator.ServerConfig{Name: "cartographer", URL: "https://mcp.example.test/mcp"}
 	r, err := configurator.Emit(cfg, configurator.ProviderCodex)
 	if err != nil {
 		t.Fatal(err)
@@ -100,7 +100,7 @@ func TestApplyCodex_PreservesUserTOML(t *testing.T) {
 
 func TestRemoveCodex_StripsBlock_DeletesFileIfEmpty(t *testing.T) {
 	dir := t.TempDir()
-	cfg := &configurator.ServerConfig{Name: "cartographer", URL: "http://localhost:8080/mcp"}
+	cfg := &configurator.ServerConfig{Name: "cartographer", URL: "https://mcp.example.test/mcp"}
 	r, err := configurator.Emit(cfg, configurator.ProviderCodex)
 	if err != nil {
 		t.Fatal(err)
@@ -128,7 +128,7 @@ func TestRemoveCodex_PreservesUserContent(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	cfg := &configurator.ServerConfig{Name: "cartographer", URL: "http://localhost:8080/mcp"}
+	cfg := &configurator.ServerConfig{Name: "cartographer", URL: "https://mcp.example.test/mcp"}
 	r, err := configurator.Emit(cfg, configurator.ProviderCodex)
 	if err != nil {
 		t.Fatal(err)
@@ -162,7 +162,7 @@ func TestRemoveCodex_PreservesUserContent(t *testing.T) {
 
 func TestRemoveCodex_DryRunDoesNotWrite(t *testing.T) {
 	dir := t.TempDir()
-	cfg := &configurator.ServerConfig{Name: "cartographer", URL: "http://localhost:8080/mcp"}
+	cfg := &configurator.ServerConfig{Name: "cartographer", URL: "https://mcp.example.test/mcp"}
 	r, err := configurator.Emit(cfg, configurator.ProviderCodex)
 	if err != nil {
 		t.Fatal(err)
@@ -200,7 +200,7 @@ func TestRemoveCodex_LegacyConfigJSON_Cleanup(t *testing.T) {
 	}
 	legacy := `{
   "mcpServers": {
-    "cartographer": {"url": "http://localhost:8080/mcp", "type": "http"},
+    "cartographer": {"url": "https://mcp.example.test/mcp", "type": "http"},
     "other": {"url": "https://example.com/mcp", "type": "http"}
   }
 }`
@@ -208,7 +208,7 @@ func TestRemoveCodex_LegacyConfigJSON_Cleanup(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cfg := &configurator.ServerConfig{Name: "cartographer", URL: "http://localhost:8080/mcp"}
+	cfg := &configurator.ServerConfig{Name: "cartographer", URL: "https://mcp.example.test/mcp"}
 	removed, err := configurator.Remove(cfg, configurator.ProviderCodex, dir, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -235,12 +235,12 @@ func TestRemoveCodex_LegacyConfigJSON_DeletesIfOnlyEntry(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	legacy := `{"mcpServers": {"cartographer": {"url": "http://localhost:8080/mcp", "type": "http"}}}`
+	legacy := `{"mcpServers": {"cartographer": {"url": "https://mcp.example.test/mcp", "type": "http"}}}`
 	if err := os.WriteFile(legacyPath, []byte(legacy), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	cfg := &configurator.ServerConfig{Name: "cartographer", URL: "http://localhost:8080/mcp"}
+	cfg := &configurator.ServerConfig{Name: "cartographer", URL: "https://mcp.example.test/mcp"}
 	if _, err := configurator.Remove(cfg, configurator.ProviderCodex, dir, false); err != nil {
 		t.Fatal(err)
 	}
@@ -268,7 +268,7 @@ func writeCodexConfig(t *testing.T, dir, content string) string {
 // returns the resulting config.toml plus the warnings Apply produced.
 func applyCodexEntry(t *testing.T, dir string) (string, []string) {
 	t.Helper()
-	cfg := &configurator.ServerConfig{Name: "cartographer", URL: "http://localhost:8080/mcp"}
+	cfg := &configurator.ServerConfig{Name: "cartographer", URL: "https://mcp.example.test/mcp"}
 	r, err := configurator.Emit(cfg, configurator.ProviderCodex)
 	if err != nil {
 		t.Fatal(err)
@@ -291,7 +291,7 @@ func TestApplyCodex_AdoptsOrphanTable_AfterCodexRewrote(t *testing.T) {
 
 [mcp_servers.cartographer]
 bearer_token_env_var = "CARTOGRAPHER_TOKENS"
-url = "http://localhost:8080/mcp"
+url = "https://mcp.example.test/mcp"
 
 [mcp_servers.other]
 url = "https://example.com/mcp"
@@ -322,7 +322,7 @@ func TestApplyCodex_AdoptsOrphanTable_WithSubTable(t *testing.T) {
 model = "gpt-5.6"
 
 [mcp_servers.cartographer]
-url = "http://localhost:8080/mcp"
+url = "https://mcp.example.test/mcp"
 
 [mcp_servers.cartographer.env]
 FOO = "bar"
@@ -405,13 +405,13 @@ url = "https://developers.openai.com/mcp"
 
 [mcp_servers.cartographer]
 bearer_token_env_var = "CARTOGRAPHER_TOKENS"
-url = "http://localhost:8080/mcp"
+url = "https://mcp.example.test/mcp"
 
 [projects."/Users/me"]
 trust_level = "trusted"
 
 [mcp_servers.cartographer]
-url = "http://localhost:8080/mcp"
+url = "https://mcp.example.test/mcp"
 bearer_token_env_var = "CARTOGRAPHER_TOKENS"
 `)
 

--- a/internal/configurator/configurator_test.go
+++ b/internal/configurator/configurator_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/BeppeTemp/cartographer/internal/configurator"
+	"github.com/BeppeTemp/cartographer/internal/defaults"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -14,8 +15,8 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.Name == "" {
 		t.Error("Name should have a default value")
 	}
-	if cfg.URL == "" {
-		t.Error("URL should have a default value")
+	if cfg.URL != defaults.DefaultMCPURL {
+		t.Errorf("URL = %q, want %q", cfg.URL, defaults.DefaultMCPURL)
 	}
 	if cfg.AuthEnabled {
 		t.Error("AuthEnabled should default to false")
@@ -28,7 +29,7 @@ func TestDefaultConfig(t *testing.T) {
 func TestEmitClaudeCode(t *testing.T) {
 	cfg := &configurator.ServerConfig{
 		Name:        "wiki",
-		URL:         "http://localhost:8080/mcp",
+		URL:         "https://mcp.example.test/mcp",
 		AuthEnabled: true,
 		TokenEnv:    "CARTOGRAPHER_TOKENS",
 	}
@@ -69,7 +70,7 @@ func TestEmitClaudeCode(t *testing.T) {
 func TestEmitAll(t *testing.T) {
 	cfg := &configurator.ServerConfig{
 		Name: "wiki",
-		URL:  "http://localhost:8080/mcp",
+		URL:  "https://mcp.example.test/mcp",
 	}
 	results, err := configurator.EmitAll(cfg)
 	if err != nil {
@@ -100,7 +101,7 @@ func TestEmitAll(t *testing.T) {
 func TestEmitOpenCode_HTTP_NoAuth(t *testing.T) {
 	cfg := &configurator.ServerConfig{
 		Name:        "wiki",
-		URL:         "http://localhost:8080/mcp",
+		URL:         "https://mcp.example.test/mcp",
 		AuthEnabled: false,
 		TokenEnv:    "CARTOGRAPHER_TOKENS",
 	}
@@ -130,8 +131,8 @@ func TestEmitOpenCode_HTTP_NoAuth(t *testing.T) {
 	if entry["type"] != "remote" {
 		t.Errorf("type = %v, want remote", entry["type"])
 	}
-	if entry["url"] != "http://localhost:8080/mcp" {
-		t.Errorf("url = %v, want http://localhost:8080/mcp", entry["url"])
+	if entry["url"] != "https://mcp.example.test/mcp" {
+		t.Errorf("url = %v, want https://mcp.example.test/mcp", entry["url"])
 	}
 	if entry["enabled"] != true {
 		t.Errorf("enabled = %v, want true", entry["enabled"])
@@ -144,7 +145,7 @@ func TestEmitOpenCode_HTTP_NoAuth(t *testing.T) {
 func TestEmitOpenCode_HTTP_Auth(t *testing.T) {
 	cfg := &configurator.ServerConfig{
 		Name:        "wiki",
-		URL:         "http://localhost:8080/mcp",
+		URL:         "https://mcp.example.test/mcp",
 		AuthEnabled: true,
 		TokenEnv:    "CARTOGRAPHER_TOKENS",
 	}
@@ -173,7 +174,7 @@ func TestEmitOpenCode_HTTP_Auth(t *testing.T) {
 func TestApplyDryRun(t *testing.T) {
 	cfg := &configurator.ServerConfig{
 		Name: "wiki",
-		URL:  "http://localhost:8080/mcp",
+		URL:  "https://mcp.example.test/mcp",
 	}
 	results, err := configurator.EmitAll(cfg)
 	if err != nil {
@@ -195,7 +196,7 @@ func TestApplyDryRun(t *testing.T) {
 }
 
 func TestApply_ReturnsAbsolutePaths(t *testing.T) {
-	r, err := configurator.Emit(&configurator.ServerConfig{Name: "wiki", URL: "http://localhost:8080/mcp"}, configurator.ProviderClaudeCode)
+	r, err := configurator.Emit(&configurator.ServerConfig{Name: "wiki", URL: "https://mcp.example.test/mcp"}, configurator.ProviderClaudeCode)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -214,7 +215,7 @@ func TestApply_ReturnsAbsolutePaths(t *testing.T) {
 }
 
 func TestRemove_NonDestructiveMerge(t *testing.T) {
-	cfg := &configurator.ServerConfig{Name: "wiki", URL: "http://localhost:8080/mcp"}
+	cfg := &configurator.ServerConfig{Name: "wiki", URL: "https://mcp.example.test/mcp"}
 	r, err := configurator.Emit(cfg, configurator.ProviderClaudeCode)
 	if err != nil {
 		t.Fatal(err)
@@ -278,7 +279,7 @@ func TestRemove_NonDestructiveMerge(t *testing.T) {
 }
 
 func TestRemove_NoFileIsNoop(t *testing.T) {
-	cfg := &configurator.ServerConfig{Name: "wiki", URL: "http://localhost:8080/mcp"}
+	cfg := &configurator.ServerConfig{Name: "wiki", URL: "https://mcp.example.test/mcp"}
 	dir := t.TempDir()
 
 	removed, err := configurator.Remove(cfg, configurator.ProviderClaudeCode, dir, false)
@@ -291,7 +292,7 @@ func TestRemove_NoFileIsNoop(t *testing.T) {
 }
 
 func TestRemove_MissingKeyIsNoop(t *testing.T) {
-	cfg := &configurator.ServerConfig{Name: "wiki", URL: "http://localhost:8080/mcp"}
+	cfg := &configurator.ServerConfig{Name: "wiki", URL: "https://mcp.example.test/mcp"}
 	r, err := configurator.Emit(cfg, configurator.ProviderClaudeCode)
 	if err != nil {
 		t.Fatal(err)
@@ -301,7 +302,7 @@ func TestRemove_MissingKeyIsNoop(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	otherCfg := &configurator.ServerConfig{Name: "other", URL: "http://localhost:8080/mcp"}
+	otherCfg := &configurator.ServerConfig{Name: "other", URL: "https://mcp.example.test/mcp"}
 	removed, err := configurator.Remove(otherCfg, configurator.ProviderClaudeCode, dir, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -321,7 +322,7 @@ func TestRemove_MissingKeyIsNoop(t *testing.T) {
 }
 
 func TestRemove_DryRunDoesNotWrite(t *testing.T) {
-	cfg := &configurator.ServerConfig{Name: "wiki", URL: "http://localhost:8080/mcp"}
+	cfg := &configurator.ServerConfig{Name: "wiki", URL: "https://mcp.example.test/mcp"}
 	r, err := configurator.Emit(cfg, configurator.ProviderClaudeCode)
 	if err != nil {
 		t.Fatal(err)
@@ -356,7 +357,7 @@ func TestRemove_DryRunDoesNotWrite(t *testing.T) {
 func TestApplyWrite(t *testing.T) {
 	cfg := &configurator.ServerConfig{
 		Name: "wiki",
-		URL:  "http://localhost:8080/mcp",
+		URL:  "https://mcp.example.test/mcp",
 	}
 	results, err := configurator.EmitAll(cfg)
 	if err != nil {

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -1,0 +1,18 @@
+// Package defaults contains the local endpoint values shared by the native
+// service and client first-run paths. It deliberately has no dependencies so
+// these values cannot drift between those entry points.
+package defaults
+
+const (
+	// DefaultPort is the reserved local port used for newly generated service
+	// configuration and client configuration.
+	DefaultPort = 39273
+
+	// DefaultListenAddress is the loopback HTTP address used when generating a
+	// native service configuration for the first time.
+	DefaultListenAddress = "127.0.0.1:39273"
+
+	// DefaultMCPURL is the HTTP MCP endpoint used for a first-run client when
+	// no persisted configuration or CARTOGRAPHER_SERVER_URL is available.
+	DefaultMCPURL = "http://localhost:39273/mcp"
+)

--- a/internal/defaults/defaults_test.go
+++ b/internal/defaults/defaults_test.go
@@ -1,0 +1,15 @@
+package defaults
+
+import "testing"
+
+func TestLocalEndpointDefaults(t *testing.T) {
+	if DefaultPort != 39273 {
+		t.Errorf("DefaultPort = %d, want 39273", DefaultPort)
+	}
+	if DefaultListenAddress != "127.0.0.1:39273" {
+		t.Errorf("DefaultListenAddress = %q, want 127.0.0.1:39273", DefaultListenAddress)
+	}
+	if DefaultMCPURL != "http://localhost:39273/mcp" {
+		t.Errorf("DefaultMCPURL = %q, want http://localhost:39273/mcp", DefaultMCPURL)
+	}
+}

--- a/internal/mcpserver/httpserver.go
+++ b/internal/mcpserver/httpserver.go
@@ -178,7 +178,7 @@ func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]interface{}{"ready": true})
 }
 
-// ListenAndServe starts the HTTP server on the given address (e.g. ":8080").
+// ListenAndServe starts the HTTP server on the given address (e.g. ":39273").
 func (s *Server) ListenAndServe(addr string) error {
 	handler := s.HTTPHandler()
 	log.Printf("MCP HTTP server listening on %s", addr)

--- a/internal/provisioning/provisioning_codex_test.go
+++ b/internal/provisioning/provisioning_codex_test.go
@@ -213,7 +213,7 @@ func TestApply_Codex_Hook_MCPBlock_CoesisteConHook(t *testing.T) {
 	}
 	baseDir := t.TempDir()
 
-	cfg := &configurator.ServerConfig{Name: "cartographer", URL: "http://localhost:8080/mcp"}
+	cfg := &configurator.ServerConfig{Name: "cartographer", URL: "https://mcp.example.test/mcp"}
 	r, err := configurator.Emit(cfg, configurator.ProviderCodex)
 	if err != nil {
 		t.Fatal(err)
@@ -306,7 +306,7 @@ func TestPruneManaged_Codex_Hook_RimuoveEntryConfigTOML(t *testing.T) {
 	// (everything before the em dash), or the block would be duplicated.
 	preexisting := "# cartographer:mcp:begin — blocco gestito da Cartographer, non modificare a mano\n" +
 		"[mcp_servers.cartographer]\n" +
-		"url = \"http://localhost:8080/mcp\"\n" +
+		"url = \"https://mcp.example.test/mcp\"\n" +
 		"# cartographer:mcp:end\n\n" +
 		"# cartographer:hook:notify:begin\n" +
 		"[[hooks.PostToolUse]]\n" +

--- a/internal/provisioning/provisioning_disconnect_test.go
+++ b/internal/provisioning/provisioning_disconnect_test.go
@@ -144,7 +144,7 @@ func TestRoundTrip_ConnectDisconnect_NessunResiduo(t *testing.T) {
 		configurator.ProviderKiro,
 		configurator.ProviderOpenCode,
 	}
-	scfg := &configurator.ServerConfig{Name: "cartographer", URL: "http://localhost:8080/mcp"}
+	scfg := &configurator.ServerConfig{Name: "cartographer", URL: "https://mcp.example.test/mcp"}
 
 	// --- Connect: MCP config + bootstrap hook + manifest, same order as doConnect ---
 	lockPath := filepath.Join(targetDir, provisioning.LockFileName)

--- a/internal/provisioning/provisioning_mcp_test.go
+++ b/internal/provisioning/provisioning_mcp_test.go
@@ -247,7 +247,7 @@ func TestApply_MCP_PreservesOtherEntriesInSharedFile(t *testing.T) {
 
 	// Pre-existing .claude.json with Cartographer's own entry and unrelated keys.
 	claudeJSONPath := filepath.Join(dir, ".claude.json")
-	preexisting := `{"mcpServers":{"cartographer":{"url":"http://localhost:8080/mcp","type":"http"}},"model":"opus"}`
+	preexisting := `{"mcpServers":{"cartographer":{"url":"https://mcp.example.test/mcp","type":"http"}},"model":"opus"}`
 	if err := os.WriteFile(claudeJSONPath, []byte(preexisting), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/service/manager.go
+++ b/internal/service/manager.go
@@ -331,8 +331,8 @@ func (m *Manager) Status(configPath string) (Status, error) {
 }
 
 // checkHealth reports whether GET http://<addr>/health returns 200 within
-// healthTimeout. addr may be a bare port (":8080") or host:port
-// ("127.0.0.1:8080"); a bare port is normalized to a 127.0.0.1 host.
+// healthTimeout. addr may be a bare port (":39273") or host:port
+// ("127.0.0.1:39273"); a bare port is normalized to a 127.0.0.1 host.
 func checkHealth(addr string) bool {
 	url := healthURL(addr)
 	if url == "" {
@@ -348,7 +348,7 @@ func checkHealth(addr string) bool {
 }
 
 // healthURL builds the /health URL from a server http address, normalizing a
-// bare-port address (":8080") to a 127.0.0.1 host. Returns "" if addr is empty.
+// bare-port address (":39273") to a 127.0.0.1 host. Returns "" if addr is empty.
 func healthURL(addr string) string {
 	if addr == "" {
 		return ""

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/BeppeTemp/cartographer/internal/config"
+	"github.com/BeppeTemp/cartographer/internal/defaults"
 )
 
 func TestRenderLaunchdPlist(t *testing.T) {
@@ -50,9 +51,9 @@ func TestRenderSystemdUnit(t *testing.T) {
 }
 
 func TestDefaultServerYAML(t *testing.T) {
-	out := DefaultServerYAML("/home/x/cartographer-data", "127.0.0.1:8080")
+	out := DefaultServerYAML("/home/x/cartographer-data", defaults.DefaultListenAddress)
 	for _, want := range []string{
-		`http: "127.0.0.1:8080"`,
+		`http: "127.0.0.1:39273"`,
 		`data: "/home/x/cartographer-data"`,
 		"init: true",
 		"cartographer service install",
@@ -73,7 +74,7 @@ func TestDefaultServerYAML(t *testing.T) {
 	if err != nil {
 		t.Fatalf("config.Load generated YAML: %v", err)
 	}
-	if cfg.HTTP != "127.0.0.1:8080" || cfg.Data != "/home/x/cartographer-data" || !cfg.Init {
+	if cfg.HTTP != defaults.DefaultListenAddress || cfg.Data != "/home/x/cartographer-data" || !cfg.Init {
 		t.Fatalf("loaded generated YAML = %+v", cfg)
 	}
 }
@@ -174,7 +175,7 @@ func TestInstall_GeneratesConfigAndPlist_Darwin(t *testing.T) {
 
 	dataDir := filepath.Join(home, "cartographer-data")
 	m, stub := newTestManager()
-	warnings, err := m.Install(InstallOptions{DataDir: dataDir, HTTPAddr: "127.0.0.1:8080"})
+	warnings, err := m.Install(InstallOptions{DataDir: dataDir, HTTPAddr: "127.0.0.1:39273"})
 	if err != nil {
 		t.Fatalf("Install: %v", err)
 	}
@@ -246,7 +247,7 @@ func TestInstall_PrefersStableCaskroomSymlink(t *testing.T) {
 	t.Cleanup(func() { osExecutable = origExecutable })
 
 	m, _ := newTestManager()
-	if _, err := m.Install(InstallOptions{DataDir: filepath.Join(home, "data"), HTTPAddr: "127.0.0.1:8080"}); err != nil {
+	if _, err := m.Install(InstallOptions{DataDir: filepath.Join(home, "data"), HTTPAddr: "127.0.0.1:39273"}); err != nil {
 		t.Fatalf("Install: %v", err)
 	}
 
@@ -275,13 +276,14 @@ func TestInstall_ExistingConfigNotOverwritten_WarnsOnExplicitFlags(t *testing.T)
 	configPath := filepath.Join(home, ".config", "cartographer", "server.yaml")
 	os.MkdirAll(filepath.Dir(configPath), 0o755)
 	customDataDir := filepath.Join(home, "custom")
-	existing := "http: \":9999\"\ndata: " + customDataDir + "\n"
+	// A generated service must never migrate this persisted pre-D112 endpoint.
+	existing := "http: \"127.0.0.1:8080\"\ndata: " + customDataDir + "\n"
 	if err := os.WriteFile(configPath, []byte(existing), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	m, _ := newTestManager()
-	warnings, err := m.Install(InstallOptions{DataDir: filepath.Join(home, "data"), HTTPAddr: "127.0.0.1:8080", DataExplicit: true})
+	warnings, err := m.Install(InstallOptions{DataDir: filepath.Join(home, "data"), HTTPAddr: defaults.DefaultListenAddress, DataExplicit: true, HTTPExplicit: true})
 	if err != nil {
 		t.Fatalf("Install: %v", err)
 	}
@@ -311,7 +313,7 @@ func TestInstall_Idempotent(t *testing.T) {
 	t.Cleanup(func() { osExecutable = origExecutable })
 
 	m, _ := newTestManager()
-	opts := InstallOptions{DataDir: filepath.Join(home, "data"), HTTPAddr: "127.0.0.1:8080"}
+	opts := InstallOptions{DataDir: filepath.Join(home, "data"), HTTPAddr: "127.0.0.1:39273"}
 	if _, err := m.Install(opts); err != nil {
 		t.Fatalf("first Install: %v", err)
 	}
@@ -384,6 +386,8 @@ func TestStatus_InstalledAndRunning(t *testing.T) {
 
 	configPath := filepath.Join(home, ".config", "cartographer", "server.yaml")
 	os.MkdirAll(filepath.Dir(configPath), 0o755)
+	// A service installed before D112 may still listen on 8080; status reports
+	// the persisted value rather than substituting the new default.
 	os.WriteFile(configPath, []byte("http: \"127.0.0.1:8080\"\n"), 0o644)
 
 	m, _ := newTestManager() // stub run() succeeds unconditionally
@@ -398,15 +402,15 @@ func TestStatus_InstalledAndRunning(t *testing.T) {
 		t.Error("Running should be true, stub run() succeeds")
 	}
 	if st.HTTPAddr != "127.0.0.1:8080" {
-		t.Errorf("HTTPAddr = %q, want 127.0.0.1:8080", st.HTTPAddr)
+		t.Errorf("HTTPAddr = %q, want preserved 127.0.0.1:8080", st.HTTPAddr)
 	}
 }
 
 func TestHealthURL(t *testing.T) {
 	cases := map[string]string{
 		"":                  "",
-		":8080":             "http://127.0.0.1:8080/health",
-		"127.0.0.1:8080":    "http://127.0.0.1:8080/health",
+		":39273":            "http://127.0.0.1:39273/health",
+		"127.0.0.1:39273":   "http://127.0.0.1:39273/health",
 		"0.0.0.0:9090":      "http://0.0.0.0:9090/health",
 		"not-a-valid-value": "",
 	}

--- a/internal/skillbundle/bundled/cartographer-ops/SKILL.md
+++ b/internal/skillbundle/bundled/cartographer-ops/SKILL.md
@@ -39,7 +39,7 @@ variables or the platform secret store, not in a committed YAML file.
 |---|---|
 | `CARTOGRAPHER_KB` | One or more explicit KB paths. |
 | `CARTOGRAPHER_DATA` | Data directory whose direct subfolders are discovered as KBs. |
-| `CARTOGRAPHER_HTTP` | HTTP listen address, such as `:8080`. |
+| `CARTOGRAPHER_HTTP` | HTTP listen address, such as `:39273`. |
 | `CARTOGRAPHER_AUTH` | Explicit auth mode: on, off, or automatic when unset. |
 | `CARTOGRAPHER_TOKENS` | Bearer tokens, including optional per-KB scopes. |
 | `CARTOGRAPHER_GIT_SYNC` | Set `false` only when remote git synchronization around writes is intentionally disabled. |

--- a/test/e2e/lib/server.sh
+++ b/test/e2e/lib/server.sh
@@ -6,7 +6,7 @@
 #   E2E_TOKENS  token string (required if E2E_AUTH=true)
 
 # HTTP port for the E2E tests. High port unlikely to collide with common
-# services on 8080 (Docker/Colima, port-forward, etc.).
+# services on either the conventional HTTP port or Cartographer's local default.
 E2E_HTTP_PORT="${E2E_HTTP_PORT:-47821}"
 
 # File where the server process PID is saved.


### PR DESCRIPTION
## Summary

- centralize local port, listen address, and MCP URL in internal/defaults
- move new local service and client defaults to port 39273 while preserving existing 8080 configuration
- update operator surfaces, fixtures, documentation, and D112

## Validation

- rtk make vet
- rtk make test
- rtk proxy rg -n '8080' . (only explicit backwards-compatibility tests and decision history)

Generated with Codex

Closes #82