### PR TITLE
feat: unify CLI and TUI user experience

### DIFF
--- a/cmd/cartographer/agents.go
+++ b/cmd/cartographer/agents.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"flag"
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -13,8 +13,15 @@ import (
 // this machine (internal/agents.Detect) and whether it is connected (listed in the
 // machine-wide .cartographer.yaml, see clientconfig.TargetDir).
 func cmdAgents(args []string) int {
-	fs := flag.NewFlagSet("agents", flag.ExitOnError)
-	fs.Parse(args)
+	output, remaining, err := outputFlag(args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		return 2
+	}
+	if len(remaining) != 0 {
+		fmt.Fprintln(os.Stderr, "Error: usage: cartographer agents [--output table|json]")
+		return 2
+	}
 
 	dir, err := clientconfig.TargetDir()
 	if err != nil {
@@ -22,17 +29,26 @@ func cmdAgents(args []string) int {
 		return 2
 	}
 
+	cfg, _ := clientconfig.Load(dir)
+	s := emptySnapshot()
+	s.Providers = providerStatuses(cfg)
+	if cfg != nil {
+		s.ServerURL = cfg.ServerURL
+		s.State = "configured"
+	}
+	if output == "json" {
+		_ = json.NewEncoder(os.Stdout).Encode(s)
+		return 0
+	}
+
+	fmt.Printf("%-10s %-10s %-10s %s\n", "PROVIDER", "INSTALLED", "CONNECTED", "EVIDENCE")
 	connected := map[string]bool{}
-	if cfg, err := clientconfig.Load(dir); err == nil {
+	if cfg != nil {
 		for _, a := range cfg.Agents {
 			connected[a] = true
 		}
 	}
-
-	detected := agents.Detect()
-
-	fmt.Printf("%-10s %-10s %-10s %s\n", "PROVIDER", "INSTALLED", "CONNECTED", "EVIDENCE")
-	for _, a := range detected {
+	for _, a := range agents.Detect() {
 		fmt.Printf("%-10s %-10s %-10s %s\n", a.Provider, yesNo(a.Installed), yesNo(connected[string(a.Provider)]), dashIfEmpty(a.Evidence))
 	}
 	return 0

--- a/cmd/cartographer/connectform.go
+++ b/cmd/cartographer/connectform.go
@@ -109,6 +109,9 @@ type connectFormModel struct {
 	// SpinnerView while Submitting is true — e.g. "probing the server…" during
 	// the pre-connect probe (D64). Empty means "connecting…".
 	SubmittingLabel string
+	// Width is supplied by the embedding dashboard. Zero preserves the
+	// standalone CLI form's natural layout.
+	Width int
 }
 
 // newConnectFormModel builds a connectFormModel titled title (e.g. "Connect
@@ -327,6 +330,13 @@ func (m *connectFormModel) clearProbeState() {
 }
 
 func (m connectFormModel) View() string {
+	if m.Width > 0 {
+		w := m.Width - 20
+		if w < 16 {
+			w = 16
+		}
+		m.url.Width, m.tokenEnv.Width = w, w
+	}
 	auth := "[ ] disabled"
 	if m.auth {
 		auth = "[x] enabled"
@@ -336,7 +346,11 @@ func (m connectFormModel) View() string {
 		trust = "[x] enabled"
 	}
 
-	tokenEnvLine := formFieldLine("Token env var", m.tokenEnv.View(), m.focus == fieldTokenEnv)
+	tokenLabel := "Token env var"
+	if m.Width > 0 && m.Width < 80 {
+		tokenLabel = "Token"
+	}
+	tokenEnvLine := formFieldLine(tokenLabel, m.tokenEnv.View(), m.focus == fieldTokenEnv)
 	if !m.auth {
 		// Secondary/dimmed when auth is off: the field is collected but unused
 		// (see resolveToken/probeServer, which only read it when Auth is
@@ -345,7 +359,11 @@ func (m connectFormModel) View() string {
 		tokenEnvLine = styleSubtitle.Render(tokenEnvLine)
 	}
 
-	fields := []string{formFieldLine("Server URL", m.url.View(), m.focus == fieldServerURL)}
+	urlLabel := "Server URL"
+	if m.Width > 0 && m.Width < 80 {
+		urlLabel = "URL"
+	}
+	fields := []string{formFieldLine(urlLabel, m.url.View(), m.focus == fieldServerURL)}
 	if m.selectAgents {
 		fields = append(fields,
 			formProviderLine("claude", m.providers["claude"], m.focus == fieldAgentClaude),
@@ -354,7 +372,11 @@ func (m connectFormModel) View() string {
 			formProviderLine("kiro", m.providers["kiro"], m.focus == fieldAgentKiro),
 		)
 	}
-	fields = append(fields, tokenEnvLine, formFieldLine("Auth", auth, m.focus == fieldAuth), formFieldLine("Trust KB artifacts", trust, m.focus == fieldTrust))
+	trustLabel := "Trust KB artifacts"
+	if m.Width > 0 && m.Width < 80 {
+		trustLabel = "Trust"
+	}
+	fields = append(fields, tokenEnvLine, formFieldLine("Auth", auth, m.focus == fieldAuth), formFieldLine(trustLabel, trust, m.focus == fieldTrust))
 
 	submit := "  Connect"
 	if m.focus == fieldSubmit {

--- a/cmd/cartographer/main.go
+++ b/cmd/cartographer/main.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"strings"
 )
 
 // version is the build version, normally overridden at link time via
@@ -15,25 +14,26 @@ var version = "dev"
 
 // subcommand describes one entry of `cartographer help`.
 type subcommand struct {
-	name string
-	desc string
+	group string
+	name  string
+	desc  string
 }
 
 // subcommands lists every subcommand for the usage output.
 var subcommands = []subcommand{
-	{"serve", "Run the MCP server (stdio or HTTP)"},
-	{"kb", "Create or mount local KBs (kb create|clone)"},
-	{"version", "Print the build version"},
-	{"help", "Show this help message"},
-	{"agents", "List detected/connected agent clients on this machine"},
-	{"connect", "Connect this machine to a cartographer server"},
-	{"disconnect", "Disconnect this machine from a cartographer server"},
-	{"status", "Show sync status against the configured server"},
-	{"sync", "Synchronize local agent clients with the configured server"},
-	{"service", "Manage the MCP server as a native service (install|uninstall|start|stop|restart|status)"},
-	{"import", "Mechanically import an external markdown corpus into a KB (D74 scaffold)"},
-	{"resolve", "Resolve a {{repo:<key>}}/{{path:<name>}} placeholder to a local path (D75)"},
-	{"reindex", "Reconcile search indexes after out-of-band KB changes"},
+	{"Get started", "help", "Show this help"},
+	{"Get started", "version", "Print the build version"},
+	{"Client", "agents", "List local agent clients"},
+	{"Client", "connect", "Connect an agent client"},
+	{"Client", "disconnect", "Disconnect an agent client"},
+	{"Client", "status", "Show client sync status"},
+	{"Client", "sync", "Synchronize agent clients"},
+	{"Server", "serve", "Run the MCP server"},
+	{"Server", "service", "Manage the native server service"},
+	{"Knowledge base", "kb", "Create or mount local knowledge bases"},
+	{"Knowledge base", "import", "Import an external markdown corpus"},
+	{"Knowledge base", "resolve", "Resolve a configured path placeholder"},
+	{"Diagnostics", "reindex", "Reconcile search indexes"},
 }
 
 // serveFn/versionFn/agentsFn/connectFn/disconnectFn/statusFn/syncFn are
@@ -82,7 +82,7 @@ func run(args []string) int {
 		return serveFn(rest)
 	case "kb":
 		return kbFn(rest)
-	case "version":
+	case "version", "--version":
 		return versionFn()
 	case "help", "-h", "--help":
 		printUsage(os.Stdout)
@@ -106,11 +106,12 @@ func run(args []string) int {
 	case "reindex":
 		return reindexFn(rest)
 	default:
-		if strings.HasPrefix(cmd, "-") {
-			fmt.Fprintf(os.Stderr, "Error: flags are not accepted at the root level; did you mean %q?\n\n", "cartographer serve ...")
-		} else {
-			fmt.Fprintf(os.Stderr, "Error: unknown command %q; did you mean %q?\n\n", cmd, "cartographer serve")
+		fmt.Fprintf(os.Stderr, "Error: unknown command %q", cmd)
+		if suggestion := commandSuggestion(cmd); suggestion != "" {
+			fmt.Fprintf(os.Stderr, "; did you mean %q", suggestion)
 		}
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr)
 		printUsage(os.Stderr)
 		return 2
 	}
@@ -132,13 +133,68 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  cartographer <command> [flags]")
 	fmt.Fprintln(w, "")
-	fmt.Fprintln(w, "Commands:")
+	fmt.Fprintln(w, "Get started:")
 	fmt.Fprintf(w, "  %-10s %s\n", "(none)", "Launch interactive dashboard (TTY only)")
+	group := ""
 	for _, sc := range subcommands {
+		if sc.group != group {
+			if group != "" {
+				fmt.Fprintln(w)
+			}
+			if sc.group != "Get started" {
+				fmt.Fprintf(w, "%s:\n", sc.group)
+			}
+			group = sc.group
+		}
 		fmt.Fprintf(w, "  %-10s %s\n", sc.name, sc.desc)
 	}
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Run 'cartographer <command> -h' for flags of a specific command.")
+}
+
+// commandSuggestion returns the only close command. A distance of two keeps
+// corrections useful ("agent" → "agents") without guessing unrelated input.
+func commandSuggestion(input string) string {
+	var match string
+	for _, sc := range subcommands {
+		if editDistance(input, sc.name) <= 2 {
+			if match != "" {
+				return ""
+			}
+			match = sc.name
+		}
+	}
+	return match
+}
+
+func editDistance(a, b string) int {
+	prev := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i, ra := range a {
+		cur := make([]int, len(b)+1)
+		cur[0] = i + 1
+		for j, rb := range b {
+			cost := 0
+			if ra != rb {
+				cost = 1
+			}
+			cur[j+1] = minInt(prev[j+1]+1, cur[j]+1, prev[j]+cost)
+		}
+		prev = cur
+	}
+	return prev[len(b)]
+}
+
+func minInt(values ...int) int {
+	n := values[0]
+	for _, v := range values[1:] {
+		if v < n {
+			n = v
+		}
+	}
+	return n
 }
 
 // envFallback returns val if non-empty, else os.Getenv(envKey).

--- a/cmd/cartographer/main_test.go
+++ b/cmd/cartographer/main_test.go
@@ -138,6 +138,39 @@ func TestRunVersionDispatch(t *testing.T) {
 	}
 }
 
+func TestRunVersionAliases(t *testing.T) {
+	orig := versionFn
+	defer func() { versionFn = orig }()
+	called := 0
+	versionFn = func() int { called++; return 0 }
+	for _, args := range [][]string{{"version"}, {"--version"}} {
+		if code := run(args); code != 0 {
+			t.Fatalf("run(%v) = %d", args, code)
+		}
+	}
+	if called != 2 {
+		t.Fatalf("version calls = %d, want 2", called)
+	}
+}
+
+func TestCommandSuggestionIsConservative(t *testing.T) {
+	if got := commandSuggestion("agnts"); got != "agents" {
+		t.Errorf("suggestion = %q", got)
+	}
+	if got := commandSuggestion("definitely-unrelated"); got != "" {
+		t.Errorf("unrelated suggestion = %q", got)
+	}
+}
+
+func TestUsageFits80Columns(t *testing.T) {
+	out := withStdout(t, func() { printUsage(os.Stdout) })
+	for _, line := range strings.Split(strings.TrimSuffix(out, "\n"), "\n") {
+		if len(line) > 80 {
+			t.Errorf("help line is %d columns: %q", len(line), line)
+		}
+	}
+}
+
 func TestRunServeDispatch(t *testing.T) {
 	origServeFn := serveFn
 	defer func() { serveFn = origServeFn }()

--- a/cmd/cartographer/service.go
+++ b/cmd/cartographer/service.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -24,6 +26,10 @@ const (
 // cmdService manages the cartographer MCP server as a native per-user
 // service: launchd on macOS, a systemd user unit on Linux.
 func cmdService(args []string) int {
+	if len(args) == 1 && (args[0] == "-h" || args[0] == "--help") {
+		printServiceUsage(os.Stdout)
+		return 0
+	}
 	target, rest := splitPositional(args, "")
 
 	switch target {
@@ -40,9 +46,14 @@ func cmdService(args []string) int {
 	case "status":
 		return cmdServiceStatus(rest)
 	default:
-		fmt.Fprintln(os.Stderr, "Error: usage: cartographer service install|uninstall|start|stop|restart|status")
+		fmt.Fprintln(os.Stderr, "Error: service action required")
+		printServiceUsage(os.Stderr)
 		return exitStatusError
 	}
+}
+
+func printServiceUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage: cartographer service <install|uninstall|start|stop|restart|status> [flags]")
 }
 
 func cmdServiceInstall(args []string) int {
@@ -131,9 +142,14 @@ func cmdServiceRestart(args []string) int {
 }
 
 func cmdServiceStatus(args []string) int {
+	output, remaining, err := outputFlag(args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		return exitStatusError
+	}
 	fs := flag.NewFlagSet("service status", flag.ExitOnError)
 	configFlag := fs.String("config", "", "Server config YAML to read the http address from (default: the standard path)")
-	fs.Parse(args)
+	fs.Parse(remaining)
 
 	st, err := service.NewManager().Status(*configFlag)
 	if err != nil {
@@ -141,11 +157,21 @@ func cmdServiceStatus(args []string) int {
 		return exitStatusError
 	}
 
-	fmt.Printf("binary:  %s\n", st.BinPath)
-	fmt.Printf("config:  %s\n", st.ConfigPath)
-	fmt.Printf("installed: %v\n", st.Installed)
-	fmt.Printf("running:   %v\n", st.Running)
-	fmt.Printf("healthy:   %v (http %s)\n", st.Healthy, st.HTTPAddr)
+	s := statusSnapshot{Schema: statusSchema, Client: version, State: "running", Service: &serviceSnapshot{st.Installed, st.Running, st.Healthy, st.HTTPAddr}}
+	if !st.Installed {
+		s.State = "not_installed"
+	} else if !st.Running {
+		s.State = "stopped"
+	}
+	if output == "json" {
+		_ = json.NewEncoder(os.Stdout).Encode(s)
+	} else {
+		fmt.Printf("binary:  %s\n", st.BinPath)
+		fmt.Printf("config:  %s\n", st.ConfigPath)
+		fmt.Printf("installed: %v\n", st.Installed)
+		fmt.Printf("running:   %v\n", st.Running)
+		fmt.Printf("healthy:   %v (http %s)\n", st.Healthy, st.HTTPAddr)
+	}
 
 	if !st.Installed {
 		return exitStatusNotInstalled

--- a/cmd/cartographer/service_test.go
+++ b/cmd/cartographer/service_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestServiceHelpUsesStdoutAndSucceeds(t *testing.T) {
+	out := withStdout(t, func() {
+		if code := cmdService([]string{"--help"}); code != 0 {
+			t.Errorf("exit = %d, want 0", code)
+		}
+	})
+	if !strings.Contains(out, "Usage: cartographer service") {
+		t.Fatalf("help = %q", out)
+	}
+}
+
+func TestServiceWithoutActionFails(t *testing.T) {
+	if code := cmdService(nil); code != exitStatusError {
+		t.Errorf("exit = %d, want %d", code, exitStatusError)
+	}
+}

--- a/cmd/cartographer/status.go
+++ b/cmd/cartographer/status.go
@@ -1,15 +1,14 @@
 package main
 
 import (
-	"flag"
+	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/BeppeTemp/cartographer/internal/client"
 	"github.com/BeppeTemp/cartographer/internal/clientconfig"
-	"github.com/BeppeTemp/cartographer/internal/configurator"
-	"github.com/BeppeTemp/cartographer/internal/provisioning"
 	"github.com/BeppeTemp/cartographer/internal/service"
 )
 
@@ -29,8 +28,15 @@ var (
 // configured server: in-sync or drift, with added/updated/removed detail.
 // Exit codes: 0 in-sync, 1 drift, 2 error (missing config, unreachable server, ...).
 func cmdStatus(args []string) int {
-	fs := flag.NewFlagSet("status", flag.ExitOnError)
-	fs.Parse(args)
+	output, remaining, err := outputFlag(args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		return 2
+	}
+	if len(remaining) != 0 {
+		fmt.Fprintln(os.Stderr, "Error: usage: cartographer status [--output table|json]")
+		return 2
+	}
 
 	dir, err := clientconfig.TargetDir()
 	if err != nil {
@@ -43,75 +49,45 @@ func cmdStatus(args []string) int {
 		return 2
 	}
 	if len(cfg.Agents) == 0 {
+		return renderStatus(output, emptySnapshot(), 0)
+	}
+	s := snapshotForConfig(dir, cfg, true)
+	code := 0
+	if s.State == "drift" {
+		code = 1
+	}
+	if s.State == "unavailable" || s.State == "error" {
+		code = 2
+	}
+	return renderStatus(output, s, code)
+}
+
+func renderStatus(output string, s statusSnapshot, code int) int {
+	if output == "json" {
+		_ = json.NewEncoder(os.Stdout).Encode(s)
+		return code
+	}
+	if s.State == "not_configured" {
 		fmt.Println("no agent connected (run `cartographer connect`)")
-		return 0
+		return code
 	}
-
-	printVersionStatus(cfg)
-
-	m, err := statusManifestFn(cfg)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error:", err)
-		return 2
+	if s.Reachable {
+		fmt.Printf("client %s — server %s (%s)\n", s.Client, s.Server, s.ServerURL)
+	} else if s.Error != nil {
+		fmt.Println(s.Error.Message)
 	}
-	// cfg.Trust (persisted at connect time, see D54) upgrades kb:-sourced
-	// artifacts to Signed:true before the diff, so the reported status is
-	// honest: a trusted server never shows a leftover "needs approval".
-	m = upgradeTrustedManifest(m, cfg.Trust)
-
-	lockFile, err := provisioning.ReadLockFile(lockFilePath(dir))
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error:", err)
-		return 2
-	}
-
-	drift := false
-	for _, p := range cfg.Agents {
-		lock := lockFile.ForProvider(p)
-		// Diff and counts only over the kinds the provider supports (see
-		// FilterForProvider): hook does not count as drift for opencode & co.
-		// (agent does for opencode, D55 — it stays excluded only for codex/kiro).
-		pm := provisioning.FilterForProvider(m, configurator.Provider(p))
-		d := provisioning.ComputeDiff(pm, lock)
-		if d.InSync {
-			fmt.Printf("[%s] in-sync (revision %s)\n", p, pm.Revision)
-			if kindLine := formatKindStatus(pm, lock); kindLine != "" {
-				fmt.Printf("  %s\n", kindLine)
-			}
-			continue
-		}
-		drift = true
-		fmt.Printf("[%s] drift (manifest %s, lock %s)\n", p, pm.Revision, lock.AppliedRevision)
-		if kindLine := formatKindStatus(pm, lock); kindLine != "" {
-			fmt.Printf("  %s\n", kindLine)
-		}
-		unsigned := false
-		for _, a := range d.Added {
-			fmt.Printf("  + %s/%s [%s] signed=%v\n", a.Kind, a.Name, a.Source, a.Signed)
-			unsigned = unsigned || !a.Signed
-			if a.Kind == "hook" {
-				fmt.Printf("    new hook: after the sync, add the entry to settings.json manually (see hook.json in .claude/hooks/%s/)\n", a.Name)
-			}
-		}
-		for _, a := range d.Updated {
-			fmt.Printf("  ~ %s/%s [%s] signed=%v\n", a.Kind, a.Name, a.Source, a.Signed)
-			unsigned = unsigned || !a.Signed
-			if a.Kind == "hook" {
-				fmt.Printf("    hook updated: after the sync, verify the entry in settings.json (see hook.json in .claude/hooks/%s/)\n", a.Name)
-			}
-		}
-		for _, mf := range d.Removed {
-			fmt.Printf("  - %s/%s (%s)\n", mf.Kind, mf.Name, mf.Path)
-		}
-		if unsigned {
-			fmt.Printf("  to approve the unsigned artifacts run: %s\n", autoTrustCommand())
+	if s.State == "version_skew" {
+		fmt.Printf("version skew: client %s ≠ server %s\n", s.Client, s.Server)
+		if s.Service != nil && s.Service.Installed {
+			fmt.Println("local service may still run the old binary — run: cartographer service restart")
 		}
 	}
-
-	if drift {
-		return 1
+	for _, p := range s.Providers {
+		if p.Connected {
+			fmt.Printf("[%s] %s\n", p.Name, strings.ReplaceAll(p.State, "_", "-"))
+		}
 	}
-	return 0
+	return code
 }
 
 // printVersionStatus reports the binary versions before the artifact status.

--- a/cmd/cartographer/status.go
+++ b/cmd/cartographer/status.go
@@ -83,8 +83,44 @@ func renderStatus(output string, s statusSnapshot, code int) int {
 		}
 	}
 	for _, p := range s.Providers {
-		if p.Connected {
+		if !p.Connected {
+			continue
+		}
+		if p.State == "in_sync" {
+			fmt.Printf("[%s] in-sync (revision %s)\n", p.Name, p.Revision)
+			if p.Kinds != "" {
+				fmt.Printf("  %s\n", p.Kinds)
+			}
+			continue
+		}
+		if p.State != "drift" {
 			fmt.Printf("[%s] %s\n", p.Name, strings.ReplaceAll(p.State, "_", "-"))
+			continue
+		}
+		fmt.Printf("[%s] drift (manifest %s, lock %s)\n", p.Name, p.Revision, p.LockRevision)
+		if p.Kinds != "" {
+			fmt.Printf("  %s\n", p.Kinds)
+		}
+		unsigned := false
+		for _, a := range p.Added {
+			fmt.Printf("  + %s/%s [%s] signed=%v\n", a.Kind, a.Name, a.Source, a.Signed)
+			unsigned = unsigned || !a.Signed
+			if a.Kind == "hook" {
+				fmt.Printf("    new hook: after the sync, add the entry to settings.json manually (see hook.json in .claude/hooks/%s/)\n", a.Name)
+			}
+		}
+		for _, a := range p.Updated {
+			fmt.Printf("  ~ %s/%s [%s] signed=%v\n", a.Kind, a.Name, a.Source, a.Signed)
+			unsigned = unsigned || !a.Signed
+			if a.Kind == "hook" {
+				fmt.Printf("    hook updated: after the sync, verify the entry in settings.json (see hook.json in .claude/hooks/%s/)\n", a.Name)
+			}
+		}
+		for _, a := range p.Removed {
+			fmt.Printf("  - %s/%s (%s)\n", a.Kind, a.Name, a.Path)
+		}
+		if unsigned {
+			fmt.Printf("  to approve the unsigned artifacts run: %s\n", autoTrustCommand())
 		}
 	}
 	return code

--- a/cmd/cartographer/status_snapshot.go
+++ b/cmd/cartographer/status_snapshot.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/BeppeTemp/cartographer/internal/agents"
+	"github.com/BeppeTemp/cartographer/internal/client"
+	"github.com/BeppeTemp/cartographer/internal/clientconfig"
+	"github.com/BeppeTemp/cartographer/internal/configurator"
+	"github.com/BeppeTemp/cartographer/internal/provisioning"
+	"github.com/BeppeTemp/cartographer/internal/service"
+)
+
+// statusSchema is deliberately versioned: scripts can reject incompatible
+// additions while table output remains a human convenience.
+const statusSchema = "cartographer.status/v1"
+
+type statusError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Cause   string `json:"cause,omitempty"`
+}
+
+type providerStatus struct {
+	Name      string `json:"name"`
+	Installed bool   `json:"installed"`
+	Connected bool   `json:"connected"`
+	State     string `json:"state"`
+	Added     int    `json:"added,omitempty"`
+	Updated   int    `json:"updated,omitempty"`
+	Removed   int    `json:"removed,omitempty"`
+}
+
+type serviceSnapshot struct {
+	Installed bool   `json:"installed"`
+	Running   bool   `json:"running"`
+	Healthy   bool   `json:"healthy"`
+	HTTPAddr  string `json:"http_addr,omitempty"`
+}
+
+// statusSnapshot has no renderer-specific fields and is the single remote
+// read used by status and the dashboard. Provider states are explicit so one
+// server failure cannot turn into several conflicting error messages.
+type statusSnapshot struct {
+	Schema    string           `json:"schema_version"`
+	ServerURL string           `json:"server_url,omitempty"`
+	Client    string           `json:"client_version"`
+	Server    string           `json:"server_version,omitempty"`
+	Reachable bool             `json:"reachable"`
+	Ready     *bool            `json:"ready,omitempty"`
+	KBs       []string         `json:"kbs,omitempty"`
+	Providers []providerStatus `json:"providers"`
+	Artifacts int              `json:"artifact_count"`
+	State     string           `json:"state"`
+	Error     *statusError     `json:"error,omitempty"`
+	Service   *serviceSnapshot `json:"service,omitempty"`
+}
+
+func classifyNetworkError(endpoint string, err error) statusError {
+	code := "request_failed"
+	if errors.Is(err, client.ErrUnauthorized) {
+		code = "unauthorized"
+	} else {
+		var dnsErr *net.DNSError
+		var opErr *net.OpError
+		switch {
+		case errors.As(err, &dnsErr):
+			code = "dns_failed"
+		case errors.As(err, &opErr):
+			code = "unreachable"
+		}
+	}
+	action := "check the configured URL"
+	if isLoopbackURL(endpoint) {
+		action = "check `cartographer service status`"
+	}
+	return statusError{Code: code, Message: fmt.Sprintf("could not reach %s; %s", endpoint, action), Cause: err.Error()}
+}
+
+func outputFlag(args []string) (string, []string, error) {
+	output := "table"
+	remaining := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--output" && i+1 < len(args) {
+			output, i = args[i+1], i+1
+			continue
+		}
+		if strings.HasPrefix(args[i], "--output=") {
+			output = strings.TrimPrefix(args[i], "--output=")
+			continue
+		}
+		remaining = append(remaining, args[i])
+	}
+	if output != "table" && output != "json" {
+		return "", nil, fmt.Errorf("invalid --output %q (want table|json)", output)
+	}
+	return output, remaining, nil
+}
+
+func snapshotForConfig(dir string, cfg *clientconfig.Config, includeService bool) statusSnapshot {
+	s := statusSnapshot{Schema: statusSchema, Client: version, State: "in_sync", Providers: providerStatuses(cfg), ServerURL: cfg.ServerURL}
+	if includeService && isLoopbackURL(cfg.ServerURL) {
+		if st, err := statusServiceFn(); err == nil {
+			s.Service = &serviceSnapshot{st.Installed, st.Running, st.Healthy, st.HTTPAddr}
+		}
+	}
+	health, err := statusHealthFn(cfg)
+	if err != nil {
+		s.State = "unavailable"
+		e := classifyNetworkError(cfg.ServerURL, err)
+		s.Error = &e
+		for i := range s.Providers {
+			if s.Providers[i].Connected {
+				s.Providers[i].State = "unknown"
+			}
+		}
+		return s
+	}
+	s.Reachable, s.Server, s.Ready = true, health.Version, health.Ready
+	if health.KBs != nil {
+		for _, kb := range *health.KBs {
+			s.KBs = append(s.KBs, kb.Name)
+		}
+	}
+	m, err := statusManifestFn(cfg)
+	if err != nil {
+		s.State = "unavailable"
+		e := classifyNetworkError(cfg.ServerURL, err)
+		s.Error = &e
+		for i := range s.Providers {
+			if s.Providers[i].Connected {
+				s.Providers[i].State = "unknown"
+			}
+		}
+		return s
+	}
+	m = upgradeTrustedManifest(m, cfg.Trust)
+	s.Artifacts = len(m.Artifacts)
+	lockFile, err := provisioning.ReadLockFile(lockFilePath(dir))
+	if err != nil {
+		s.State = "error"
+		s.Error = &statusError{Code: "lockfile_failed", Message: "could not read local sync state", Cause: err.Error()}
+		return s
+	}
+	for i := range s.Providers {
+		if !s.Providers[i].Connected {
+			continue
+		}
+		pm := provisioning.FilterForProvider(m, configurator.Provider(s.Providers[i].Name))
+		d := provisioning.ComputeDiff(pm, lockFile.ForProvider(s.Providers[i].Name))
+		if d.InSync {
+			s.Providers[i].State = "in_sync"
+			continue
+		}
+		s.Providers[i].State, s.Providers[i].Added, s.Providers[i].Updated, s.Providers[i].Removed = "drift", len(d.Added), len(d.Updated), len(d.Removed)
+		s.State = "drift"
+	}
+	if s.Server != "" && s.Client != "" && s.Client != "dev" && s.Server != "dev" && s.Client != s.Server && s.State == "in_sync" {
+		s.State = "version_skew"
+	}
+	return s
+}
+
+func providerStatuses(cfg *clientconfig.Config) []providerStatus {
+	connected := map[string]bool{}
+	if cfg != nil {
+		for _, p := range cfg.Agents {
+			connected[p] = true
+		}
+	}
+	detected := agents.Detect()
+	out := make([]providerStatus, len(detected))
+	for i, a := range detected {
+		state := "not_connected"
+		if connected[string(a.Provider)] {
+			state = "unknown"
+		}
+		out[i] = providerStatus{Name: string(a.Provider), Installed: a.Installed, Connected: connected[string(a.Provider)], State: state}
+	}
+	return out
+}
+
+func emptySnapshot() statusSnapshot {
+	return statusSnapshot{Schema: statusSchema, Client: version, State: "not_configured", Providers: providerStatuses(nil)}
+}
+
+func effectiveEndpoint(raw string) string {
+	if u, err := url.Parse(raw); err == nil {
+		return u.String()
+	}
+	return raw
+}
+
+var _ = service.Status{}

--- a/cmd/cartographer/status_snapshot.go
+++ b/cmd/cartographer/status_snapshot.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"net/url"
 	"strings"
 
 	"github.com/BeppeTemp/cartographer/internal/agents"
@@ -12,7 +11,6 @@ import (
 	"github.com/BeppeTemp/cartographer/internal/clientconfig"
 	"github.com/BeppeTemp/cartographer/internal/configurator"
 	"github.com/BeppeTemp/cartographer/internal/provisioning"
-	"github.com/BeppeTemp/cartographer/internal/service"
 )
 
 // statusSchema is deliberately versioned: scripts can reject incompatible
@@ -26,13 +24,24 @@ type statusError struct {
 }
 
 type providerStatus struct {
-	Name      string `json:"name"`
-	Installed bool   `json:"installed"`
-	Connected bool   `json:"connected"`
-	State     string `json:"state"`
-	Added     int    `json:"added,omitempty"`
-	Updated   int    `json:"updated,omitempty"`
-	Removed   int    `json:"removed,omitempty"`
+	Name         string           `json:"name"`
+	Installed    bool             `json:"installed"`
+	Connected    bool             `json:"connected"`
+	State        string           `json:"state"`
+	Revision     string           `json:"revision,omitempty"`
+	LockRevision string           `json:"lock_revision,omitempty"`
+	Kinds        string           `json:"kind_status,omitempty"`
+	Added        []statusArtifact `json:"added,omitempty"`
+	Updated      []statusArtifact `json:"updated,omitempty"`
+	Removed      []statusArtifact `json:"removed,omitempty"`
+}
+
+type statusArtifact struct {
+	Kind   string `json:"kind"`
+	Name   string `json:"name"`
+	Source string `json:"source,omitempty"`
+	Path   string `json:"path,omitempty"`
+	Signed bool   `json:"signed,omitempty"`
 }
 
 type serviceSnapshot struct {
@@ -152,17 +161,38 @@ func snapshotForConfig(dir string, cfg *clientconfig.Config, includeService bool
 		}
 		pm := provisioning.FilterForProvider(m, configurator.Provider(s.Providers[i].Name))
 		d := provisioning.ComputeDiff(pm, lockFile.ForProvider(s.Providers[i].Name))
+		p := &s.Providers[i]
+		p.Revision = pm.Revision
+		p.LockRevision = lockFile.ForProvider(p.Name).AppliedRevision
+		p.Kinds = formatKindStatus(pm, lockFile.ForProvider(p.Name))
 		if d.InSync {
-			s.Providers[i].State = "in_sync"
+			p.State = "in_sync"
 			continue
 		}
-		s.Providers[i].State, s.Providers[i].Added, s.Providers[i].Updated, s.Providers[i].Removed = "drift", len(d.Added), len(d.Updated), len(d.Removed)
+		p.State = "drift"
+		p.Added, p.Updated, p.Removed = snapshotArtifacts(d.Added), snapshotArtifacts(d.Updated), snapshotRemoved(d.Removed)
 		s.State = "drift"
 	}
 	if s.Server != "" && s.Client != "" && s.Client != "dev" && s.Server != "dev" && s.Client != s.Server && s.State == "in_sync" {
 		s.State = "version_skew"
 	}
 	return s
+}
+
+func snapshotArtifacts(artifacts []provisioning.Artifact) []statusArtifact {
+	out := make([]statusArtifact, len(artifacts))
+	for i, a := range artifacts {
+		out[i] = statusArtifact{Kind: a.Kind, Name: a.Name, Source: a.Source, Signed: a.Signed}
+	}
+	return out
+}
+
+func snapshotRemoved(files []provisioning.ManagedFile) []statusArtifact {
+	out := make([]statusArtifact, len(files))
+	for i, f := range files {
+		out[i] = statusArtifact{Kind: f.Kind, Name: f.Name, Path: f.Path}
+	}
+	return out
 }
 
 func providerStatuses(cfg *clientconfig.Config) []providerStatus {
@@ -187,12 +217,3 @@ func providerStatuses(cfg *clientconfig.Config) []providerStatus {
 func emptySnapshot() statusSnapshot {
 	return statusSnapshot{Schema: statusSchema, Client: version, State: "not_configured", Providers: providerStatuses(nil)}
 }
-
-func effectiveEndpoint(raw string) string {
-	if u, err := url.Parse(raw); err == nil {
-		return u.String()
-	}
-	return raw
-}
-
-var _ = service.Status{}

--- a/cmd/cartographer/status_snapshot_test.go
+++ b/cmd/cartographer/status_snapshot_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/BeppeTemp/cartographer/internal/client"
+)
+
+func TestStatusJSONSchemaAndStates(t *testing.T) {
+	ready := true
+	cases := []statusSnapshot{
+		{Schema: statusSchema, State: "in_sync", Reachable: true, Ready: &ready, Providers: []providerStatus{{Name: "claude", Connected: true, State: "in_sync"}}},
+		{Schema: statusSchema, State: "not_configured", Providers: []providerStatus{}},
+		{Schema: statusSchema, State: "unavailable", Error: &statusError{Code: "unreachable", Cause: "dial"}, Providers: []providerStatus{{Name: "codex", Connected: true, State: "unknown"}}},
+		{Schema: statusSchema, State: "drift", Providers: []providerStatus{{Name: "claude", Connected: true, State: "drift", Added: []statusArtifact{{Kind: "hook", Name: "x"}}}}},
+		{Schema: statusSchema, State: "version_skew", Server: "v1", Client: "v2"},
+		{Schema: statusSchema, State: "stopped", Service: &serviceSnapshot{Installed: true}},
+	}
+	for _, s := range cases {
+		out := withStdout(t, func() { renderStatus("json", s, 0) })
+		var got statusSnapshot
+		if err := json.Unmarshal([]byte(out), &got); err != nil {
+			t.Fatalf("JSON contaminated: %v: %q", err, out)
+		}
+		if got.Schema != statusSchema {
+			t.Fatalf("schema=%q", got.Schema)
+		}
+	}
+}
+
+func TestClassifyNetworkErrorAndOutputValidation(t *testing.T) {
+	if got := classifyNetworkError("http://127.0.0.1:39273/mcp", errors.New("boom")); !strings.Contains(got.Message, "service status") {
+		t.Fatalf("loopback hint: %+v", got)
+	}
+	if got := classifyNetworkError("https://x/mcp", client.ErrUnauthorized); got.Code != "unauthorized" {
+		t.Fatalf("auth code: %+v", got)
+	}
+	for _, args := range [][]string{{"--output", "yaml"}, {"--output=yaml"}} {
+		if _, _, err := outputFlag(args); err == nil {
+			t.Fatalf("%v accepted", args)
+		}
+	}
+	if code := cmdAgents([]string{"--output", "yaml"}); code != 2 {
+		t.Fatalf("agents exit=%d", code)
+	}
+	if code := cmdServiceStatus([]string{"--output", "yaml"}); code != 2 {
+		t.Fatalf("service exit=%d", code)
+	}
+}
+
+func TestStatusTableRetainsDriftDetails(t *testing.T) {
+	s := statusSnapshot{Schema: statusSchema, Reachable: true, Client: "v1", Server: "v1", ServerURL: "http://x/mcp", State: "drift", Providers: []providerStatus{{Name: "claude", Connected: true, State: "drift", Revision: "new", LockRevision: "old", Kinds: "skill 0/1", Added: []statusArtifact{{Kind: "hook", Name: "h", Source: "kb:x", Signed: false}}, Updated: []statusArtifact{{Kind: "skill", Name: "s", Source: "kb:x", Signed: true}}, Removed: []statusArtifact{{Kind: "agent", Name: "a", Path: "a.json"}}}}}
+	out := withStdout(t, func() { renderStatus("table", s, 1) })
+	for _, want := range []string{"drift (manifest new, lock old)", "skill 0/1", "+ hook/h [kb:x] signed=false", "new hook:", "~ skill/s [kb:x] signed=true", "- agent/a (a.json)", "cartographer sync --auto-trust"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in %s", want, out)
+		}
+	}
+}

--- a/cmd/cartographer/tui.go
+++ b/cmd/cartographer/tui.go
@@ -761,7 +761,7 @@ func (m Model) View() string {
 	fmt.Fprintf(&b, "%s %s\n%s\n\n",
 		styleTitle.Render("Cartographer"),
 		styleSubtitle.Render(displayVersion(m.version)),
-		styleSubtitle.Render(m.dir))
+		styleSubtitle.Render(compactForWidth(m.dir, m.width)))
 
 	switch m.screen {
 	case screenConnect:
@@ -790,14 +790,14 @@ func (m Model) View() string {
 
 	switch m.screen {
 	case screenConnect:
-		b.WriteString(styleFooter.Render("tab/shift+tab move · space toggle auth/trust · enter next/submit · esc cancel · ctrl+c quit"))
+		b.WriteString(styleFooter.Render(wrapForWidth("tab/shift+tab move · space toggle auth/trust · enter next/submit · esc cancel · ctrl+c quit", m.width-6)))
 	case screenConfirmDisconnect:
-		b.WriteString(styleFooter.Render("←/→ select · enter confirm · y/n shortcut · esc cancel · ctrl+c quit"))
+		b.WriteString(styleFooter.Render(wrapForWidth("←/→ select · enter confirm · y/n shortcut · esc cancel · ctrl+c quit", m.width-6)))
 	default:
 		if len(m.rows) > 0 && m.rows[m.cursor].Connected {
-			b.WriteString(styleFooter.Render("↑/↓ move · enter/s sync · S sync all · d disconnect · r refresh · q quit"))
+			b.WriteString(styleFooter.Render(wrapForWidth("↑/↓ move · enter/s sync · S sync all · d disconnect · r refresh · q quit", m.width-6)))
 		} else {
-			b.WriteString(styleFooter.Render("↑/↓ move · enter connect · r refresh · q quit"))
+			b.WriteString(styleFooter.Render(wrapForWidth("↑/↓ move · enter connect · r refresh · q quit", m.width-6)))
 		}
 	}
 
@@ -878,13 +878,13 @@ func (m Model) viewServerPanel() string {
 	state := strings.ReplaceAll(s.State, "_", "-")
 	line := fmt.Sprintf("Server  %s  %s", compactForWidth(s.ServerURL, m.width), state)
 	if s.Reachable {
-		line += fmt.Sprintf("  client %s · server %s", s.Client, s.Server)
+		line += fmt.Sprintf("  ready=%s  client %s · server %s", readinessLabel(s.Ready), s.Client, s.Server)
 	}
 	if len(s.KBs) > 0 {
 		line += "  KBs " + strings.Join(s.KBs, ", ")
 	}
 	if s.Error != nil {
-		line += "\n  " + s.Error.Message
+		line += "\n  " + wrapForWidth(s.Error.Message, m.width-8)
 	}
 	if s.Service != nil {
 		line += fmt.Sprintf("\n  local service: installed=%t running=%t", s.Service.Installed, s.Service.Running)
@@ -903,6 +903,32 @@ func compactForWidth(s string, width int) string {
 	return s[:limit/2] + "…" + s[len(s)-(limit-limit/2-1):]
 }
 
+func readinessLabel(ready *bool) string {
+	if ready == nil {
+		return "unknown"
+	}
+	if *ready {
+		return "ready"
+	}
+	return "not-ready"
+}
+
+func wrapForWidth(s string, width int) string {
+	if width <= 0 || len(s) <= width {
+		return s
+	}
+	var lines []string
+	for len(s) > width {
+		cut := strings.LastIndex(s[:width+1], " ")
+		if cut <= 0 {
+			cut = width
+		}
+		lines = append(lines, s[:cut])
+		s = strings.TrimSpace(s[cut:])
+	}
+	return strings.Join(append(lines, s), "\n")
+}
+
 func (m Model) viewConfirmDisconnect() string {
 	if m.disconnecting {
 		return fmt.Sprintf("Disconnect %s?\n\n%s disconnecting…", m.confirmProvider, m.spinner.View())
@@ -913,8 +939,7 @@ func (m Model) viewConfirmDisconnect() string {
 	} else {
 		no = styleSelected.Render("> no <")
 	}
-	return fmt.Sprintf("Disconnect %s? This removes its MCP config entry and managed artifacts.\n\n   %s   %s",
-		m.confirmProvider, yes, no)
+	return fmt.Sprintf("%s\n\n   %s   %s", wrapForWidth(fmt.Sprintf("Disconnect %s? This removes its MCP config entry and managed artifacts.", m.confirmProvider), m.width-6), yes, no)
 }
 
 // displayVersion normalizes the build version for the title bar: the

--- a/cmd/cartographer/tui.go
+++ b/cmd/cartographer/tui.go
@@ -89,6 +89,9 @@ type Model struct {
 	screen  screen
 	message string
 	err     error
+	// snapshot is shared with the non-interactive status command. It gives the
+	// dashboard one server-level explanation instead of repeating it per row.
+	snapshot *statusSnapshot
 
 	formProvider string
 	connectForm  connectFormModel
@@ -115,6 +118,7 @@ type Model struct {
 // keyed by provider name. Missing keys mean "leave SkillStatus unchanged".
 type remoteStatusMsg struct {
 	statuses map[string]string
+	snapshot statusSnapshot
 }
 
 // connectDoneMsg carries the result of a connectCmd run.
@@ -261,43 +265,16 @@ func loadRemoteStatusCmd(dir string) tea.Cmd {
 	return func() tea.Msg {
 		cfg, err := clientconfig.Load(dir)
 		if err != nil || len(cfg.Agents) == 0 {
-			return remoteStatusMsg{}
+			return remoteStatusMsg{snapshot: emptySnapshot()}
 		}
-
+		s := snapshotForConfig(dir, cfg, true)
 		statuses := make(map[string]string, len(cfg.Agents))
-		m, err := fetchMergedManifest(cfg)
-		if err != nil {
-			for _, p := range cfg.Agents {
-				statuses[p] = "server unreachable"
+		for _, p := range s.Providers {
+			if p.Connected {
+				statuses[p.Name] = strings.ReplaceAll(p.State, "_", "-")
 			}
-			return remoteStatusMsg{statuses: statuses}
 		}
-		// cfg.Trust (persisted at connect time, D54) upgrades kb:-sourced
-		// artifacts to Signed:true before the diff, matching cmdStatus.
-		m = upgradeTrustedManifest(m, cfg.Trust)
-
-		lockFile, err := provisioning.ReadLockFile(lockFilePath(dir))
-		if err != nil {
-			for _, p := range cfg.Agents {
-				statuses[p] = fmt.Sprintf("error: %v", err)
-			}
-			return remoteStatusMsg{statuses: statuses}
-		}
-
-		for _, p := range cfg.Agents {
-			lock := lockFile.ForProvider(p)
-			// Only the kinds the provider supports (see FilterForProvider): a
-			// hook opencode cannot materialize (or an agent for codex/kiro —
-			// D55) is not drift.
-			pm := provisioning.FilterForProvider(m, configurator.Provider(p))
-			d := provisioning.ComputeDiff(pm, lock)
-			status := formatDiffStatus(d)
-			if kindLine := formatKindStatus(pm, lock); kindLine != "" {
-				status += "  (" + kindLine + ")"
-			}
-			statuses[p] = status
-		}
-		return remoteStatusMsg{statuses: statuses}
+		return remoteStatusMsg{statuses: statuses, snapshot: s}
 	}
 }
 
@@ -498,6 +475,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case remoteStatusMsg:
 		m.loading = false
+		m.snapshot = &msg.snapshot
 		for i := range m.rows {
 			if !m.rows[i].Connected {
 				continue
@@ -611,6 +589,21 @@ func (m Model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, loadRemoteStatusCmd(m.dir)
 		}
 		return m, nil
+
+	case "S":
+		var cmds []tea.Cmd
+		for _, row := range m.rows {
+			if row.Connected {
+				cmds = append(cmds, syncCmd(string(row.Provider), m.dir))
+			}
+		}
+		if len(cmds) == 0 {
+			return m, nil
+		}
+		m.loading = true
+		m.message = "syncing all connected providers…"
+		m.err = nil
+		return m, tea.Batch(cmds...)
 
 	case "enter", "s":
 		if len(m.rows) == 0 {
@@ -773,6 +766,7 @@ func (m Model) View() string {
 	switch m.screen {
 	case screenConnect:
 		form := m.connectForm
+		form.Width = m.width
 		form.Submitting = m.probing || m.submitting
 		if m.probing {
 			form.SubmittingLabel = "probing the server…"
@@ -800,7 +794,11 @@ func (m Model) View() string {
 	case screenConfirmDisconnect:
 		b.WriteString(styleFooter.Render("←/→ select · enter confirm · y/n shortcut · esc cancel · ctrl+c quit"))
 	default:
-		b.WriteString(styleFooter.Render("↑/↓ move · enter connect/sync · s sync · d disconnect · r refresh · q quit"))
+		if len(m.rows) > 0 && m.rows[m.cursor].Connected {
+			b.WriteString(styleFooter.Render("↑/↓ move · enter/s sync · S sync all · d disconnect · r refresh · q quit"))
+		} else {
+			b.WriteString(styleFooter.Render("↑/↓ move · enter connect · r refresh · q quit"))
+		}
 	}
 
 	box := styleBorder
@@ -817,6 +815,9 @@ func (m Model) View() string {
 
 func (m Model) viewList() string {
 	var lines []string
+	if m.snapshot != nil {
+		lines = append(lines, m.viewServerPanel(), "")
+	}
 	for i, row := range m.rows {
 		cursor := "  "
 		if i == m.cursor {
@@ -867,6 +868,39 @@ func (m Model) viewList() string {
 		lines = append(lines, "no agents detected")
 	}
 	return strings.Join(lines, "\n")
+}
+
+func (m Model) viewServerPanel() string {
+	s := m.snapshot
+	if s == nil {
+		return ""
+	}
+	state := strings.ReplaceAll(s.State, "_", "-")
+	line := fmt.Sprintf("Server  %s  %s", compactForWidth(s.ServerURL, m.width), state)
+	if s.Reachable {
+		line += fmt.Sprintf("  client %s · server %s", s.Client, s.Server)
+	}
+	if len(s.KBs) > 0 {
+		line += "  KBs " + strings.Join(s.KBs, ", ")
+	}
+	if s.Error != nil {
+		line += "\n  " + s.Error.Message
+	}
+	if s.Service != nil {
+		line += fmt.Sprintf("\n  local service: installed=%t running=%t", s.Service.Installed, s.Service.Running)
+	}
+	return line
+}
+
+func compactForWidth(s string, width int) string {
+	if width <= 0 || width >= 80 || len(s) <= width/2 {
+		return s
+	}
+	limit := width / 2
+	if limit < 12 {
+		limit = 12
+	}
+	return s[:limit/2] + "…" + s[len(s)-(limit-limit/2-1):]
 }
 
 func (m Model) viewConfirmDisconnect() string {

--- a/cmd/cartographer/tui_test.go
+++ b/cmd/cartographer/tui_test.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -14,6 +16,59 @@ import (
 	"github.com/BeppeTemp/cartographer/internal/configurator"
 	"github.com/BeppeTemp/cartographer/internal/provisioning"
 )
+
+var ansiRE = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func TestViewResponsiveServerPanelAndWidth(t *testing.T) {
+	ready := true
+	for _, width := range []int{60, 80, 120} {
+		m := testModel()
+		m.width = width
+		m.snapshot = &statusSnapshot{Schema: statusSchema, ServerURL: "https://very-long.example.test/a/really/long/mcp/endpoint", Reachable: true, Ready: &ready, Client: "v1", Server: "v2", State: "version_skew"}
+		out := ansiRE.ReplaceAllString(m.View(), "")
+		if !strings.Contains(out, "Server") || !strings.Contains(out, "ready=ready") {
+			t.Fatalf("width %d misses server/readiness: %s", width, out)
+		}
+		for _, line := range strings.Split(out, "\n") {
+			if got := utf8.RuneCountInString(line); got > width {
+				t.Fatalf("width %d overflow %d: %q", width, got, line)
+			}
+		}
+	}
+}
+
+func TestViewServerFailureOnceAndSyncAll(t *testing.T) {
+	m := testModel()
+	m.width = 80
+	m.snapshot = &statusSnapshot{Schema: statusSchema, ServerURL: "http://127.0.0.1:39273/mcp", State: "unavailable", Error: &statusError{Message: "could not reach server; check service status"}}
+	out := ansiRE.ReplaceAllString(m.View(), "")
+	if strings.Count(out, "could not reach server") != 1 {
+		t.Fatalf("server error repeated: %s", out)
+	}
+	next, cmd := m.Update(keyMsg("S"))
+	m = next.(Model)
+	if !m.loading || cmd == nil {
+		t.Fatal("S must sync all connected providers")
+	}
+}
+
+func TestNarrowFailureAndConfirmationDoNotOverflow(t *testing.T) {
+	for _, width := range []int{60, 80, 120} {
+		m := testModel()
+		m.width = width
+		m.snapshot = &statusSnapshot{Schema: statusSchema, State: "unavailable", Error: &statusError{Message: "could not reach https://a-very-long-endpoint.example.test/with/a/long/path; check cartographer service status"}}
+		m.screen, m.confirmProvider = screenConfirmDisconnect, "a-provider-with-a-long-name"
+		out := ansiRE.ReplaceAllString(m.View(), "")
+		for _, line := range strings.Split(out, "\n") {
+			if got := utf8.RuneCountInString(line); got > width {
+				t.Fatalf("width %d overflow %d: %q", width, got, line)
+			}
+		}
+		if !strings.Contains(out, "yes") {
+			t.Fatalf("width %d hides primary confirmation", width)
+		}
+	}
+}
 
 // testModel builds a minimal, deterministic Model for Update() tests, bypassing
 // newModel (which calls agents.Detect()/clientconfig.Load() against the real

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -16,6 +16,22 @@ materialization logic (`internal/provisioning`) are the same used server-side by
 
 ## Subcommands
 
+### Discovery, version and output formats
+
+Root help groups commands into Get started, Client, Server, Knowledge base and
+Diagnostics. `cartographer version` and `cartographer --version` are aliases;
+root and `service` help write to stdout and exit 0. Unknown commands only offer
+a correction for one command within edit distance two.
+
+`agents`, `status`, and `service status` accept `--output table|json` (table is
+the default). JSON is written only to stdout and uses schema
+`cartographer.status/v1`: it includes the schema version, effective server URL,
+client/server facts, provider states and artifact counts; when relevant it also
+contains native-service facts. State and error `code` fields are stable for
+automation; a wrapped low-level `cause` is retained in JSON only. `status`
+keeps exit 0 for in-sync, 1 for drift and 2 for configuration or operational
+errors. `service status` retains 0 running, 3 stopped and 4 not installed.
+
 ### `cartographer agents`
 
 Lists the four supported providers, whether they are installed on the machine (`internal/agents.Detect`:
@@ -147,6 +163,22 @@ counts (`provisioning.KindCounts`), e.g. `skill 4/5 · agent 2/2 · hook 1/1`. O
 prints the diff (added/updated/removed, with `signed`). Before the artifact report it prints the
 client and server versions. A non-`dev` mismatch is a warning only (it does not change the exit
 code); on loopback, an installed local service also gets a `cartographer service restart` hint.
+For an unavailable endpoint, the table names the configured endpoint once and
+suggests checking that URL (or `cartographer service status` for loopback);
+connected providers are reported as `unknown`, rather than repeating a network
+failure for each provider.
+
+### Dashboard
+
+With no subcommand in a TTY, the dashboard renders the same status snapshot as
+`status`. Its server panel shows the effective URL, reachability/readiness,
+versions, selected KBs and loopback native-service state. `Enter` connects a
+disconnected provider or syncs a connected one; `s` syncs the selected provider,
+`S` syncs all connected providers, `d` opens the disconnect confirmation and
+`r` refreshes. Unavailable actions are omitted from the contextual key map.
+At 60 columns it uses compact labels and shortened endpoints; 80 is the normal
+layout and 120 retains full endpoint and artifact detail. Failures keep the
+current selection and entered connect-form values.
 
 ### `cartographer sync`
 

--- a/docs/decisions/client-configurator.md
+++ b/docs/decisions/client-configurator.md
@@ -242,3 +242,23 @@ into a 400, without introducing a client-side multiplexing protocol.
 **Rationale.** D58's ownership model (comment markers + `internal/blocktext`) assumes the markers survive. They do not: Codex CLI re-serializes the whole `config.toml` whenever it persists its own settings (trusted hook hashes, `[tui]`, `[projects.*]`), emitting the tables in canonical form and dropping every comment. The tables survive, the markers do not, and `blocktext.Write` — which appends when it finds no markers — then declares `[mcp_servers.cartographer]` a second time: a duplicate key, so `codex` refuses to start. For hooks the file stays valid (an array-of-tables may repeat) and the hook simply fires twice, which is quieter and worse. Parsing the file as TOML would fix it and lose exactly what D58 exists to protect, so ownership is instead resolved by identity: a table we would write, outside every block of ours, is a copy of ours.
 
 **Consequences.** `connect`/`sync` self-heal an already-broken machine on the next run: no hand-editing, and nothing on the client's read path parses `config.toml`, so a duplicated file never blocks the repair. `[hooks.state."…"]` entries are deliberately **not** pruned: they are Codex's own bookkeeping (a trusted hash per hook, keyed by position), a stale one is inert because Codex gates it on a hash we do not compute, and deleting them would mean interpreting Codex's internals — the very format-awareness D58 rules out. `EnsureBootstrapHook` has no warnings channel and drops its repair message; the same repair on the MCP entry is reported, which is what makes the file visibly change. Table identity is the reason hooks are matched by command path and not by header: `[[hooks.PreToolUse]]` is shared by every hook on that event.
+
+---
+
+<a id="d113"></a>
+## D113 — One client status snapshot across CLI and dashboard
+
+**Status: implemented (2026-07-28).**
+
+**Decision.** Client status is collected once into a versioned,
+renderer-independent snapshot. Table commands, JSON output and the Bubble Tea
+dashboard consume that snapshot. A failed endpoint request produces one
+classified server error and marks connected provider state unknown; JSON keeps
+the wrapped cause while human output gives the endpoint and an actionable next
+step. Command discovery is grouped and conservative, and the dashboard adapts
+its presentation and visible actions to terminal width and selection.
+
+**Rationale.** Independent render paths had drifted into separate network calls
+and contradictory repeated errors. A small stable schema gives scripts a safe
+contract while keeping the terminal interface concise, and makes the dashboard
+an alternate view of the same facts rather than a second status implementation.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -22,6 +22,12 @@ client configuration.
 
 `make vet` runs `go vet ./...`. Both are required in CI.
 
+CLI JSON tests decode stdout as JSON and assert that diagnostics remain on
+stderr. Golden help is limited to 80 columns. Bubble Tea view/update tests use
+60, 80 and 120-column window messages, strip ANSI sequences before measuring
+line width, and cover healthy, unavailable, drift, connect retry, sync-all and
+disconnect confirmation states.
+
 ### Stdio smoke
 
 `make smoke` builds the binary, starts a temporary stdio server and verifies


### PR DESCRIPTION
## Summary

- group root command discovery, add version aliases, conservative suggestions, and service help semantics
- introduce the shared versioned status snapshot for table, JSON, and dashboard views
- add a server panel, responsive connect-form layout, contextual dashboard actions, and D113 documentation

## Validation

- `rtk go test ./cmd/cartographer` → exit 0
- `rtk make vet` → exit 0
- `rtk make build` → exit 0
- `rtk make test` → exit 0
- `rtk make smoke-http` → exit 0
- `rtk make e2e` → exit 0
- `rtk git diff --check` → exit 0

## Manual checklist

- [x] root grouped help and `version` / `--version` aliases
- [x] `service --help` uses stdout and exits 0
- [x] JSON redirection remains valid JSON with an unreachable configured endpoint
- [x] unreachable endpoint reports a single classified server error
- [x] dashboard layouts covered at 60/80/120 columns by deterministic tests

Generated with Codex

Closes #83