### PR TITLE
feat: verify provisioning artifacts cryptographically

### DIFF
--- a/cmd/cartographer/clientsync.go
+++ b/cmd/cartographer/clientsync.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/BeppeTemp/cartographer/internal/agents"
+	"github.com/BeppeTemp/cartographer/internal/artifactsig"
 	"github.com/BeppeTemp/cartographer/internal/client"
 	"github.com/BeppeTemp/cartographer/internal/clientconfig"
 	"github.com/BeppeTemp/cartographer/internal/configurator"
@@ -24,13 +26,15 @@ type pulledFileJSON struct {
 }
 
 type pulledArtifactJSON struct {
-	Kind        string           `json:"kind"`
-	Name        string           `json:"name"`
-	Source      string           `json:"source"`
-	Version     string           `json:"version,omitempty"`
-	ContentHash string           `json:"content_hash"`
-	Signed      bool             `json:"signed"`
-	Files       []pulledFileJSON `json:"files"`
+	Kind        string                 `json:"kind"`
+	Name        string                 `json:"name"`
+	Source      string                 `json:"source"`
+	Version     string                 `json:"version,omitempty"`
+	ContentHash string                 `json:"content_hash"`
+	Signed      bool                   `json:"signed"`
+	BuiltIn     bool                   `json:"built_in,omitempty"`
+	Signature   *artifactsig.Signature `json:"signature,omitempty"`
+	Files       []pulledFileJSON       `json:"files"`
 }
 
 type pulledManifestJSON struct {
@@ -70,6 +74,7 @@ func kbTargets(cfg *clientconfig.Config) []string {
 func fetchMergedManifest(cfg *clientconfig.Config) (provisioning.Manifest, error) {
 	token := resolveToken(cfg)
 	var all []provisioning.Artifact
+	seen := make(map[string]provisioning.Artifact)
 
 	for _, kbName := range kbTargets(cfg) {
 		c := client.New(cfg.ServerURL, token).WithKB(kbName)
@@ -94,15 +99,53 @@ func fetchMergedManifest(cfg *clientconfig.Config) (provisioning.Manifest, error
 				}
 				files[i] = provisioning.ArtifactFile{Path: pf.Path, Content: data, Executable: pf.Executable}
 			}
-			all = append(all, provisioning.Artifact{
+			if got := provisioning.ContentHashFiles(files); got != pa.ContentHash {
+				return provisioning.Manifest{}, fmt.Errorf("sync_pull: content hash mismatch for %s/%s", pa.Kind, pa.Name)
+			}
+			a := provisioning.Artifact{
 				Kind: pa.Kind, Name: pa.Name, Source: pa.Source, Version: pa.Version,
-				ContentHash: pa.ContentHash, Signed: pa.Signed, Files: files,
-			})
+				ContentHash: pa.ContentHash, BuiltIn: pa.BuiltIn, Signature: pa.Signature, Files: files,
+			}
+			key := a.Kind + "\x00" + a.Name + "\x00" + a.Source
+			if previous, exists := seen[key]; exists && !sameSignature(previous.Signature, a.Signature) {
+				return provisioning.Manifest{}, fmt.Errorf("sync_pull: conflicting signatures for %s/%s", a.Kind, a.Name)
+			}
+			seen[key] = a
+			all = append(all, a)
 		}
 	}
 
-	return provisioning.MergeArtifacts(all), nil
+	pins, err := pinnedPublicKeys(cfg)
+	if err != nil {
+		return provisioning.Manifest{}, err
+	}
+	return provisioning.VerifiedManifest(provisioning.MergeArtifacts(all), pins)
 }
+
+func sameSignature(a, b *artifactsig.Signature) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.Algorithm == b.Algorithm && a.KeyID == b.KeyID && a.EnvelopeVersion == b.EnvelopeVersion && a.Value == b.Value
+}
+
+func pinnedPublicKeys(cfg *clientconfig.Config) (map[string][]ed25519.PublicKey, error) {
+	pins := make(map[string][]ed25519.PublicKey)
+	for kbName, encoded := range cfg.SigningKeys {
+		for _, value := range encoded {
+			key, err := artifactsig.ParsePublicKey(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid signing key pin for KB %q: %w", kbName, err)
+			}
+			pins[kbName] = append(pins[kbName], key)
+		}
+	}
+	return pins, nil
+}
+
+// upgradeTrustedManifest remains the status-path compatibility hook. Trust is
+// authorization consumed by ApplyOptions, never a mutation of verification.
+func upgradeTrustedManifest(m provisioning.Manifest, trust bool) provisioning.Manifest { return m }
 
 // upgradeTrustedManifest returns a copy of m with every kb:-sourced artifact
 // upgraded to Signed:true when trust is true; m unchanged (same slice) when
@@ -119,20 +162,6 @@ func fetchMergedManifest(cfg *clientconfig.Config) (provisioning.Manifest, error
 // MCP server is an endpoint that receives the agent's data, a stricter policy
 // than the other kinds — it always needs its own approval at first appearance
 // and at every hash change, even with AutoTrust/cfg.Trust on.
-func upgradeTrustedManifest(m provisioning.Manifest, trust bool) provisioning.Manifest {
-	if !trust {
-		return m
-	}
-	artifacts := make([]provisioning.Artifact, len(m.Artifacts))
-	copy(artifacts, m.Artifacts)
-	for i := range artifacts {
-		if artifacts[i].Kind != "mcp" && strings.HasPrefix(artifacts[i].Source, "kb:") {
-			artifacts[i].Signed = true
-		}
-	}
-	return provisioning.Manifest{Revision: m.Revision, Artifacts: artifacts}
-}
-
 // materializeForProviders applies manifest m for each provider in providers,
 // persisting a single v2 LockFile at <targetDir>/.cartographer-sync.lock.json (one
 // Lock entry per provider). autoTrust upgrades kb:-sourced artifacts to Signed:true
@@ -143,8 +172,6 @@ func upgradeTrustedManifest(m provisioning.Manifest, trust bool) provisioning.Ma
 // expansion (D75 WP3) — this is the one place cmd/cartographer turns
 // ApplyOptions.ExpandPlaceholders on; internal/mcpserver never does.
 func materializeForProviders(m provisioning.Manifest, providers []string, targetDir string, autoTrust, dryRun bool, searchRoots []string, paths map[string]string) (map[string]provisioning.AppliedResult, error) {
-	mm := upgradeTrustedManifest(m, autoTrust)
-
 	lockPath := lockFilePath(targetDir)
 	lockFile, err := provisioning.ReadLockFile(lockPath)
 	if err != nil {
@@ -157,6 +184,7 @@ func materializeForProviders(m provisioning.Manifest, providers []string, target
 			Provider:           configurator.Provider(p),
 			BaseDir:            targetDir,
 			DryRun:             dryRun,
+			AutoTrust:          autoTrust,
 			Lock:               lockFile.ForProvider(p),
 			SkipLockWrite:      true,
 			ExpandPlaceholders: true,
@@ -167,7 +195,7 @@ func materializeForProviders(m provisioning.Manifest, providers []string, target
 		// unsupported kinds (e.g. hook outside Claude Code, or agent outside
 		// Claude Code/OpenCode — D55) are neither drift nor pending, they
 		// simply don't concern it.
-		applied, err := provisioning.Apply(provisioning.FilterForProvider(mm, configurator.Provider(p)), opts)
+		applied, err := provisioning.Apply(provisioning.FilterForProvider(m, configurator.Provider(p)), opts)
 		if err != nil {
 			return nil, fmt.Errorf("apply %s: %w", p, err)
 		}

--- a/cmd/cartographer/clientsync_test.go
+++ b/cmd/cartographer/clientsync_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/BeppeTemp/cartographer/internal/artifactsig"
 	"github.com/BeppeTemp/cartographer/internal/clientconfig"
 	"github.com/BeppeTemp/cartographer/internal/configurator"
 	"github.com/BeppeTemp/cartographer/internal/provisioning"
@@ -35,7 +38,13 @@ func TestPulledFileJSON_ExecutableBackwardCompatibility(t *testing.T) {
 
 func TestFetchMergedManifest_PreservesBinaryExecutableFilesThroughApply(t *testing.T) {
 	binary := []byte{0x00, 0xff, 0x80, 0x01}
-	const artifactHash = "binary-executable-hash"
+	first, err := base64.StdEncoding.DecodeString("LS0tXG5uYW1lOiB3aXJlXG5kZXNjcmlwdGlvbjogdGVzdFxuLS0tXG4=")
+	if err != nil {
+		t.Fatal(err)
+	}
+	artifactHash := provisioning.ContentHashFiles([]provisioning.ArtifactFile{
+		{Path: "SKILL.md", Content: first}, {Path: "run.bin", Content: binary, Executable: true},
+	})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mcp" {
 			http.NotFound(w, r)
@@ -47,7 +56,7 @@ func TestFetchMergedManifest_PreservesBinaryExecutableFilesThroughApply(t *testi
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Fatal(err)
 		}
-		payload := `{"revision":"wire-rev","artifacts":[{"kind":"skill","name":"wire","source":"kb:test","content_hash":"` + artifactHash + `","signed":true,"files":[{"path":"SKILL.md","content_b64":"LS0tXG5uYW1lOiB3aXJlXG5kZXNjcmlwdGlvbjogdGVzdFxuLS0tXG4=","executable":false},{"path":"run.bin","content_b64":"AP+AAQ==","executable":true}]}]}`
+		payload := `{"revision":"wire-rev","artifacts":[{"kind":"skill","name":"wire","source":"bundle","content_hash":"` + artifactHash + `","built_in":true,"files":[{"path":"SKILL.md","content_b64":"LS0tXG5uYW1lOiB3aXJlXG5kZXNjcmlwdGlvbjogdGVzdFxuLS0tXG4=","executable":false},{"path":"run.bin","content_b64":"AP+AAQ==","executable":true}]}]}`
 		if err := json.NewEncoder(w).Encode(map[string]any{
 			"jsonrpc": "2.0",
 			"id":      req.ID,
@@ -96,6 +105,106 @@ func TestFetchMergedManifest_PreservesBinaryExecutableFilesThroughApply(t *testi
 		if err != nil || info.Mode()&0o111 == 0 {
 			t.Fatalf("Apply(%s) mode = %v, err=%v", provider, info.Mode(), err)
 		}
+	}
+}
+
+func TestFetchMergedManifestVerifiesPinnedSignatureAndRejectsTampering(t *testing.T) {
+	key, err := artifactsig.ParseSeed(strings.Repeat("03", ed25519.SeedSize))
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := []provisioning.ArtifactFile{{Path: "SKILL.md", Content: []byte("skill")}}
+	hash := provisioning.ContentHashFiles(files)
+	identity := artifactsig.Identity{Source: "kb:homelab", Kind: "skill", Name: "signed", ContentHash: hash}
+	sig, err := artifactsig.Sign(key, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serve := func(content string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": map[string]any{"content": []map[string]string{{"type": "text", "text": content}}}})
+		}))
+	}
+	payloadFor := func(mutate func(map[string]any)) string {
+		copySig := *sig
+		artifact := map[string]any{
+			"kind": "skill", "name": "signed", "source": "kb:homelab", "content_hash": hash, "signature": &copySig,
+			"files": []map[string]any{{"path": "SKILL.md", "content_b64": base64.StdEncoding.EncodeToString(files[0].Content), "executable": false}},
+		}
+		if mutate != nil {
+			mutate(artifact)
+		}
+		payload, marshalErr := json.Marshal(map[string]any{"revision": "r", "artifacts": []map[string]any{artifact}})
+		if marshalErr != nil {
+			t.Fatal(marshalErr)
+		}
+		return string(payload)
+	}
+	payload := payloadFor(nil)
+	srv := serve(string(payload))
+	cfg := &clientconfig.Config{ServerURL: srv.URL, SigningKeys: map[string][]string{"homelab": {artifactsig.PublicKeyHex(key.Public().(ed25519.PublicKey))}}}
+	m, err := fetchMergedManifest(cfg)
+	srv.Close()
+	if err != nil || len(m.Artifacts) != 1 || !m.Artifacts[0].Signed {
+		t.Fatalf("verified manifest = %+v, err=%v", m, err)
+	}
+
+	target := t.TempDir()
+	if _, err := materializeForProviders(m, []string{"claude"}, target, false, false, nil, nil); err != nil {
+		t.Fatalf("materialize valid manifest: %v", err)
+	}
+	lockPath := filepath.Join(target, provisioning.LockFileName)
+	providerPath := filepath.Join(target, ".claude", "skills", "signed", "SKILL.md")
+	beforeState, err := os.ReadFile(providerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeLock, _ := os.ReadFile(lockPath)
+	for _, tc := range []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{"file bytes", func(a map[string]any) {
+			a["files"] = []map[string]any{{"path": "SKILL.md", "content_b64": base64.StdEncoding.EncodeToString([]byte("evil")), "executable": false}}
+		}},
+		{"executable mode", func(a map[string]any) {
+			a["files"] = []map[string]any{{"path": "SKILL.md", "content_b64": base64.StdEncoding.EncodeToString(files[0].Content), "executable": true}}
+		}},
+		{"path", func(a map[string]any) {
+			a["files"] = []map[string]any{{"path": "renamed.md", "content_b64": base64.StdEncoding.EncodeToString(files[0].Content), "executable": false}}
+		}},
+		{"source", func(a map[string]any) { a["source"] = "bundle" }},
+		{"kind", func(a map[string]any) { a["kind"] = "hook" }},
+		{"signature", func(a map[string]any) {
+			a["signature"].(*artifactsig.Signature).Value = base64.RawStdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))
+		}},
+		{"unknown key", func(a map[string]any) { a["signature"].(*artifactsig.Signature).KeyID = strings.Repeat("0", 64) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := serve(payloadFor(tc.mutate))
+			cfg.ServerURL = srv.URL
+			fetched, fetchErr := fetchMergedManifest(cfg)
+			srv.Close()
+			if fetchErr == nil {
+				_, fetchErr = materializeForProviders(fetched, []string{"claude"}, target, false, false, nil, nil)
+			}
+			if fetchErr == nil {
+				t.Fatal("tampered sync unexpectedly succeeded")
+			}
+			afterState, stateErr := os.ReadFile(providerPath)
+			afterLock, lockErr := os.ReadFile(lockPath)
+			if stateErr != nil || lockErr != nil || !bytes.Equal(beforeState, afterState) || !bytes.Equal(beforeLock, afterLock) {
+				t.Fatalf("tampering changed local state: state=%q/%v lock=%q/%v", afterState, stateErr, afterLock, lockErr)
+			}
+		})
+	}
+}
+
+func TestFetchMergedManifestRejectsMalformedConfiguredPin(t *testing.T) {
+	cfg := &clientconfig.Config{SigningKeys: map[string][]string{"homelab": {"not-a-public-key"}}}
+	if _, err := pinnedPublicKeys(cfg); err == nil || !strings.Contains(err.Error(), "invalid signing key pin") {
+		t.Fatalf("pinnedPublicKeys error = %v", err)
 	}
 }
 
@@ -164,23 +273,16 @@ func kbSkillManifest() provisioning.Manifest {
 	}
 }
 
-func TestUpgradeTrustedManifest_TrustSignsKBArtifacts(t *testing.T) {
+func TestAuthorizationDoesNotSetSigned(t *testing.T) {
 	m := kbSkillManifest()
-	got := upgradeTrustedManifest(m, true)
-	if !got.Artifacts[0].Signed {
-		t.Error("expected kb: artifact to be Signed=true when trust=true")
-	}
-	// original untouched.
 	if m.Artifacts[0].Signed {
-		t.Error("upgradeTrustedManifest must not mutate its input")
+		t.Fatal("test fixture must be unsigned")
 	}
-}
-
-func TestUpgradeTrustedManifest_NoTrustLeavesUnsigned(t *testing.T) {
-	m := kbSkillManifest()
-	got := upgradeTrustedManifest(m, false)
-	if got.Artifacts[0].Signed {
-		t.Error("expected kb: artifact to stay Signed=false when trust=false")
+	if _, err := materializeForProviders(m, []string{"claude"}, t.TempDir(), true, true, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if m.Artifacts[0].Signed {
+		t.Error("authorization must not mutate verification state")
 	}
 }
 
@@ -284,24 +386,19 @@ func TestMaterializeForProviders_Instructions_ClaudeEKiro(t *testing.T) {
 	}
 }
 
-// TestDiffWithTrust_NoNeedsApproval mirrors what cmdStatus/loadRemoteStatusCmd
-// do: upgradeTrustedManifest before ComputeDiff. With trust active, an added
-// kb: artifact must report Signed=true in the diff — not a leftover "needs
-// approval" — matching the real materialization outcome.
-func TestDiffWithTrust_NoNeedsApproval(t *testing.T) {
+func TestDiffWithTrustKeepsVerificationState(t *testing.T) {
 	m := kbSkillManifest()
-	trusted := upgradeTrustedManifest(m, true)
-	pm := provisioning.FilterForProvider(trusted, configurator.ProviderClaudeCode)
+	pm := provisioning.FilterForProvider(m, configurator.ProviderClaudeCode)
 	d := provisioning.ComputeDiff(pm, provisioning.Lock{})
 
 	if len(d.Added) != 1 {
 		t.Fatalf("expected 1 added artifact, got %d", len(d.Added))
 	}
-	if !d.Added[0].Signed {
-		t.Error("expected Added[0].Signed=true with trust active (no leftover needs-approval)")
+	if d.Added[0].Signed {
+		t.Error("trust must not change cryptographic verification state")
 	}
-	if got := formatDiffStatus(d); got != "drift +1 ~0 -0" {
-		t.Errorf("formatDiffStatus = %q, want no needs-approval suffix", got)
+	if got := formatDiffStatus(d); got != "drift +1 ~0 -0 (1 needs approval, use CLI --auto-trust)" {
+		t.Errorf("formatDiffStatus = %q", got)
 	}
 }
 

--- a/cmd/cartographer/connect.go
+++ b/cmd/cartographer/connect.go
@@ -19,6 +19,11 @@ import (
 	"github.com/BeppeTemp/cartographer/internal/service"
 )
 
+type repeatedString []string
+
+func (r *repeatedString) String() string         { return strings.Join(*r, ",") }
+func (r *repeatedString) Set(value string) error { *r = append(*r, value); return nil }
+
 // probeTimeout bounds probeServer's reachability check (D64): short enough
 // that a down server fails fast in the interactive form/CLI, well under the
 // client package's normal 30s HTTP timeout used for the real sync_pull calls.
@@ -242,6 +247,8 @@ func cmdConnect(args []string) int {
 	tokenEnv := fs.String("token-env", "CARTOGRAPHER_TOKENS", "Env var holding the bearer token")
 	dryRun := fs.Bool("dry-run", false, "Print what would be written without writing")
 	autoTrust := fs.Bool("auto-trust", false, "Trust KB-sourced skills without explicit signature")
+	var pinKeys repeatedString
+	fs.Var(&pinKeys, "pin-key", "Pin a KB Ed25519 public key as KB=PUBLIC_KEY (repeatable)")
 	noInput := fs.Bool("no-input", false, "Never open the interactive form, even in a TTY")
 	agentsCSV := fs.String("agents", "", "Comma-separated agent subset: claude,codex")
 	fs.Parse(rest)
@@ -286,6 +293,7 @@ func cmdConnect(args []string) int {
 		DryRun:    *dryRun,
 		AutoTrust: *autoTrust,
 		Trust:     settings.Trust,
+		PinKeys:   pinKeys,
 	}
 
 	if interactive {
@@ -444,7 +452,8 @@ type connectOptions struct {
 	// existing/default config, see cmdConnect) and persisted to
 	// .cartographer.yaml by doConnect. Unlike AutoTrust (a one-time flag),
 	// Trust applies to every future sync until changed again.
-	Trust bool
+	Trust   bool
+	PinKeys []string
 }
 
 // connectResult is the outcome of doConnect: which providers were connected, the
@@ -481,6 +490,15 @@ func doConnect(opts connectOptions) (connectResult, error) {
 	if err != nil {
 		existing = clientconfig.Default()
 	}
+	for _, pin := range opts.PinKeys {
+		kbName, key, found := strings.Cut(pin, "=")
+		if !found {
+			return connectResult{}, fmt.Errorf("invalid --pin-key %q (want KB=PUBLIC_KEY)", pin)
+		}
+		if err := existing.AddSigningKey(kbName, key); err != nil {
+			return connectResult{}, fmt.Errorf("invalid --pin-key %q: %w", pin, err)
+		}
+	}
 	kbs, healthListed, healthErr := enumerateKBs(opts.ServerURL, opts.Auth, opts.TokenEnv)
 	entryKBs := kbs
 	if healthErr != nil || !healthListed {
@@ -514,7 +532,7 @@ func doConnect(opts connectOptions) (connectResult, error) {
 	if healthErr == nil {
 		pullKBs = kbs
 	}
-	pullCfg := &clientconfig.Config{ServerURL: opts.ServerURL, ServerName: opts.Name, Auth: opts.Auth, TokenEnv: opts.TokenEnv, KBs: pullKBs}
+	pullCfg := &clientconfig.Config{ServerURL: opts.ServerURL, ServerName: opts.Name, Auth: opts.Auth, TokenEnv: opts.TokenEnv, KBs: pullKBs, SigningKeys: existing.SigningKeys}
 
 	res := connectResult{Providers: opts.Providers, ConfigsWritten: configsWritten, MCPEntries: entryNames(entries), Warnings: configWarnings}
 	if m, err := fetchMergedManifest(pullCfg); err != nil {

--- a/cmd/cartographer/serve.go
+++ b/cmd/cartographer/serve.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/ed25519"
 	"flag"
 	"fmt"
 	"log"
@@ -13,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/BeppeTemp/cartographer/internal/artifactsig"
 	"github.com/BeppeTemp/cartographer/internal/audit"
 	"github.com/BeppeTemp/cartographer/internal/auth"
 	"github.com/BeppeTemp/cartographer/internal/config"
@@ -249,8 +251,9 @@ func runServe(cfg *config.Config) {
 
 	seenNames := make(map[string]string) // name → first path seen
 	var kbs []*kb.KB
-	var kbNames []string        // index-aligned with kbs
-	var kbToolPrefixes []string // index-aligned with kbs (D102, "" = unprefixed)
+	var kbNames []string                       // index-aligned with kbs
+	var kbToolPrefixes []string                // index-aligned with kbs (D102, "" = unprefixed)
+	var kbArtifactSigners []ed25519.PrivateKey // index-aligned with kbs
 	for _, m := range mounts {
 		var k *kb.KB
 		var err error
@@ -304,9 +307,18 @@ func runServe(cfg *config.Config) {
 			log.Fatal(err)
 		}
 		seenNames[name] = m.Path
+		var artifactSigner ed25519.PrivateKey
+		if m.Spec.ArtifactSigningSeed != "" {
+			artifactSigner, err = artifactsig.ParseSeed(m.Spec.ArtifactSigningSeed)
+			if err != nil {
+				log.Fatalf("KB %q artifact signing seed invalid: %v", name, err)
+			}
+			log.Printf("KB %q provisioning artifact signing enabled (key ID %s)", name, artifactsig.KeyID(artifactSigner.Public().(ed25519.PublicKey)))
+		}
 		kbs = append(kbs, k)
 		kbNames = append(kbNames, name)
 		kbToolPrefixes = append(kbToolPrefixes, toolPrefix)
+		kbArtifactSigners = append(kbArtifactSigners, artifactSigner)
 		if _, ok := k.HasRemote(); kb.ShouldWarnGitIdentity(k.GitSync, ok, k.GitAuthorEmail) {
 			log.Printf("WARNING: KB %q commits will be authored as cartographer@localhost; forges with author push rules will reject the push", name)
 		}
@@ -348,19 +360,19 @@ func runServe(cfg *config.Config) {
 	}
 
 	if cfg.HTTP != "" {
-		serveHTTP(cfg.HTTP, kbs, kbNames, kbToolPrefixes, cfg.Auth, cfg.ToolsProfile, emb, vecStore, sqlIdxs, auditLog)
+		serveHTTP(cfg.HTTP, kbs, kbNames, kbToolPrefixes, kbArtifactSigners, cfg.Auth, cfg.ToolsProfile, emb, vecStore, sqlIdxs, auditLog)
 	} else {
-		serveStdio(kbs[0], cfg.ToolsProfile, emb, vecStore, sqlIdxs, auditLog)
+		serveStdio(kbs[0], kbArtifactSigners[0], cfg.ToolsProfile, emb, vecStore, sqlIdxs, auditLog)
 	}
 }
 
-func serveStdio(k *kb.KB, toolsProfile string, emb embed.Embedder, store *embed.Store, sqlIdxs map[string]*sqlindex.Index, auditLog *audit.Log) {
+func serveStdio(k *kb.KB, artifactSigner ed25519.PrivateKey, toolsProfile string, emb embed.Embedder, store *embed.Store, sqlIdxs map[string]*sqlindex.Index, auditLog *audit.Log) {
 	if auditLog != nil {
 		log.Printf("audit log active")
 	}
 	sqlIdx := sqlIdxs[filepath.Clean(k.Root)]
 	s := mcpserver.New(version)
-	mcpserver.RegisterKBTools(s, k, mcpserver.Deps{Embedder: emb, VecStore: store, SQLIndex: sqlIdx, BundleFS: skillbundle.FS})
+	mcpserver.RegisterKBTools(s, k, mcpserver.Deps{Embedder: emb, VecStore: store, SQLIndex: sqlIdx, BundleFS: skillbundle.FS, ArtifactSigner: artifactSigner})
 	s.SetToolsProfile(toolsProfile)
 	log.Printf("stdio transport, KB: %s (tools profile: %s)", k.Root, toolsProfile)
 	// s.Run blocks on the stdio read loop and returns when the client closes
@@ -376,7 +388,7 @@ func serveStdio(k *kb.KB, toolsProfile string, emb embed.Embedder, store *embed.
 	}
 }
 
-func serveHTTP(addr string, kbs []*kb.KB, names []string, toolPrefixes []string, authCfg config.AuthConfig, toolsProfile string, emb embed.Embedder, vecStore *embed.Store, sqlIdxs map[string]*sqlindex.Index, auditLog *audit.Log) {
+func serveHTTP(addr string, kbs []*kb.KB, names []string, toolPrefixes []string, artifactSigners []ed25519.PrivateKey, authCfg config.AuthConfig, toolsProfile string, emb embed.Embedder, vecStore *embed.Store, sqlIdxs map[string]*sqlindex.Index, auditLog *audit.Log) {
 	if auditLog != nil {
 		log.Printf("audit log active")
 	}
@@ -409,7 +421,7 @@ func serveHTTP(addr string, kbs []*kb.KB, names []string, toolPrefixes []string,
 				s.SetDisplayName("cartographer:" + name)
 			}
 			sqlIdx := sqlIdxs[filepath.Clean(k.Root)]
-			mcpserver.RegisterKBTools(s, k, mcpserver.Deps{Embedder: emb, VecStore: vecStore, SQLIndex: sqlIdx, BundleFS: skillbundle.FS})
+			mcpserver.RegisterKBTools(s, k, mcpserver.Deps{Embedder: emb, VecStore: vecStore, SQLIndex: sqlIdx, BundleFS: skillbundle.FS, ArtifactSigner: artifactSigners[i]})
 			s.SetToolsProfile(toolsProfile)
 		})
 		if err != nil {

--- a/cmd/cartographer/sync.go
+++ b/cmd/cartographer/sync.go
@@ -80,16 +80,15 @@ func cmdSync(args []string) int {
 		}
 	}
 
-	// The bootstrap hook (D60) is purely local — it must be guaranteed even if
-	// the manifest fetch below fails (server temporarily down): it is precisely
-	// the hook that, on the next session, will kick off a successful sync.
-	if err := ensureBootstrapForProviders(cfg.Agents, dir, *dryRun); err != nil {
+	m, err := fetchMergedManifest(cfg)
+	if err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)
 		return 2
 	}
 
-	m, err := fetchMergedManifest(cfg)
-	if err != nil {
+	// Do not write even the local bootstrap hook until the complete remote
+	// manifest has passed its content and signature checks.
+	if err := ensureBootstrapForProviders(cfg.Agents, dir, *dryRun); err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)
 		return 2
 	}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -24,6 +24,8 @@ kbs:
                             # (kb:wiki-kb:*), the clone dir (/data/wiki-kb), and the
                             # git.token_dir/sops.age_key_dir conventions below.
   - path: /data/kb-locale
+    # artifact_signing_seed: ${CARTOGRAPHER_ARTIFACT_SIGNING_SEED}
+    # 32-byte hexadecimal Ed25519 seed from a secret mount; never commit it.
     # optional per-KB overrides (zero value = fall back to global git/sops):
     # ssh_key: /etc/kb-ssh/id_ed25519_locale
     # author_name: cartographer-locale

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -76,6 +76,7 @@ cartographer connect                                   # all agents detected on 
 cartographer connect claude                             # Claude Code only
 cartographer connect --agents claude,codex              # selected subset
 cartographer connect opencode --server-url http://cartographer.example.com/mcp --auth
+cartographer connect claude --pin-key homelab=0123...  # pin a KB Ed25519 public key
 cartographer connect all --auto-trust --dry-run
 ```
 
@@ -88,6 +89,12 @@ cartographer connect all --auto-trust --dry-run
 | `--token-env` | `CARTOGRAPHER_TOKENS` | Env var holding the Bearer token |
 | `--dry-run` | `false` | Prints without writing |
 | `--auto-trust` | `false` | Also treats KB skills as trusted (unsigned) |
+| `--pin-key` | *(repeatable)* | Pins `KB=PUBLIC_KEY` for Ed25519-verified provisioning artifacts; existing pins are preserved |
+
+`signing_keys` in `.cartographer.yaml` stores public-key pins per KB. Pins are
+operator-supplied and are never learned from `sync_pull`; multiple pins permit
+key rotation. Pin the new key, switch the server signer, then remove the old
+pin after all clients have synchronized.
 
 If no provider is detected and no explicit name is passed, the command exits with an error
 (exit 1) without writing anything.

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -102,9 +102,9 @@ Tools marked **[A]** (advanced, `advancedToolNames` in `internal/mcpserver/visib
 
 | Tool | Purpose |
 |---|---|
-| `sync_check([applied_revision])` **[R]** **[A]** | Read-only. Returns the current manifest's `revision` (bundle + KB), the artifact list (`kind`: `skill`/`agent`/`hook`/`instructions`/`mcp`, `name`, `source`, `signed`), `in_sync=true/false` (if the client's lockfile revision is supplied), and **`open_conflicts`** (the count of open git rebase conflicts — useful as a SessionStart hook). Safe even on a remote server. |
-| `sync_apply(base_dir, [dry_run], [auto_trust])` **[A]** | Materializes into `base_dir` the artifacts with `signed=true`, prunes obsolete managed ones, and updates the lockfile (`.cartographer-sync.lock.json`). Intended for local (stdio) deployments where server and client share the filesystem. Unsigned artifacts go into `needs_approval`. `dry_run=true` shows the diff without writing. `auto_trust=true` also treats KB skills as trusted (opt-in workspace policy: `signed` is set by policy, not cryptographically verified — issue #54). |
-| `sync_pull()` **[R]** **[A]** | Read-only, no parameters. Returns the provisioning manifest with each artifact's file contents embedded in base64, for a remote HTTP client that does not share the filesystem with the server. Used by `cartographer connect`/`cartographer sync`/`cartographer status` on the client side (the `auto_trust` trust decision is client-side, not a tool parameter). |
+| `sync_check([applied_revision])` **[R]** **[A]** | Read-only. Returns the current manifest's revision and artifact list, including cryptographic `signed` verification output and separate `built_in` trust origin. |
+| `sync_apply(base_dir, [dry_run], [auto_trust])` **[A]** | Materializes verified or built-in artifacts into `base_dir`; `auto_trust` is explicit unsigned authorization and never sets `signed`. A local signer is verified before applying. |
+| `sync_pull()` **[R]** **[A]** | Read-only, no parameters. Returns base64 file contents plus optional detached Ed25519 signature (`algorithm`, `key_id`, envelope version, value). Remote clients recompute hashes and verify pinned keys before materialization. |
 | `sync_status()` **[R]** **[A]** | Read-only. Returns local Git replication state (`disabled`, `no_remote`, `clean`, `pending`, or `failed`), the last error/attempt, HEAD, best-effort unpushed count, identity warning, and push mode. |
 
 ### KB-root artifacts

--- a/docs/decisions/sync-provisioning.md
+++ b/docs/decisions/sync-provisioning.md
@@ -444,6 +444,31 @@ No server-side substitution: it would break `content_hash`/`if_match` (hash on t
 
 ---
 
+<a id="d114"></a>
+## D114 — Verify provisioning artifacts cryptographically
+
+**Decision.** A KB may configure an operator-controlled 32-byte Ed25519 seed.
+The server signs a deterministic, domain-separated binary envelope containing
+format version, KB source, kind, name, version and canonical content hash. The
+client pins public keys out of band per KB and verifies both reconstructed file
+content (including paths and executable bits) and detached signature before
+materialization. `Signed` is verification output only; bundle trust is the
+separate `BuiltIn` origin.
+
+**Failure semantics.** An absent signature is unsigned and remains eligible for
+the existing explicit trust policy. A malformed, invalid, source-mismatched or
+unknown-key signature, a duplicate conflicting signature, or a content-hash
+mismatch is tampering: remote sync fails before provider files or lockfiles
+change. Multiple client pins support rotation: pin the new key, switch the
+server seed, then retire the old pin after clients have synchronized.
+
+**Rationale.** A policy boolean sent by a server cannot authenticate an artifact
+received over a compromised transport. Canonical length-prefixed bytes avoid
+making JSON serialization the signed protocol and bind signatures to a precise
+KB artifact identity, preventing replay across KBs, kinds or names.
+
+---
+
 <a id="d105"></a>
 ## D105 — Binary-safe provisioning artifacts and executable KB scripts
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,6 +10,15 @@ The server is distributed as a native **Go binary** (via `install.sh`, see §Cli
 |---|---|
 | **Local** | The binary runs as a native user service (`cartographer service`, launchd/systemd); the client on the same machine points to `127.0.0.1`. |
 | **Shared server** | HTTP with optional static bearer tokens for multiple agents, on a trusted network or behind a reverse proxy (for example Kubernetes). |
+
+### Provisioning artifact signing
+
+An explicit `kbs:` entry may set `artifact_signing_seed` to a 32-byte hex
+Ed25519 seed. Mount it from a secret manager or protected secret volume: never
+commit it, expose it in health/MCP output, or place it in logs. The server logs
+only the KB and derived key ID. Distribute and pin the corresponding public key
+on each client before switching a signer; unsigned KBs remain supported through
+the explicit client trust policy.
 | **Partitioned servers** | Several instances mount different KBs. A client can connect to entries from more than one server. Do not use several active writer servers as replicas for the same KB; git conflict recovery is a safety net, not a write-scaling protocol. |
 
 ### State and volumes

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -70,14 +70,14 @@ On the stdio transport, the server emits `notifications/skills/list_changed` aft
 When client and server don't share a filesystem (`internal/client`, `internal/clientconfig`, `cmd/cartographer/clientsync.go`):
 
 1. the client calls `sync_pull` (once per KB configured in `.cartographer.yaml`) and merges the manifests with `provisioning.MergeArtifacts`;
-2. **trust is decided client-side** (§Security): trusted `kb:*` artifacts are marked `Signed:true` before `provisioning.Apply`;
+2. it reconstructs each artifact hash from received paths, bytes and executable modes, then verifies any detached signature against the local KB pin;
 3. `Apply` materializes/prunes and writes the v2 lockfile;
 4. pruning remains managed-only.
 
 ## Security
 
-- **Signature gate (default: notify + gate).** Skills and hooks are executable code: `sync_apply`/`Apply` automatically materialize only `signed:true` artifacts; the rest is flagged and requires approval. Bundle = always trusted (compiled into the binary); `kb:*` artifacts = trusted if `cfg.Trust || --auto-trust`. The `signed` field is set by policy, not verified: there is no cryptography behind it (issue #54).
-- **Per-server persisted trust.** An explicit choice made once at `connect` (toggle in the form, `trust` field in `.cartographer.yaml`, default `true`); `--auto-trust` remains a one-off override. Revocation: `trust: false` in the file. Details → [D54](decisions/sync-provisioning.md#d54).
+- **Cryptographic signature gate.** A configured KB signer creates a canonical Ed25519 envelope over domain, format version, source KB, kind, name, version and content hash. The remote client recomputes the content hash and verifies against out-of-band `signing_keys` pins before writing any provider file or lockfile. `signed:true` is verification output only; malformed, invalid, source-mismatched, unknown-key or tampered content fails the whole sync. Bundled artifacts use the separate `built_in:true` origin.
+- **Explicit unsigned authorization.** `trust: true` and one-shot `--auto-trust` retain the backwards-compatible approval path for eligible unsigned KB artifacts, but never change `signed`. Rotate keys by pinning the new public key first, switching the server signer second, then removing the old pin.
 - **Path traversal.** Artifact names and paths come from the server via JSON: `provisioning.Apply` rejects anything that is not `filepath.IsLocal` (no absolute paths, no `../`) before writing. Applies to every kind.
 - Sync never carries secrets, only references (`skills-services-secrets.md`).
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -22,6 +22,10 @@ client configuration.
 
 `make vet` runs `go vet ./...`. Both are required in CI.
 
+Provisioning signature coverage includes deterministic Ed25519 envelopes, strict
+key parsing and identity separation, plus remote `sync_pull` verification and
+tampering rejection before `Apply`.
+
 CLI JSON tests decode stdout as JSON and assert that diagnostics remain on
 stderr. Golden help is limited to 80 columns. Bubble Tea view/update tests use
 60, 80 and 120-column window messages, strip ANSI sequences before measuring

--- a/internal/artifactsig/artifactsig.go
+++ b/internal/artifactsig/artifactsig.go
@@ -1,0 +1,117 @@
+// Package artifactsig signs and verifies provisioning artifact envelopes.
+package artifactsig
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+const (
+	Algorithm       = "ed25519"
+	EnvelopeVersion = 1
+	domain          = "cartographer:provisioning-artifact:v1"
+)
+
+type Identity struct{ Source, Kind, Name, Version, ContentHash string }
+type Signature struct {
+	Algorithm       string `json:"algorithm"`
+	KeyID           string `json:"key_id"`
+	EnvelopeVersion int    `json:"envelope_version"`
+	Value           string `json:"value"`
+}
+
+func ParseSeed(seed string) (ed25519.PrivateKey, error) {
+	b, err := hex.DecodeString(seed)
+	if err != nil || len(b) != ed25519.SeedSize {
+		return nil, fmt.Errorf("artifact signing seed must be %d-byte hexadecimal", ed25519.SeedSize)
+	}
+	return ed25519.NewKeyFromSeed(b), nil
+}
+func ParsePublicKey(key string) (ed25519.PublicKey, error) {
+	b, err := hex.DecodeString(key)
+	if err != nil || len(b) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("artifact signing public key must be %d-byte hexadecimal", ed25519.PublicKeySize)
+	}
+	return ed25519.PublicKey(b), nil
+}
+func PublicKeyHex(key ed25519.PublicKey) string { return hex.EncodeToString(key) }
+func KeyID(key ed25519.PublicKey) string        { h := sha256.Sum256(key); return hex.EncodeToString(h[:]) }
+func Sign(key ed25519.PrivateKey, identity Identity) (*Signature, error) {
+	if len(key) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("invalid artifact signing private key")
+	}
+	envelope, err := CanonicalEnvelope(identity)
+	if err != nil {
+		return nil, err
+	}
+	public := key.Public().(ed25519.PublicKey)
+	return &Signature{Algorithm: Algorithm, KeyID: KeyID(public), EnvelopeVersion: EnvelopeVersion, Value: base64.RawStdEncoding.EncodeToString(ed25519.Sign(key, envelope))}, nil
+}
+func Verify(key ed25519.PublicKey, identity Identity, sig *Signature) error {
+	if len(key) != ed25519.PublicKeySize {
+		return fmt.Errorf("invalid artifact signing public key")
+	}
+	if sig == nil {
+		return fmt.Errorf("missing artifact signature")
+	}
+	if sig.Algorithm != Algorithm || sig.EnvelopeVersion != EnvelopeVersion {
+		return fmt.Errorf("unsupported artifact signature format")
+	}
+	if sig.KeyID != KeyID(key) {
+		return fmt.Errorf("artifact signature key ID does not match public key")
+	}
+	value, err := base64.RawStdEncoding.DecodeString(sig.Value)
+	if err != nil || len(value) != ed25519.SignatureSize {
+		return fmt.Errorf("invalid artifact signature encoding")
+	}
+	envelope, err := CanonicalEnvelope(identity)
+	if err != nil {
+		return err
+	}
+	if !ed25519.Verify(key, envelope, value) {
+		return fmt.Errorf("invalid artifact signature")
+	}
+	return nil
+}
+func CanonicalEnvelope(identity Identity) ([]byte, error) {
+	if err := validateIdentity(identity); err != nil {
+		return nil, err
+	}
+	fields := []string{domain, identity.Source, identity.Kind, identity.Name, identity.Version, identity.ContentHash}
+	buf := make([]byte, 0, 192)
+	for _, field := range fields {
+		var length [8]byte
+		binary.BigEndian.PutUint64(length[:], uint64(len(field)))
+		buf = append(buf, length[:]...)
+		buf = append(buf, field...)
+	}
+	return buf, nil
+}
+func validateIdentity(identity Identity) error {
+	if !strings.HasPrefix(identity.Source, "kb:") || !canonicalField(strings.TrimPrefix(identity.Source, "kb:")) {
+		return fmt.Errorf("invalid artifact signature source")
+	}
+	for _, f := range []string{identity.Kind, identity.Name} {
+		if !canonicalField(f) {
+			return fmt.Errorf("non-canonical artifact signature identity")
+		}
+	}
+	if identity.Version != strings.TrimSpace(identity.Version) || strings.ContainsRune(identity.Version, '\x00') {
+		return fmt.Errorf("non-canonical artifact signature identity")
+	}
+	if len(identity.ContentHash) != sha256.Size*2 {
+		return fmt.Errorf("invalid artifact content hash")
+	}
+	if _, err := hex.DecodeString(identity.ContentHash); err != nil || strings.ToLower(identity.ContentHash) != identity.ContentHash {
+		return fmt.Errorf("invalid artifact content hash")
+	}
+	return nil
+}
+func canonicalField(value string) bool {
+	return value != "" && value == strings.TrimSpace(value) && !strings.ContainsRune(value, '\x00')
+}

--- a/internal/artifactsig/artifactsig_test.go
+++ b/internal/artifactsig/artifactsig_test.go
@@ -1,0 +1,71 @@
+package artifactsig
+
+import (
+	"crypto/ed25519"
+	"strings"
+	"testing"
+)
+
+func testIdentity() Identity {
+	return Identity{Source: "kb:homelab", Kind: "skill", Name: "deploy", Version: "1.0.0", ContentHash: strings.Repeat("a", 64)}
+}
+func TestSignVerifyAndDomainSeparation(t *testing.T) {
+	key, err := ParseSeed(strings.Repeat("01", ed25519.SeedSize))
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := testIdentity()
+	sig, err := Sign(key, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Verify(key.Public().(ed25519.PublicKey), identity, sig); err != nil {
+		t.Fatal(err)
+	}
+	wrongKey, _ := ParseSeed(strings.Repeat("09", ed25519.SeedSize))
+	if err := Verify(wrongKey.Public().(ed25519.PublicKey), identity, sig); err == nil {
+		t.Fatal("verification succeeded with wrong key")
+	}
+	wrongHash := identity
+	wrongHash.ContentHash = strings.Repeat("b", 64)
+	if err := Verify(key.Public().(ed25519.PublicKey), wrongHash, sig); err == nil {
+		t.Fatal("verification succeeded with wrong hash")
+	}
+	for _, altered := range []Identity{{Source: "kb:other", Kind: identity.Kind, Name: identity.Name, Version: identity.Version, ContentHash: identity.ContentHash}, {Source: identity.Source, Kind: "hook", Name: identity.Name, Version: identity.Version, ContentHash: identity.ContentHash}, {Source: identity.Source, Kind: identity.Kind, Name: "other", Version: identity.Version, ContentHash: identity.ContentHash}} {
+		if err := Verify(key.Public().(ed25519.PublicKey), altered, sig); err == nil {
+			t.Fatalf("verification succeeded for %+v", altered)
+		}
+	}
+}
+func TestParsingAndMalformedSignature(t *testing.T) {
+	if _, err := ParseSeed("bad"); err == nil {
+		t.Fatal("expected invalid seed")
+	}
+	if _, err := ParsePublicKey("bad"); err == nil {
+		t.Fatal("expected invalid public key")
+	}
+	key, _ := ParseSeed(strings.Repeat("02", ed25519.SeedSize))
+	sig, _ := Sign(key, testIdentity())
+	sig.Value = "not-base64!"
+	if err := Verify(key.Public().(ed25519.PublicKey), testIdentity(), sig); err == nil {
+		t.Fatal("expected malformed signature failure")
+	}
+}
+func TestCanonicalEnvelopeDeterministic(t *testing.T) {
+	a, err := CanonicalEnvelope(testIdentity())
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := CanonicalEnvelope(testIdentity())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(a) != string(b) {
+		t.Fatal("canonical envelope is not deterministic")
+	}
+	bad := testIdentity()
+	bad.Source = "kb: homelab"
+	if _, err := CanonicalEnvelope(bad); err == nil {
+		t.Fatal("expected non-canonical identity failure")
+	}
+}

--- a/internal/clientconfig/clientconfig.go
+++ b/internal/clientconfig/clientconfig.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/BeppeTemp/cartographer/internal/artifactsig"
 	"github.com/BeppeTemp/cartographer/internal/defaults"
 	"gopkg.in/yaml.v3"
 )
@@ -48,6 +50,10 @@ type Config struct {
 	// see repoindex.Resolve). Never written by `cartographer connect`/`sync`
 	// — this is purely user-maintained, per-machine.
 	Paths map[string]string `yaml:"paths,omitempty"`
+
+	// SigningKeys pins Ed25519 public keys by source KB. Pins are configured
+	// out of band and are never learned from sync_pull responses.
+	SigningKeys map[string][]string `yaml:"signing_keys,omitempty"`
 }
 
 // yamlConfig mirrors Config for YAML (de)serialization. Trust is a *bool here
@@ -55,15 +61,16 @@ type Config struct {
 // (nil, defaults to true) apart from an explicit `trust: false` written by a
 // user who revoked it.
 type yamlConfig struct {
-	ServerURL   string            `yaml:"server_url"`
-	ServerName  string            `yaml:"server_name"`
-	Auth        bool              `yaml:"auth"`
-	TokenEnv    string            `yaml:"token_env"`
-	Agents      []string          `yaml:"agents"`
-	KBs         []string          `yaml:"kbs,omitempty"`
-	Trust       *bool             `yaml:"trust,omitempty"`
-	SearchRoots []string          `yaml:"search_roots,omitempty"`
-	Paths       map[string]string `yaml:"paths,omitempty"`
+	ServerURL   string              `yaml:"server_url"`
+	ServerName  string              `yaml:"server_name"`
+	Auth        bool                `yaml:"auth"`
+	TokenEnv    string              `yaml:"token_env"`
+	Agents      []string            `yaml:"agents"`
+	KBs         []string            `yaml:"kbs,omitempty"`
+	Trust       *bool               `yaml:"trust,omitempty"`
+	SearchRoots []string            `yaml:"search_roots,omitempty"`
+	Paths       map[string]string   `yaml:"paths,omitempty"`
+	SigningKeys map[string][]string `yaml:"signing_keys,omitempty"`
 }
 
 // Default returns a Config with the same defaults as configurator.DefaultConfig.
@@ -122,6 +129,7 @@ func Load(dir string) (*Config, error) {
 		Trust:       true, // absent `trust` key defaults to true, see yamlConfig doc
 		SearchRoots: y.SearchRoots,
 		Paths:       y.Paths,
+		SigningKeys: y.SigningKeys,
 	}
 	if y.Trust != nil {
 		cfg.Trust = *y.Trust
@@ -149,6 +157,7 @@ func Save(dir string, cfg *Config) error {
 		Trust:       &cfg.Trust,
 		SearchRoots: cfg.SearchRoots,
 		Paths:       cfg.Paths,
+		SigningKeys: cfg.SigningKeys,
 	}
 	data, err := yaml.Marshal(&y)
 	if err != nil {
@@ -157,6 +166,26 @@ func Save(dir string, cfg *Config) error {
 	if err := os.WriteFile(Path(dir), data, 0o644); err != nil {
 		return fmt.Errorf("clientconfig: write %s: %w", Path(dir), err)
 	}
+	return nil
+}
+
+// AddSigningKey pins key for kbName unless it is already present.
+func (c *Config) AddSigningKey(kbName, key string) error {
+	if kbName == "" || kbName != strings.TrimSpace(kbName) || key == "" || key != strings.TrimSpace(key) {
+		return fmt.Errorf("clientconfig: invalid signing key pin")
+	}
+	if _, err := artifactsig.ParsePublicKey(key); err != nil {
+		return fmt.Errorf("clientconfig: invalid signing key pin: %w", err)
+	}
+	if c.SigningKeys == nil {
+		c.SigningKeys = make(map[string][]string)
+	}
+	for _, existing := range c.SigningKeys[kbName] {
+		if existing == key {
+			return nil
+		}
+	}
+	c.SigningKeys[kbName] = append(c.SigningKeys[kbName], key)
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,8 +94,12 @@ func (t *TokenSpec) UnmarshalYAML(node *yaml.Node) error {
 // optional per-KB overrides for git identity and SOPS; a zero value falls
 // back to the corresponding global GitConfig/SopsConfig setting.
 type KBSpec struct {
-	Path   string `yaml:"path"`
-	Remote string `yaml:"remote"`
+	// ArtifactSigningSeed is a 32-byte hexadecimal Ed25519 seed used only to
+	// sign provisioning artifacts served from this KB. It is never exposed by
+	// health, MCP responses, or diagnostic output.
+	ArtifactSigningSeed string `yaml:"artifact_signing_seed,omitempty"`
+	Path                string `yaml:"path"`
+	Remote              string `yaml:"remote"`
 
 	// Name overrides the KB name that would otherwise be derived from the
 	// basename of Remote/Path (see cmd/cartographer.resolveKBName). If set,

--- a/internal/mcpserver/docs_test.go
+++ b/internal/mcpserver/docs_test.go
@@ -34,6 +34,7 @@ var toolPrefixes = []string{
 // not tools: lint rule names, frontmatter fields, and one deliberate mention of
 // an operation that does not exist (documented as such).
 var docsNonTools = map[string]bool{
+	"artifact_signing_seed": true,
 	// lint rules (internal/lint)
 	"concept_oversize": true, "map_oversize": true, "machine_path": true,
 	"expanded_as_category": true, "expanded_ambiguous": true,

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -2796,6 +2796,7 @@ func TestServer_SyncPull(t *testing.T) {
 			Source      string `json:"source"`
 			ContentHash string `json:"content_hash"`
 			Signed      bool   `json:"signed"`
+			BuiltIn     bool   `json:"built_in"`
 			Files       []struct {
 				Path       string `json:"path"`
 				ContentB64 string `json:"content_b64"`
@@ -2820,6 +2821,7 @@ func TestServer_SyncPull(t *testing.T) {
 		Source      string `json:"source"`
 		ContentHash string `json:"content_hash"`
 		Signed      bool   `json:"signed"`
+		BuiltIn     bool   `json:"built_in"`
 		Files       []struct {
 			Path       string `json:"path"`
 			ContentB64 string `json:"content_b64"`
@@ -2845,7 +2847,7 @@ func TestServer_SyncPull(t *testing.T) {
 	if instr.Source == "bundle" || len(instr.Files) != 1 || instr.Files[0].Path != "instructions.md" {
 		t.Errorf("sync_pull: unexpected instructions artifact: %+v", instr)
 	}
-	if art.Name != "kb-create" || art.Source != "bundle" || !art.Signed {
+	if art.Name != "kb-create" || art.Source != "bundle" || art.Signed || !art.BuiltIn {
 		t.Errorf("sync_pull: unexpected artifact: %+v", art)
 	}
 	if len(art.Files) != 1 || art.Files[0].Path != "SKILL.md" {

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -1,6 +1,7 @@
 package mcpserver
 
 import (
+	"crypto/ed25519"
 	"encoding/json"
 	"fmt"
 	"io/fs"
@@ -16,10 +17,11 @@ import (
 
 // Deps holds the optional dependencies for tool registration.
 type Deps struct {
-	Embedder embed.Embedder  // nil → keyword-only search
-	VecStore *embed.Store    // required if Embedder is set
-	SQLIndex *sqlindex.Index // nil → in-memory index
-	BundleFS fs.FS           // nil → no bundled skills
+	Embedder       embed.Embedder     // nil → keyword-only search
+	VecStore       *embed.Store       // required if Embedder is set
+	SQLIndex       *sqlindex.Index    // nil → in-memory index
+	BundleFS       fs.FS              // nil → no bundled skills
+	ArtifactSigner ed25519.PrivateKey // nil → KB artifacts remain unsigned
 }
 
 // RegisterKBTools registers all KB tools on the server, including search, navigation,
@@ -125,9 +127,9 @@ func RegisterKBTools(s *Server, k *kb.KB, deps Deps) {
 	if deps.BundleFS != nil {
 		register(toolSkillListWithBundle(k, deps.BundleFS))
 		register(notifyWrap(s, gitWrap(k, toolSkillInstall(k, deps.BundleFS)), "notifications/skills/list_changed"))
-		register(toolSyncCheck(k, deps.BundleFS))
-		register(toolSyncApply(k, deps.BundleFS))
-		register(toolSyncPull(k, deps.BundleFS))
+		register(toolSyncCheck(k, deps.BundleFS, deps.ArtifactSigner))
+		register(toolSyncApply(k, deps.BundleFS, deps.ArtifactSigner))
+		register(toolSyncPull(k, deps.BundleFS, deps.ArtifactSigner))
 	} else {
 		register(toolSkillList(k))
 	}

--- a/internal/mcpserver/tools_artifact.go
+++ b/internal/mcpserver/tools_artifact.go
@@ -291,7 +291,7 @@ func toolArtifactList(k *kb.KB) Tool {
 			kbRoots := map[string]string{artifactManifestKBKey: k.Root}
 			// Reuses provisioning.BuildManifest (no bundle) so the kind
 			// classification stays in a single place (D71 WP1).
-			m, err := provisioning.BuildManifest(nil, kbRoots, false)
+			m, err := provisioning.BuildManifest(nil, kbRoots, provisioning.BuildOptions{})
 			if err != nil {
 				return errorResult("artifact_list: " + err.Error()), nil
 			}

--- a/internal/mcpserver/tools_skill_test.go
+++ b/internal/mcpserver/tools_skill_test.go
@@ -24,8 +24,12 @@ func setupServiceTestKB(t *testing.T, sopsAgeKeyFile string) *kb.KB {
 	if err := os.WriteFile(filepath.Join(k.DataRoot(), "svc-test.md"), []byte(svcContent), 0o644); err != nil {
 		t.Fatalf("write service concept: %v", err)
 	}
-	if err := os.MkdirAll(filepath.Join(k.Root, "secrets"), 0o755); err != nil { t.Fatalf("mkdir secrets: %v", err) }
-	if err := os.WriteFile(filepath.Join(k.Root, "secrets", "test.sops.yaml"), []byte("placeholder"), 0o600); err != nil { t.Fatalf("write secret: %v", err) }
+	if err := os.MkdirAll(filepath.Join(k.Root, "secrets"), 0o755); err != nil {
+		t.Fatalf("mkdir secrets: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(k.Root, "secrets", "test.sops.yaml"), []byte("placeholder"), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
 	return k
 }
 

--- a/internal/mcpserver/tools_sync.go
+++ b/internal/mcpserver/tools_sync.go
@@ -1,6 +1,7 @@
 package mcpserver
 
 import (
+	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/BeppeTemp/cartographer/internal/artifactsig"
 	"github.com/BeppeTemp/cartographer/internal/configurator"
 	"github.com/BeppeTemp/cartographer/internal/kb"
 	"github.com/BeppeTemp/cartographer/internal/provisioning"
@@ -46,7 +48,7 @@ func flushPendingPush(k *kb.KB, toolName string) {
 // toolSyncCheck returns the current revision of the provisioning manifest (bundle + KB).
 // Read-only: writes nothing, safe on a remote server too.
 // The client may pass its own lockfile revision; the response includes in_sync=true/false.
-func toolSyncCheck(k *kb.KB, bundleFS fs.FS) Tool {
+func toolSyncCheck(k *kb.KB, bundleFS fs.FS, signer ed25519.PrivateKey) Tool {
 	return Tool{
 		Name:     "sync_check",
 		ReadOnly: true,
@@ -71,7 +73,7 @@ func toolSyncCheck(k *kb.KB, bundleFS fs.FS) Tool {
 
 			// Use the basename of k.Root as the KB name in the manifest.
 			kbName := filepath.Base(k.Root)
-			m, err := provisioning.BuildManifest(bundleFS, map[string]string{kbName: k.Root}, false)
+			m, err := provisioning.BuildManifest(bundleFS, map[string]string{kbName: k.Root}, buildOptions(kbName, signer))
 			if err != nil {
 				return errorResult(fmt.Sprintf("sync_check: build manifest: %v", err)), nil
 			}
@@ -84,6 +86,7 @@ func toolSyncCheck(k *kb.KB, bundleFS fs.FS) Tool {
 				Source  string `json:"source"`
 				Version string `json:"version,omitempty"`
 				Signed  bool   `json:"signed"`
+				BuiltIn bool   `json:"built_in,omitempty"`
 			}
 			arts := make([]artifactJSON, len(m.Artifacts))
 			for i, a := range m.Artifacts {
@@ -93,6 +96,7 @@ func toolSyncCheck(k *kb.KB, bundleFS fs.FS) Tool {
 					Source:  a.Source,
 					Version: a.Version,
 					Signed:  a.Signed,
+					BuiltIn: a.BuiltIn,
 				}
 			}
 
@@ -120,7 +124,7 @@ func toolSyncCheck(k *kb.KB, bundleFS fs.FS) Tool {
 // toolSyncApply materializes the provisioning artifacts into the client's base_dir.
 // Intended for local deployment (stdio): server and client share the filesystem.
 // For remote deployment use `cartographer sync`/`cartographer connect` (via sync_pull) from the client machine.
-func toolSyncApply(k *kb.KB, bundleFS fs.FS) Tool {
+func toolSyncApply(k *kb.KB, bundleFS fs.FS, signer ed25519.PrivateKey) Tool {
 	return Tool{
 		Name: "sync_apply",
 		Description: "Materializes the provisioning skills into the given base_dir, updates the lockfile and prunes " +
@@ -162,9 +166,16 @@ func toolSyncApply(k *kb.KB, bundleFS fs.FS) Tool {
 			kbName := filepath.Base(k.Root)
 			kbRoots := map[string]string{kbName: k.Root}
 
-			m, err := provisioning.BuildManifest(bundleFS, kbRoots, params.AutoTrust)
+			m, err := provisioning.BuildManifest(bundleFS, kbRoots, buildOptions(kbName, signer))
 			if err != nil {
 				return errorResult(fmt.Sprintf("sync_apply: build manifest: %v", err)), nil
+			}
+			if len(signer) != 0 {
+				verified, verifyErr := provisioning.VerifiedManifest(m, map[string][]ed25519.PublicKey{kbName: {signer.Public().(ed25519.PublicKey)}})
+				if verifyErr != nil {
+					return errorResult(fmt.Sprintf("sync_apply: verify manifest: %v", verifyErr)), nil
+				}
+				m = verified
 			}
 
 			lockPath := filepath.Join(params.BaseDir, provisioning.LockFileName)
@@ -241,20 +252,22 @@ type pulledFileJSON struct {
 
 // pulledArtifactJSON is an Artifact plus its file contents, as returned by sync_pull.
 type pulledArtifactJSON struct {
-	Kind        string           `json:"kind"`
-	Name        string           `json:"name"`
-	Source      string           `json:"source"`
-	Version     string           `json:"version,omitempty"`
-	ContentHash string           `json:"content_hash"`
-	Signed      bool             `json:"signed"`
-	Files       []pulledFileJSON `json:"files"`
+	Kind        string                 `json:"kind"`
+	Name        string                 `json:"name"`
+	Source      string                 `json:"source"`
+	Version     string                 `json:"version,omitempty"`
+	ContentHash string                 `json:"content_hash"`
+	Signed      bool                   `json:"signed"`
+	BuiltIn     bool                   `json:"built_in,omitempty"`
+	Signature   *artifactsig.Signature `json:"signature,omitempty"`
+	Files       []pulledFileJSON       `json:"files"`
 }
 
 // toolSyncPull returns the provisioning manifest (bundle + KB) with each
 // artifact's file contents embedded (base64). Meant for a remote HTTP client
 // that does not share the filesystem with the server: the client materializes
 // locally without reading bundle/KB directly. Read-only, no arguments required.
-func toolSyncPull(k *kb.KB, bundleFS fs.FS) Tool {
+func toolSyncPull(k *kb.KB, bundleFS fs.FS, signer ed25519.PrivateKey) Tool {
 	return Tool{
 		Name:     "sync_pull",
 		ReadOnly: true,
@@ -267,7 +280,7 @@ func toolSyncPull(k *kb.KB, bundleFS fs.FS) Tool {
 			kbName := filepath.Base(k.Root)
 			kbRoots := map[string]string{kbName: k.Root}
 
-			m, err := provisioning.BuildManifest(bundleFS, kbRoots, false)
+			m, err := provisioning.BuildManifest(bundleFS, kbRoots, buildOptions(kbName, signer))
 			if err != nil {
 				return errorResult(fmt.Sprintf("sync_pull: build manifest: %v", err)), nil
 			}
@@ -289,6 +302,8 @@ func toolSyncPull(k *kb.KB, bundleFS fs.FS) Tool {
 					Version:     a.Version,
 					ContentHash: a.ContentHash,
 					Signed:      a.Signed,
+					BuiltIn:     a.BuiltIn,
+					Signature:   a.Signature,
 					Files:       fj,
 				})
 			}
@@ -301,4 +316,11 @@ func toolSyncPull(k *kb.KB, bundleFS fs.FS) Tool {
 			return textResult(string(out)), nil
 		},
 	}
+}
+
+func buildOptions(kbName string, signer ed25519.PrivateKey) provisioning.BuildOptions {
+	if len(signer) == 0 {
+		return provisioning.BuildOptions{}
+	}
+	return provisioning.BuildOptions{Signers: map[string]ed25519.PrivateKey{kbName: signer}}
 }

--- a/internal/provisioning/bootstrap_test.go
+++ b/internal/provisioning/bootstrap_test.go
@@ -341,7 +341,7 @@ func TestApply_NomeRiservatoInKB_Warning(t *testing.T) {
 	kbRoot := t.TempDir()
 	writeHookKB(t, kbRoot, provisioning.BootstrapHookName, "PostToolUse", "", "./notify.sh")
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}

--- a/internal/provisioning/expand_test.go
+++ b/internal/provisioning/expand_test.go
@@ -21,7 +21,8 @@ import (
 
 func TestExpandPlaceholders_NoopWhenDisabled(t *testing.T) {
 	content := []byte("See {{path:design}} for the assets.")
-	opts := ApplyOptions{Paths: map[string]string{"design": "/mnt/design"}} // ExpandPlaceholders: false
+	opts := ApplyOptions{
+		AutoTrust: true, Paths: map[string]string{"design": "/mnt/design"}} // ExpandPlaceholders: false
 	tracker := newExpansionTracker()
 
 	got := expandPlaceholders(content, opts, tracker)
@@ -35,7 +36,8 @@ func TestExpandPlaceholders_NoopWhenDisabled(t *testing.T) {
 
 func TestExpandPlaceholders_PathResolved(t *testing.T) {
 	content := []byte("See {{path:design}} for the assets.")
-	opts := ApplyOptions{ExpandPlaceholders: true, Paths: map[string]string{"design": "/mnt/design"}}
+	opts := ApplyOptions{
+		AutoTrust: true, ExpandPlaceholders: true, Paths: map[string]string{"design": "/mnt/design"}}
 	tracker := newExpansionTracker()
 
 	got := expandPlaceholders(content, opts, tracker)
@@ -54,7 +56,8 @@ func TestExpandPlaceholders_RepoResolvedViaManualPathsOverride(t *testing.T) {
 	// repoindex.Resolve checks manualPaths BEFORE touching cache/filesystem:
 	// so this test neither scans nor writes anything on the real filesystem.
 	content := []byte("The repo is in {{repo:cartographer}}.")
-	opts := ApplyOptions{ExpandPlaceholders: true, Paths: map[string]string{"cartographer": "/home/x/repos/cartographer"}}
+	opts := ApplyOptions{
+		AutoTrust: true, ExpandPlaceholders: true, Paths: map[string]string{"cartographer": "/home/x/repos/cartographer"}}
 	tracker := newExpansionTracker()
 
 	got := expandPlaceholders(content, opts, tracker)
@@ -68,7 +71,8 @@ func TestExpandPlaceholders_RepoResolvedViaManualPathsOverride(t *testing.T) {
 
 func TestExpandPlaceholders_UnresolvedLeftAsIsWithWarning(t *testing.T) {
 	content := []byte("See {{path:missing}} for the assets.")
-	opts := ApplyOptions{ExpandPlaceholders: true, Paths: map[string]string{}}
+	opts := ApplyOptions{
+		AutoTrust: true, ExpandPlaceholders: true, Paths: map[string]string{}}
 	tracker := newExpansionTracker()
 
 	got := expandPlaceholders(content, opts, tracker)
@@ -82,7 +86,8 @@ func TestExpandPlaceholders_UnresolvedLeftAsIsWithWarning(t *testing.T) {
 
 func TestExpandPlaceholders_NoPlaceholdersUntouched(t *testing.T) {
 	content := []byte("No placeholder here.")
-	opts := ApplyOptions{ExpandPlaceholders: true, Paths: map[string]string{}}
+	opts := ApplyOptions{
+		AutoTrust: true, ExpandPlaceholders: true, Paths: map[string]string{}}
 	tracker := newExpansionTracker()
 
 	got := expandPlaceholders(content, opts, tracker)
@@ -149,7 +154,7 @@ func TestApply_ExpandPlaceholders_ZeroDriftAgent(t *testing.T) {
 	os.MkdirAll(agentsDir, 0o755)
 	os.WriteFile(filepath.Join(agentsDir, "reviewer.md"), []byte("---\nname: reviewer\n---\nNo placeholder here.\n"), 0o644)
 
-	m, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -165,6 +170,7 @@ func TestApply_ExpandPlaceholders_ZeroDriftAgent(t *testing.T) {
 
 	baseDir := t.TempDir()
 	res, err := Apply(m, ApplyOptions{
+		AutoTrust:          true,
 		KBRoots:            map[string]string{"kb": kbRoot},
 		Provider:           configurator.ProviderClaudeCode,
 		BaseDir:            baseDir,
@@ -192,7 +198,7 @@ func TestApply_ExpandPlaceholders_AgentPathPlaceholder(t *testing.T) {
 	os.MkdirAll(agentsDir, 0o755)
 	os.WriteFile(filepath.Join(agentsDir, "reviewer.md"), []byte("---\nname: reviewer\n---\nThe assets are in {{path:design}}.\n"), 0o644)
 
-	m, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -205,6 +211,7 @@ func TestApply_ExpandPlaceholders_AgentPathPlaceholder(t *testing.T) {
 
 	baseDir := t.TempDir()
 	res, err := Apply(m, ApplyOptions{
+		AutoTrust:          true,
 		KBRoots:            map[string]string{"kb": kbRoot},
 		Provider:           configurator.ProviderClaudeCode,
 		BaseDir:            baseDir,
@@ -241,13 +248,14 @@ func TestApply_ExpandPlaceholders_UnresolvedWarnsAndLeavesLiteral(t *testing.T) 
 	os.MkdirAll(agentsDir, 0o755)
 	os.WriteFile(filepath.Join(agentsDir, "reviewer.md"), []byte("---\nname: reviewer\n---\nThe assets are in {{path:missing}}.\n"), 0o644)
 
-	m, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
 
 	baseDir := t.TempDir()
 	res, err := Apply(m, ApplyOptions{
+		AutoTrust:          true,
 		KBRoots:            map[string]string{"kb": kbRoot},
 		Provider:           configurator.ProviderClaudeCode,
 		BaseDir:            baseDir,
@@ -276,7 +284,7 @@ func TestApply_ExpandPlaceholders_ServerNeverExpands(t *testing.T) {
 	os.MkdirAll(agentsDir, 0o755)
 	os.WriteFile(filepath.Join(agentsDir, "reviewer.md"), []byte("---\nname: reviewer\n---\nThe assets are in {{path:design}}.\n"), 0o644)
 
-	m, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -290,10 +298,11 @@ func TestApply_ExpandPlaceholders_ServerNeverExpands(t *testing.T) {
 	baseDir := t.TempDir()
 	// Like internal/mcpserver: ExpandPlaceholders never set (default false).
 	res, err := Apply(m, ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderClaudeCode,
-		BaseDir:  baseDir,
-		Lock:     Lock{},
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderClaudeCode,
+		BaseDir:   baseDir,
+		Lock:      Lock{},
 	})
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
@@ -329,7 +338,7 @@ func TestApply_ExpandPlaceholders_ZeroDriftSkill(t *testing.T) {
 	os.MkdirAll(skillDir, 0o755)
 	os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: kb-skill\ndescription: Test\n---\nNo placeholder.\n"), 0o644)
 
-	m, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -342,6 +351,7 @@ func TestApply_ExpandPlaceholders_ZeroDriftSkill(t *testing.T) {
 
 	baseDir := t.TempDir()
 	res, err := Apply(m, ApplyOptions{
+		AutoTrust:          true,
 		KBRoots:            map[string]string{"kb": kbRoot},
 		Provider:           configurator.ProviderClaudeCode,
 		BaseDir:            baseDir,
@@ -371,13 +381,14 @@ func TestApply_ExpandPlaceholders_SkillMultiFilePlaceholder(t *testing.T) {
 	os.WriteFile(filepath.Join(skillDir, "notes.md"), []byte("No placeholder here.\n"), 0o644)
 	os.WriteFile(filepath.Join(skillDir, "run.sh"), []byte("{{path:tools}}/run\n"), 0o755)
 
-	m, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
 
 	baseDir := t.TempDir()
 	result, err := Apply(m, ApplyOptions{
+		AutoTrust:          true,
 		KBRoots:            map[string]string{"kb": kbRoot},
 		Provider:           configurator.ProviderClaudeCode,
 		BaseDir:            baseDir,
@@ -421,14 +432,14 @@ func TestApply_ExpandPlaceholders_SkillMultiFilePlaceholder(t *testing.T) {
 // --- Apply: instructions (group) ---
 
 func instructionsArtifactForExpandTest(name, content string) Artifact {
-	h := sha256.Sum256([]byte(content))
+	files := []ArtifactFile{{Path: "instructions.md", Content: []byte(content)}}
 	return Artifact{
 		Kind:        "instructions",
 		Name:        name,
 		Source:      "kb:" + name,
-		ContentHash: fmt.Sprintf("%x", h),
+		ContentHash: hashArtifactFiles(files),
 		Signed:      true,
-		Files:       []ArtifactFile{{Path: "instructions.md", Content: []byte(content)}},
+		Files:       files,
 	}
 }
 
@@ -438,6 +449,7 @@ func TestApply_ExpandPlaceholders_Instructions(t *testing.T) {
 	m := MergeArtifacts([]Artifact{a})
 
 	res, err := Apply(m, ApplyOptions{
+		AutoTrust:          true,
 		Provider:           configurator.ProviderClaudeCode,
 		BaseDir:            baseDir,
 		Lock:               Lock{},
@@ -469,6 +481,7 @@ func TestApply_ExpandPlaceholders_ZeroDriftInstructions(t *testing.T) {
 	m := MergeArtifacts([]Artifact{a})
 
 	res, err := Apply(m, ApplyOptions{
+		AutoTrust:          true,
 		Provider:           configurator.ProviderClaudeCode,
 		BaseDir:            baseDir,
 		Lock:               Lock{},
@@ -519,13 +532,14 @@ func TestApply_ExpandPlaceholders_PathsTableInInstructions(t *testing.T) {
 	// in this same Apply (tracker, not per-kind).
 	os.WriteFile(filepath.Join(agentsDir, "reviewer.md"), []byte("---\nname: reviewer\n---\nThe assets are in {{path:design}}.\n"), 0o644)
 
-	m, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
 
 	baseDir := t.TempDir()
 	_, err = Apply(m, ApplyOptions{
+		AutoTrust:          true,
 		KBRoots:            map[string]string{"kb": kbRoot},
 		Provider:           configurator.ProviderClaudeCode,
 		BaseDir:            baseDir,
@@ -559,13 +573,14 @@ func TestApply_ExpandPlaceholders_NoPathsTableWhenNothingResolved(t *testing.T) 
 	os.MkdirAll(agentsDir, 0o755)
 	os.WriteFile(filepath.Join(agentsDir, "reviewer.md"), []byte("---\nname: reviewer\n---\nNo placeholder here.\n"), 0o644)
 
-	m, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
 
 	baseDir := t.TempDir()
 	_, err = Apply(m, ApplyOptions{
+		AutoTrust:          true,
 		KBRoots:            map[string]string{"kb": kbRoot},
 		Provider:           configurator.ProviderClaudeCode,
 		BaseDir:            baseDir,
@@ -591,7 +606,7 @@ func TestApply_ExpandPlaceholders_NoPathsTableServerSide(t *testing.T) {
 	os.MkdirAll(agentsDir, 0o755)
 	os.WriteFile(filepath.Join(agentsDir, "reviewer.md"), []byte("---\nname: reviewer\n---\nThe assets are in {{path:design}}.\n"), 0o644)
 
-	m, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -599,10 +614,11 @@ func TestApply_ExpandPlaceholders_NoPathsTableServerSide(t *testing.T) {
 	baseDir := t.TempDir()
 	// ExpandPlaceholders never set, like internal/mcpserver.
 	_, err = Apply(m, ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderClaudeCode,
-		BaseDir:  baseDir,
-		Lock:     Lock{},
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderClaudeCode,
+		BaseDir:   baseDir,
+		Lock:      Lock{},
 	})
 	if err != nil {
 		t.Fatalf("Apply: %v", err)

--- a/internal/provisioning/hooksettings_opencode_test.go
+++ b/internal/provisioning/hooksettings_opencode_test.go
@@ -25,17 +25,18 @@ func TestApply_OpenCode_Hook_GeneraPluginToolBefore(t *testing.T) {
 	kbRoot := t.TempDir()
 	writeHookKB(t, kbRoot, "notify", "PreToolUse", "Bash", "./notify.sh")
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
 
 	baseDir := t.TempDir()
 	res, err := provisioning.Apply(m, provisioning.ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderOpenCode,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderOpenCode,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	})
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
@@ -90,17 +91,18 @@ func TestApply_OpenCode_Hook_GeneraPluginSessionStart(t *testing.T) {
 	kbRoot := t.TempDir()
 	writeHookKB(t, kbRoot, "greet", "SessionStart", "", "./notify.sh")
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
 
 	baseDir := t.TempDir()
 	res, err := provisioning.Apply(m, provisioning.ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderOpenCode,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderOpenCode,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	})
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
@@ -123,17 +125,18 @@ func TestApply_OpenCode_Hook_ReApply_Idempotente(t *testing.T) {
 	kbRoot := t.TempDir()
 	writeHookKB(t, kbRoot, "notify", "PostToolUse", "concept_write", "./notify.sh")
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
 
 	baseDir := t.TempDir()
 	opts := provisioning.ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderOpenCode,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderOpenCode,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	}
 
 	if _, err := provisioning.Apply(m, opts); err != nil {
@@ -173,17 +176,18 @@ func TestApply_OpenCode_Hook_Removed_RimuovePluginEFile(t *testing.T) {
 	kbRoot := t.TempDir()
 	writeHookKB(t, kbRoot, "notify", "PostToolUse", "", "./notify.sh")
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
 
 	baseDir := t.TempDir()
 	opts := provisioning.ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderOpenCode,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderOpenCode,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	}
 
 	res, err := provisioning.Apply(m, opts)
@@ -197,7 +201,7 @@ func TestApply_OpenCode_Hook_Removed_RimuovePluginEFile(t *testing.T) {
 	if err := os.RemoveAll(filepath.Join(kbRoot, "hooks", "notify")); err != nil {
 		t.Fatal(err)
 	}
-	m2, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m2, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest (2): %v", err)
 	}
@@ -223,17 +227,18 @@ func TestApply_OpenCode_Hook_EventoNonMappato_NessunPluginNessunErrore(t *testin
 	kbRoot := t.TempDir()
 	writeHookKB(t, kbRoot, "onprompt", "UserPromptSubmit", "", "./notify.sh")
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
 
 	baseDir := t.TempDir()
 	res, err := provisioning.Apply(m, provisioning.ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderOpenCode,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderOpenCode,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	})
 	if err != nil {
 		t.Fatalf("Apply: expected no fatal error, got %v", err)

--- a/internal/provisioning/hooksettings_test.go
+++ b/internal/provisioning/hooksettings_test.go
@@ -74,17 +74,18 @@ func TestApply_Hook_RegistraSettingsJSON(t *testing.T) {
 	kbRoot := t.TempDir()
 	writeHookKB(t, kbRoot, "notify", "PostToolUse", "concept_write", "./notify.sh")
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
 
 	baseDir := t.TempDir()
 	res, err := provisioning.Apply(m, provisioning.ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderClaudeCode,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderClaudeCode,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	})
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
@@ -117,17 +118,18 @@ func TestApply_Hook_ReApply_NessunDuplicato(t *testing.T) {
 	kbRoot := t.TempDir()
 	writeHookKB(t, kbRoot, "notify", "PostToolUse", "concept_write", "./notify.sh")
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
 
 	baseDir := t.TempDir()
 	opts := provisioning.ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderClaudeCode,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderClaudeCode,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	}
 
 	if _, err := provisioning.Apply(m, opts); err != nil {
@@ -159,17 +161,18 @@ func TestApply_Hook_ScriptMaterializzatoEseguibile(t *testing.T) {
 	kbRoot := t.TempDir()
 	writeHookKB(t, kbRoot, "notify", "PostToolUse", "concept_write", "./notify.sh")
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
 
 	baseDir := t.TempDir()
 	if _, err := provisioning.Apply(m, provisioning.ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderClaudeCode,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderClaudeCode,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	}); err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
@@ -199,17 +202,18 @@ func TestApply_Hook_ComandoBare_VerbatimConMarkerCommento(t *testing.T) {
 	bare := "jq -e '.tool_input.x' >/dev/null 2>&1 && exit 2 || true"
 	writeHookKB(t, kbRoot, "env-block", "PreToolUse", "Edit|Write", bare)
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
 
 	baseDir := t.TempDir()
 	opts := provisioning.ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderClaudeCode,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderClaudeCode,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	}
 	if _, err := provisioning.Apply(m, opts); err != nil {
 		t.Fatalf("Apply (1): %v", err)
@@ -235,7 +239,7 @@ func TestApply_Hook_PreservaChiaviUtenteESettingsPreesistente(t *testing.T) {
 	kbRoot := t.TempDir()
 	writeHookKB(t, kbRoot, "notify", "PostToolUse", "concept_write", "./notify.sh")
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -258,10 +262,11 @@ func TestApply_Hook_PreservaChiaviUtenteESettingsPreesistente(t *testing.T) {
 	}
 
 	_, err = provisioning.Apply(m, provisioning.ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderClaudeCode,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderClaudeCode,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	})
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
@@ -298,7 +303,7 @@ func TestApply_Hook_Removed_RimuoveEntrySettings(t *testing.T) {
 	kbRoot := t.TempDir()
 	writeHookKB(t, kbRoot, "notify", "PostToolUse", "concept_write", "./notify.sh")
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -321,10 +326,11 @@ func TestApply_Hook_Removed_RimuoveEntrySettings(t *testing.T) {
 	}
 
 	res, err := provisioning.Apply(m, provisioning.ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderClaudeCode,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderClaudeCode,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	})
 	if err != nil {
 		t.Fatalf("Apply (materialize): %v", err)
@@ -335,16 +341,17 @@ func TestApply_Hook_Removed_RimuoveEntrySettings(t *testing.T) {
 	if err := os.RemoveAll(filepath.Join(kbRoot, "hooks", "notify")); err != nil {
 		t.Fatal(err)
 	}
-	m2, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m2, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest (2): %v", err)
 	}
 
 	res2, err := provisioning.Apply(m2, provisioning.ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderClaudeCode,
-		BaseDir:  baseDir,
-		Lock:     res.NewLock,
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderClaudeCode,
+		BaseDir:   baseDir,
+		Lock:      res.NewLock,
 	})
 	if err != nil {
 		t.Fatalf("Apply (removal): %v", err)

--- a/internal/provisioning/provisioning.go
+++ b/internal/provisioning/provisioning.go
@@ -12,6 +12,7 @@
 package provisioning
 
 import (
+	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
@@ -22,6 +23,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/BeppeTemp/cartographer/internal/artifactsig"
 	"github.com/BeppeTemp/cartographer/internal/configurator"
 	"github.com/BeppeTemp/cartographer/internal/okf"
 	"github.com/BeppeTemp/cartographer/internal/skill"
@@ -35,7 +37,11 @@ type Artifact struct {
 	Source      string `json:"source"` // "bundle" | "kb:<name>"
 	Version     string `json:"version,omitempty"`
 	ContentHash string `json:"content_hash"` // sha256 hex of the whole skill folder
-	Signed      bool   `json:"signed"`       // trust policy (see signature note)
+	// Signed is true only after a cryptographic verification. It is never an
+	// authorization or policy decision.
+	Signed    bool                   `json:"signed"`
+	BuiltIn   bool                   `json:"built_in,omitempty"`
+	Signature *artifactsig.Signature `json:"signature,omitempty"`
 
 	// Files, if non-empty, holds the artifact's content already in memory
 	// (e.g. received via the sync_pull MCP tool on a remote HTTP client, with
@@ -45,6 +51,10 @@ type Artifact struct {
 	// structures).
 	Files []ArtifactFile `json:"-"`
 }
+
+// BuildOptions controls manifest construction. Signers is keyed by mounted KB
+// name; a missing signer leaves that KB's artifacts unsigned.
+type BuildOptions struct{ Signers map[string]ed25519.PrivateKey }
 
 // ArtifactFile is a single file of an Artifact, with content in memory.
 type ArtifactFile struct {
@@ -90,13 +100,15 @@ type Diff struct {
 
 // ApplyOptions collects the parameters for Apply.
 type ApplyOptions struct {
-	BundleFS  fs.FS                 // FS with the bundled skills (paths: "bundled/<name>/…")
-	KBRoots   map[string]string     // KB name → absolute path on disk
-	Provider  configurator.Provider // destination provider
-	BaseDir   string                // base directory where artifacts are materialized
-	DryRun    bool                  // if true, writes nothing
-	AutoTrust bool                  // KB trust policy (used in BuildManifest)
-	Lock      Lock                  // current lockfile
+	BundleFS fs.FS                 // FS with the bundled skills (paths: "bundled/<name>/…")
+	KBRoots  map[string]string     // KB name → absolute path on disk
+	Provider configurator.Provider // destination provider
+	BaseDir  string                // base directory where artifacts are materialized
+	DryRun   bool                  // if true, writes nothing
+	// AutoTrust explicitly authorizes eligible unsigned KB artifacts. It does
+	// not alter Artifact.Signed.
+	AutoTrust bool
+	Lock      Lock // current lockfile
 
 	// SkipLockWrite, if true, computes AppliedResult.NewLock but does not persist
 	// it to <BaseDir>/LockFileName. Used by the multi-provider clients
@@ -206,6 +218,60 @@ func ContentHashDirOS(dirPath string) (string, error) {
 	return ContentHashDir(os.DirFS(dirPath), ".")
 }
 
+// ContentHashFiles computes the canonical artifact hash for transport-received
+// files. It is the counterpart of ContentHashDir and includes paths and modes.
+func ContentHashFiles(files []ArtifactFile) string { return hashArtifactFiles(files) }
+
+// VerifyArtifactSignature verifies a KB artifact against the pinned key matching
+// its signature key ID. A missing signature is deliberately unsigned, not an error.
+func VerifyArtifactSignature(a Artifact, keys map[string]ed25519.PublicKey) error {
+	if a.Signature == nil {
+		return nil
+	}
+	if !strings.HasPrefix(a.Source, "kb:") {
+		return fmt.Errorf("provisioning: signature on non-KB artifact %s/%s", a.Kind, a.Name)
+	}
+	key, ok := keys[a.Signature.KeyID]
+	if !ok {
+		return fmt.Errorf("provisioning: unknown signing key for KB %q (key ID %s)", strings.TrimPrefix(a.Source, "kb:"), a.Signature.KeyID)
+	}
+	if err := artifactsig.Verify(key, artifactsig.Identity{Source: a.Source, Kind: a.Kind, Name: a.Name, Version: a.Version, ContentHash: a.ContentHash}, a.Signature); err != nil {
+		return fmt.Errorf("provisioning: verify %s/%s: %w", a.Kind, a.Name, err)
+	}
+	return nil
+}
+
+// VerifiedManifest returns a copy whose Signed flags are cryptographic
+// verification results only. Server-provided Signed values are never trusted.
+func VerifiedManifest(m Manifest, pins map[string][]ed25519.PublicKey) (Manifest, error) {
+	artifacts := append([]Artifact(nil), m.Artifacts...)
+	for i := range artifacts {
+		a := &artifacts[i]
+		a.Signed = false
+		a.BuiltIn = a.Source == "bundle"
+		if a.Signature == nil {
+			continue
+		}
+		kbName := strings.TrimPrefix(a.Source, "kb:")
+		if !strings.HasPrefix(a.Source, "kb:") {
+			return Manifest{}, fmt.Errorf("provisioning: signature source mismatch for %s/%s", a.Kind, a.Name)
+		}
+		keys := make(map[string]ed25519.PublicKey, len(pins[kbName]))
+		for _, key := range pins[kbName] {
+			id := artifactsig.KeyID(key)
+			if _, exists := keys[id]; exists {
+				return Manifest{}, fmt.Errorf("provisioning: duplicate signing key ID for KB %q", kbName)
+			}
+			keys[id] = key
+		}
+		if err := VerifyArtifactSignature(*a, keys); err != nil {
+			return Manifest{}, err
+		}
+		a.Signed = true
+	}
+	return Manifest{Revision: m.Revision, GeneratedAt: m.GeneratedAt, Artifacts: artifacts}, nil
+}
+
 func contentHashDirOS(dirPath, kind string) (string, error) {
 	return contentHashDir(os.DirFS(dirPath), ".", func(path string, executable bool) bool {
 		return effectiveExecutable(kind, path, executable)
@@ -219,16 +285,10 @@ func contentHashDirOS(dirPath, kind string) (string, error) {
 //
 // bundleFS: FS with the bundled skills (paths "bundled/<name>/…"). Can be nil.
 // kbRoots: KB name → absolute path map. KBs with no skills/ folder are skipped.
-// autoTrust: trust policy for KB skills (see signature note below).
-//
-// Note on signing (placeholder — NO real crypto):
-// Bundle skills are always Signed:true: they are compiled into the binary and
-// considered trusted by construction. KB skills are Signed:true only if
-// autoTrust==true (opt-in workspace policy). This is the hook point for a real
-// cryptographic signature check (e.g. cosign/Sigstore) in a future version:
-// replace autoTrust with verification of the signed git commit that introduced
-// the skill.
-func BuildManifest(bundleFS fs.FS, kbRoots map[string]string, autoTrust bool) (Manifest, error) {
+// KB artifacts are signed when BuildOptions has a signer for their mounted KB.
+// Bundled artifacts are trusted by construction and carry BuiltIn instead of a
+// forged Ed25519 signature.
+func BuildManifest(bundleFS fs.FS, kbRoots map[string]string, opts BuildOptions) (Manifest, error) {
 	var artifacts []Artifact
 
 	// 1. Skill dal bundle.
@@ -260,7 +320,7 @@ func BuildManifest(bundleFS fs.FS, kbRoots map[string]string, autoTrust bool) (M
 				Source:      "bundle",
 				Version:     versionByName[name],
 				ContentHash: hash,
-				Signed:      true, // bundle = trusted by construction (see note above)
+				BuiltIn:     true,
 			})
 		}
 	}
@@ -291,9 +351,6 @@ func BuildManifest(bundleFS fs.FS, kbRoots map[string]string, autoTrust bool) (M
 				Source:      "kb:" + kbName,
 				Version:     s.Version,
 				ContentHash: hash,
-				// Signature note (placeholder): Signed:true only if autoTrust==true.
-				// In the future: cryptographic signature check (cosign) on the git commit.
-				Signed: autoTrust,
 			})
 		}
 
@@ -317,7 +374,6 @@ func BuildManifest(bundleFS fs.FS, kbRoots map[string]string, autoTrust bool) (M
 					Name:        name,
 					Source:      "kb:" + kbName,
 					ContentHash: hash,
-					Signed:      autoTrust,
 				})
 			}
 		}
@@ -345,7 +401,6 @@ func BuildManifest(bundleFS fs.FS, kbRoots map[string]string, autoTrust bool) (M
 					Name:        name,
 					Source:      "kb:" + kbName,
 					ContentHash: hash,
-					Signed:      autoTrust,
 				})
 			}
 		}
@@ -404,12 +459,27 @@ func BuildManifest(bundleFS fs.FS, kbRoots map[string]string, autoTrust bool) (M
 			Kind:        "instructions",
 			Name:        kbName,
 			Source:      "kb:" + kbName,
-			ContentHash: contentHashBytes(instrContent),
-			Signed:      autoTrust,
+			ContentHash: hashArtifactFiles([]ArtifactFile{{Path: "instructions.md", Content: instrContent}}),
 			Files:       []ArtifactFile{{Path: "instructions.md", Content: instrContent}},
 		})
 	}
 
+	for i := range artifacts {
+		a := &artifacts[i]
+		if !strings.HasPrefix(a.Source, "kb:") {
+			continue
+		}
+		kbName := strings.TrimPrefix(a.Source, "kb:")
+		key := opts.Signers[kbName]
+		if len(key) == 0 {
+			continue
+		}
+		sig, err := artifactsig.Sign(key, artifactsig.Identity{Source: a.Source, Kind: a.Kind, Name: a.Name, Version: a.Version, ContentHash: a.ContentHash})
+		if err != nil {
+			return Manifest{}, fmt.Errorf("provisioning: sign kb:%s %s/%s: %w", kbName, a.Kind, a.Name, err)
+		}
+		a.Signature = sig
+	}
 	return MergeArtifacts(artifacts), nil
 }
 
@@ -883,12 +953,13 @@ func KindCounts(m Manifest, lock Lock) map[string]KindCount {
 
 // --- Apply ---
 
-// Apply materializes the signed artifacts into BaseDir, prunes stale managed
+// Apply materializes verified, built-in, or explicitly authorized artifacts into BaseDir, prunes stale managed
 // entries and writes the updated lockfile.
 //
 // Safety rules:
-//   - Signed:true → copy/update into BaseDir for the given provider.
-//   - Signed:false → does NOT write; adds to NeedsApproval (default signature gate).
+//   - Signed:true or BuiltIn:true → copy/update into BaseDir for the given provider.
+//   - AutoTrust:true explicitly authorizes eligible unsigned KB artifacts.
+//   - all other artifacts → NeedsApproval.
 //
 // Providers supported for direct materialization:
 //   - claude: skill in .claude/skills/<name>/, agent in .claude/agents/<name>.md,
@@ -932,7 +1003,7 @@ func Apply(m Manifest, opts ApplyOptions) (AppliedResult, error) {
 	// become non-runnable merely because their bytes are unchanged.
 	for _, a := range m.Artifacts {
 		key := a.Kind + "\x00" + a.Name
-		if toWriteKeys[key] || !a.Signed {
+		if toWriteKeys[key] || !artifactAuthorized(a, opts) {
 			continue
 		}
 		if executableModeDrift(a, opts) {
@@ -969,7 +1040,7 @@ func Apply(m Manifest, opts ApplyOptions) (AppliedResult, error) {
 		}
 	}
 
-	// Materialize the signed artifacts.
+	// Materialize the authorized artifacts.
 	for _, a := range toWrite {
 		if a.Kind == "instructions" {
 			// Handled as a group by applyInstructionsGroup below, not here.
@@ -984,7 +1055,7 @@ func Apply(m Manifest, opts ApplyOptions) (AppliedResult, error) {
 				"hook %q: name reserved by Cartographer (bootstrap), KB artifact ignored", a.Name))
 			continue
 		}
-		if !a.Signed {
+		if !artifactAuthorized(a, opts) {
 			// Unsigned artifact: notify + signature gate. Don't write.
 			result.NeedsApproval = append(result.NeedsApproval, a)
 			continue
@@ -1311,7 +1382,7 @@ func applyInstructionsGroup(m Manifest, diff Diff, opts ApplyOptions, tracker *e
 	}
 	sort.Slice(current, func(i, j int) bool { return current[i].Name < current[j].Name })
 
-	// Expanded content and hash computed here, once per signed artifact,
+	// Expanded content and hash computed here, once per authorized artifact,
 	// regardless of triggered: newManaged (below) must stay consistent with the
 	// expanded content even in rounds where the block isn't rewritten
 	// (D75 WP3 — the instructions content already lives in memory via a.Files,
@@ -1320,7 +1391,7 @@ func applyInstructionsGroup(m Manifest, diff Diff, opts ApplyOptions, tracker *e
 	expandedContent := make(map[string][]byte, len(current))
 	contentHashes := make(map[string]string, len(current))
 	for _, a := range current {
-		if !a.Signed {
+		if !artifactAuthorized(a, opts) {
 			result.NeedsApproval = append(result.NeedsApproval, a)
 			continue
 		}
@@ -1335,7 +1406,7 @@ func applyInstructionsGroup(m Manifest, diff Diff, opts ApplyOptions, tracker *e
 
 		contentHash := a.ContentHash
 		if opts.ExpandPlaceholders {
-			contentHash = contentHashBytes(content)
+			contentHash = hashArtifactFiles([]ArtifactFile{{Path: "instructions.md", Content: content}})
 		}
 		contentHashes[a.Name] = contentHash
 		*newManaged = append(*newManaged, ManagedFile{
@@ -1389,6 +1460,16 @@ func applyInstructionsGroup(m Manifest, diff Diff, opts ApplyOptions, tracker *e
 		})
 	}
 	return nil
+}
+
+func artifactAuthorized(a Artifact, opts ApplyOptions) bool {
+	if a.Signed || a.BuiltIn {
+		return true
+	}
+	// MCP descriptors retain their pre-existing stricter explicit approval
+	// boundary; generic trust only preserves compatibility for ordinary KB
+	// provisioning artifacts.
+	return opts.AutoTrust && a.Kind != "mcp" && strings.HasPrefix(a.Source, "kb:")
 }
 
 // writeInstructionsBlock creates or rewrites the managed block delimited by

--- a/internal/provisioning/provisioning_agent_hook_test.go
+++ b/internal/provisioning/provisioning_agent_hook_test.go
@@ -26,7 +26,7 @@ func TestBuildManifest_AgentKB(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"mia-kb": kbRoot}, false)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"mia-kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -54,11 +54,11 @@ func TestBuildManifest_AgentHash_Determinismo(t *testing.T) {
 	os.MkdirAll(agentsDir, 0o755)
 	os.WriteFile(filepath.Join(agentsDir, "reviewer.md"), []byte("Body v1.\n"), 0o644)
 
-	m1, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, false)
+	m1, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest 1: %v", err)
 	}
-	m2, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, false)
+	m2, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest 2: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestBuildManifest_AgentHash_Determinismo(t *testing.T) {
 	}
 
 	os.WriteFile(filepath.Join(agentsDir, "reviewer.md"), []byte("Body v2.\n"), 0o644)
-	m3, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, false)
+	m3, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest 3: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestBuildManifest_HookKB(t *testing.T) {
 	os.WriteFile(filepath.Join(hookDir, "hook.json"), []byte(`{"event":"PostToolUse","matcher":"concept_write","command":"./notify.sh"}`), 0o644)
 	os.WriteFile(filepath.Join(hookDir, "notify.sh"), []byte("#!/bin/sh\necho ok\n"), 0o755)
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"mia-kb": kbRoot}, false)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"mia-kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestBuildManifest_HookHash_MultiFile_OrdineIndipendente(t *testing.T) {
 		t.Errorf("multi-file hook hash: identical content must produce the same hash: %q != %q", h1, h2)
 	}
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot1}, false)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot1}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -161,7 +161,7 @@ func TestHookEffectiveModes_HardFloorAndHashStability(t *testing.T) {
 		t.Fatal(err)
 	}
 	roots := map[string]string{"kb": kbRoot}
-	m1, err := provisioning.BuildManifest(nil, roots, true)
+	m1, err := provisioning.BuildManifest(nil, roots, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,7 +184,8 @@ func TestHookEffectiveModes_HardFloorAndHashStability(t *testing.T) {
 		}
 	}
 	base := t.TempDir()
-	if _, err := provisioning.Apply(m1, provisioning.ApplyOptions{KBRoots: roots, Provider: configurator.ProviderClaudeCode, BaseDir: base}); err != nil {
+	if _, err := provisioning.Apply(m1, provisioning.ApplyOptions{
+		AutoTrust: true, KBRoots: roots, Provider: configurator.ProviderClaudeCode, BaseDir: base}); err != nil {
 		t.Fatal(err)
 	}
 	for name, wantExec := range map[string]bool{"hook.json": false, "run.sh": true} {
@@ -196,7 +197,7 @@ func TestHookEffectiveModes_HardFloorAndHashStability(t *testing.T) {
 	if err := os.Chmod(filepath.Join(dir, "run.sh"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	m2, err := provisioning.BuildManifest(nil, roots, true)
+	m2, err := provisioning.BuildManifest(nil, roots, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,7 +213,7 @@ func TestHookEffectiveModes_HardFloorAndHashStability(t *testing.T) {
 	if err := os.Chmod(filepath.Join(dir, "hook.json"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	m3, err := provisioning.BuildManifest(nil, roots, true)
+	m3, err := provisioning.BuildManifest(nil, roots, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -227,7 +228,7 @@ func TestBuildManifest_NoAgentsHooksDir_ZeroArtefatti(t *testing.T) {
 	kbRoot := t.TempDir()
 	os.MkdirAll(filepath.Join(kbRoot, "skills"), 0o755)
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, false)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -279,9 +280,10 @@ func TestApply_DestDir_Matrix(t *testing.T) {
 		m := provisioning.MergeArtifacts([]provisioning.Artifact{a})
 		baseDir := t.TempDir()
 		res, err := provisioning.Apply(m, provisioning.ApplyOptions{
-			Provider: c.provider,
-			BaseDir:  baseDir,
-			Lock:     provisioning.Lock{},
+			AutoTrust: true,
+			Provider:  c.provider,
+			BaseDir:   baseDir,
+			Lock:      provisioning.Lock{},
 		})
 		if err != nil {
 			t.Fatalf("%s/%s: Apply: %v", c.kind, c.provider, err)
@@ -324,17 +326,18 @@ func TestApply_MaterializzaAgent(t *testing.T) {
 	os.MkdirAll(agentsDir, 0o755)
 	os.WriteFile(filepath.Join(agentsDir, "reviewer.md"), []byte("---\nname: reviewer\n---\nBody.\n"), 0o644)
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
 
 	baseDir := t.TempDir()
 	res, err := provisioning.Apply(m, provisioning.ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderClaudeCode,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderClaudeCode,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	})
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
@@ -375,9 +378,10 @@ func TestApply_OpenCode_MaterializzaAgent_ConFrontmatter(t *testing.T) {
 	m := provisioning.MergeArtifacts([]provisioning.Artifact{a})
 
 	res, err := provisioning.Apply(m, provisioning.ApplyOptions{
-		Provider: configurator.ProviderOpenCode,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		Provider:  configurator.ProviderOpenCode,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	})
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
@@ -415,9 +419,10 @@ func TestApply_OpenCode_MaterializzaAgent_SenzaFrontmatter(t *testing.T) {
 	m := provisioning.MergeArtifacts([]provisioning.Artifact{a})
 
 	_, err := provisioning.Apply(m, provisioning.ApplyOptions{
-		Provider: configurator.ProviderOpenCode,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		Provider:  configurator.ProviderOpenCode,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	})
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
@@ -450,9 +455,10 @@ func TestApply_OpenCode_MaterializzaAgent_DescriptionQuotataConDuePunti(t *testi
 	m := provisioning.MergeArtifacts([]provisioning.Artifact{a})
 
 	_, err := provisioning.Apply(m, provisioning.ApplyOptions{
-		Provider: configurator.ProviderOpenCode,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		Provider:  configurator.ProviderOpenCode,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	})
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
@@ -496,17 +502,18 @@ func TestApply_MaterializzaHook(t *testing.T) {
 	os.WriteFile(filepath.Join(hookDir, "hook.json"), []byte(`{"event":"PostToolUse"}`), 0o644)
 	os.WriteFile(filepath.Join(hookDir, "run.sh"), []byte("#!/bin/sh\n"), 0o755)
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
 
 	baseDir := t.TempDir()
 	res, err := provisioning.Apply(m, provisioning.ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderClaudeCode,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderClaudeCode,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	})
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
@@ -568,9 +575,10 @@ func TestApply_Prune_AgentHook(t *testing.T) {
 	}
 
 	res, err := provisioning.Apply(m, provisioning.ApplyOptions{
-		Provider: configurator.ProviderClaudeCode,
-		BaseDir:  baseDir,
-		Lock:     lock,
+		AutoTrust: true,
+		Provider:  configurator.ProviderClaudeCode,
+		BaseDir:   baseDir,
+		Lock:      lock,
 	})
 	if err != nil {
 		t.Fatalf("Apply prune: %v", err)
@@ -602,9 +610,10 @@ func TestApply_RifiutaPathTraversal_AgentHook(t *testing.T) {
 	for i, a := range cases {
 		m := provisioning.MergeArtifacts([]provisioning.Artifact{a})
 		_, err := provisioning.Apply(m, provisioning.ApplyOptions{
-			Provider: configurator.ProviderClaudeCode,
-			BaseDir:  baseDir,
-			Lock:     provisioning.Lock{},
+			AutoTrust: true,
+			Provider:  configurator.ProviderClaudeCode,
+			BaseDir:   baseDir,
+			Lock:      provisioning.Lock{},
 		})
 		if err == nil {
 			t.Errorf("case %d (kind=%s name=%q): Apply should have rejected the malicious name", i, a.Kind, a.Name)

--- a/internal/provisioning/provisioning_codex_test.go
+++ b/internal/provisioning/provisioning_codex_test.go
@@ -29,9 +29,10 @@ func TestApply_Codex_MaterializzaAgent_ConFrontmatter(t *testing.T) {
 	m := provisioning.MergeArtifacts([]provisioning.Artifact{a})
 
 	res, err := provisioning.Apply(m, provisioning.ApplyOptions{
-		Provider: configurator.ProviderCodex,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		Provider:  configurator.ProviderCodex,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	})
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
@@ -73,9 +74,10 @@ func TestApply_Codex_MaterializzaAgent_SenzaFrontmatter(t *testing.T) {
 	m := provisioning.MergeArtifacts([]provisioning.Artifact{a})
 
 	_, err := provisioning.Apply(m, provisioning.ApplyOptions{
-		Provider: configurator.ProviderCodex,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		Provider:  configurator.ProviderCodex,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	})
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
@@ -124,17 +126,18 @@ func TestApply_Codex_Hook_RegistraConfigTOML(t *testing.T) {
 	kbRoot := t.TempDir()
 	writeCodexHookKB(t, kbRoot, "notify", "PostToolUse", "concept_write", "./notify.sh")
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
 
 	baseDir := t.TempDir()
 	res, err := provisioning.Apply(m, provisioning.ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderCodex,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderCodex,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	})
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
@@ -174,17 +177,18 @@ func TestApply_Codex_Hook_ReApply_NessunDuplicato(t *testing.T) {
 	kbRoot := t.TempDir()
 	writeCodexHookKB(t, kbRoot, "notify", "PostToolUse", "concept_write", "./notify.sh")
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
 
 	baseDir := t.TempDir()
 	opts := provisioning.ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderCodex,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderCodex,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	}
 	for i := 0; i < 3; i++ {
 		if _, err := provisioning.Apply(m, opts); err != nil {
@@ -207,7 +211,7 @@ func TestApply_Codex_Hook_MCPBlock_CoesisteConHook(t *testing.T) {
 	// erase the other.
 	kbRoot := t.TempDir()
 	writeCodexHookKB(t, kbRoot, "notify", "PostToolUse", "concept_write", "./notify.sh")
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -223,10 +227,11 @@ func TestApply_Codex_Hook_MCPBlock_CoesisteConHook(t *testing.T) {
 	}
 
 	if _, err := provisioning.Apply(m, provisioning.ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderCodex,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderCodex,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	}); err != nil {
 		t.Fatalf("provisioning.Apply: %v", err)
 	}
@@ -247,17 +252,18 @@ func TestApply_Codex_Hook_MCPBlock_CoesisteConHook(t *testing.T) {
 func TestApply_Codex_Hook_Removed_RipulisceConfigTOML(t *testing.T) {
 	kbRoot := t.TempDir()
 	writeCodexHookKB(t, kbRoot, "notify", "PostToolUse", "concept_write", "./notify.sh")
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
 	baseDir := t.TempDir()
 
 	res, err := provisioning.Apply(m, provisioning.ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderCodex,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderCodex,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	})
 	if err != nil {
 		t.Fatalf("Apply (materialize): %v", err)
@@ -266,16 +272,17 @@ func TestApply_Codex_Hook_Removed_RipulisceConfigTOML(t *testing.T) {
 	if err := os.RemoveAll(filepath.Join(kbRoot, "hooks", "notify")); err != nil {
 		t.Fatal(err)
 	}
-	m2, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m2, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest (2): %v", err)
 	}
 
 	res2, err := provisioning.Apply(m2, provisioning.ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderCodex,
-		BaseDir:  baseDir,
-		Lock:     res.NewLock,
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderCodex,
+		BaseDir:   baseDir,
+		Lock:      res.NewLock,
 	})
 	if err != nil {
 		t.Fatalf("Apply (removal): %v", err)
@@ -381,17 +388,18 @@ func TestApply_Codex_Hook_ReApplyAfterCodexRewrite_NoDuplicate(t *testing.T) {
 	writeCodexHookKB(t, kbRoot, "notify", "PostToolUse", "concept_write", "./notify.sh")
 	writeCodexHookKB(t, kbRoot, "other", "SessionStart", "", "./notify.sh")
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
 
 	baseDir := t.TempDir()
 	opts := provisioning.ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderCodex,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderCodex,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	}
 	if _, err := provisioning.Apply(m, opts); err != nil {
 		t.Fatalf("Apply (1): %v", err)
@@ -432,7 +440,7 @@ func TestApply_Codex_Hook_ReApplyAfterCodexRewrite_NoDuplicate(t *testing.T) {
 func TestApply_Codex_Hook_Adoption_PreservesUserHookAndState(t *testing.T) {
 	kbRoot := t.TempDir()
 	writeCodexHookKB(t, kbRoot, "notify", "PostToolUse", "concept_write", "./notify.sh")
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -458,10 +466,11 @@ command = "/Users/me/scripts/mine.sh"
 	}
 
 	opts := provisioning.ApplyOptions{
-		KBRoots:  map[string]string{"kb": kbRoot},
-		Provider: configurator.ProviderCodex,
-		BaseDir:  baseDir,
-		Lock:     provisioning.Lock{},
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderCodex,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
 	}
 	if _, err := provisioning.Apply(m, opts); err != nil {
 		t.Fatalf("Apply (1): %v", err)

--- a/internal/provisioning/provisioning_disconnect_test.go
+++ b/internal/provisioning/provisioning_disconnect_test.go
@@ -124,7 +124,7 @@ func TestRoundTrip_ConnectDisconnect_NessunResiduo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}

--- a/internal/provisioning/provisioning_instructions_test.go
+++ b/internal/provisioning/provisioning_instructions_test.go
@@ -75,11 +75,11 @@ func TestBuildManifest_Instructions_Determinismo(t *testing.T) {
 		"topics":   {"networking.md"},
 	})
 
-	m1, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, false)
+	m1, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest 1: %v", err)
 	}
-	m2, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, false)
+	m2, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest 2: %v", err)
 	}
@@ -102,7 +102,7 @@ func TestBuildManifest_Instructions_Determinismo(t *testing.T) {
 	// A new page in an existing archive does NOT change the content (no
 	// counts, D65): the hash stays stable and the block doesn't need re-syncing.
 	os.WriteFile(filepath.Join(kbRoot, "data", "entities", "new.md"), []byte("# new\n"), 0o644)
-	m3, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, false)
+	m3, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest 3: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestBuildManifest_Instructions_Determinismo(t *testing.T) {
 	// A new archive, on the other hand, changes the listed structure: the hash must change.
 	os.MkdirAll(filepath.Join(kbRoot, "data", "incidents"), 0o755)
 	os.WriteFile(filepath.Join(kbRoot, "data", "incidents", "i1.md"), []byte("# i1\n"), 0o644)
-	m4, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, false)
+	m4, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest 4: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestBuildManifest_Instructions_ArchiviElencatiEdEsclusioneInfra(t *testing.
 		os.MkdirAll(filepath.Join(kbRoot, d), 0o755)
 	}
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, false)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -171,7 +171,7 @@ func TestBuildManifest_Instructions_NessunArchivio(t *testing.T) {
 	kbRoot := t.TempDir()
 	os.MkdirAll(filepath.Join(kbRoot, "data"), 0o755)
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"vuota": kbRoot}, false)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"vuota": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -195,7 +195,7 @@ func TestBuildManifest_Instructions_SezioneAgent(t *testing.T) {
 		"---\nname: zorro\ndescription: Defends the KB from intruders\n---\nzorro prompt.\n")
 	writeFile(t, filepath.Join(agentsDir, "anonimo.md"), "No frontmatter here.\n")
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, false)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -214,7 +214,7 @@ func TestBuildManifest_Instructions_SezioneAgent(t *testing.T) {
 func TestBuildManifest_Instructions_NessunaSezioneSenzaAgentNeCurato(t *testing.T) {
 	kbRoot := makeKBWithArchives(t, map[string][]string{"entities": {"a.md"}})
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, false)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -239,7 +239,7 @@ func TestBuildManifest_Instructions_CuratoSenzaFrontmatter(t *testing.T) {
 	kbRoot := makeKBWithArchives(t, map[string][]string{"entities": {"a.md"}})
 	writeFile(t, filepath.Join(kbRoot, "instructions.md"), "Rule: bulk reads -> explorer.\n")
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, false)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -260,7 +260,7 @@ func TestBuildManifest_Instructions_CuratoConFrontmatter(t *testing.T) {
 	writeFile(t, filepath.Join(kbRoot, "instructions.md"),
 		"---\ntitle: orchestration\n---\nDelegate mechanical work to OpenCode.\n")
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, false)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -283,7 +283,7 @@ func TestBuildManifest_Instructions_HashStabileConDescriptionAgent(t *testing.T)
 	agentPath := filepath.Join(agentsDir, "reviewer.md")
 	writeFile(t, agentPath, "---\ndescription: First version\n---\nPrompt.\n")
 
-	m1, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, false)
+	m1, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest 1: %v", err)
 	}
@@ -293,7 +293,7 @@ func TestBuildManifest_Instructions_HashStabileConDescriptionAgent(t *testing.T)
 	// change the block. (The updated description still travels with the
 	// "agent" kind artifact, which has its own ContentHash.)
 	writeFile(t, agentPath, "---\ndescription: Second version\n---\nPrompt.\n")
-	m2, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, false)
+	m2, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest 2: %v", err)
 	}
@@ -305,7 +305,7 @@ func TestBuildManifest_Instructions_HashStabileConDescriptionAgent(t *testing.T)
 
 	// An extra agent, on the other hand, changes the list of names: the hash must change.
 	writeFile(t, filepath.Join(agentsDir, "nuovo.md"), "---\ndescription: X\n---\nPrompt.\n")
-	m3, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, false)
+	m3, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest 3: %v", err)
 	}
@@ -320,14 +320,14 @@ func TestBuildManifest_Instructions_HashCambiaConCurato(t *testing.T) {
 	instrPath := filepath.Join(kbRoot, "instructions.md")
 	writeFile(t, instrPath, "Version one.\n")
 
-	m1, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, false)
+	m1, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest 1: %v", err)
 	}
 	h1 := findInstructionsArtifact(t, m1, "homelab").ContentHash
 
 	writeFile(t, instrPath, "Version two.\n")
-	m2, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, false)
+	m2, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest 2: %v", err)
 	}

--- a/internal/provisioning/provisioning_mcp_test.go
+++ b/internal/provisioning/provisioning_mcp_test.go
@@ -40,7 +40,7 @@ func findMCPArtifact(t *testing.T, m provisioning.Manifest, name string) provisi
 
 func TestBuildManifest_MCP_NoDirIsRetrocompat(t *testing.T) {
 	kbRoot := t.TempDir()
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, false)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -56,10 +56,10 @@ func TestBuildManifest_MCP_ScansAndAlwaysUnsigned(t *testing.T) {
 	writeMCPFixture(t, kbRoot, "wiki-tools",
 		`{"type":"http","url":"https://tools.example.com/mcp","headers":{"Authorization":"Bearer ${WIKI_TOOLS_TOKEN}"}}`)
 
-	for _, autoTrust := range []bool{false, true} {
-		m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, autoTrust)
+	{
+		m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 		if err != nil {
-			t.Fatalf("BuildManifest(autoTrust=%v): %v", autoTrust, err)
+			t.Fatalf("BuildManifest: %v", err)
 		}
 		a := findMCPArtifact(t, m, "wiki-tools")
 		if a.Source != "kb:kb" {
@@ -68,10 +68,9 @@ func TestBuildManifest_MCP_ScansAndAlwaysUnsigned(t *testing.T) {
 		if a.ContentHash == "" {
 			t.Error("ContentHash should not be empty")
 		}
-		// D69 WP5: never signed regardless of autoTrust — a stricter policy
-		// than the other kinds.
+		// Without a configured signer, an MCP artifact remains unsigned.
 		if a.Signed {
-			t.Errorf("autoTrust=%v: Signed = true, want always false for kind mcp", autoTrust)
+			t.Error("Signed = true, want false without signer")
 		}
 	}
 }
@@ -80,7 +79,7 @@ func TestBuildManifest_MCP_MalformedFileFailsBuild(t *testing.T) {
 	kbRoot := t.TempDir()
 	writeMCPFixture(t, kbRoot, "broken", `{not json`)
 
-	if _, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, false); err == nil {
+	if _, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{}); err == nil {
 		t.Fatal("expected BuildManifest to fail on a malformed mcp/*.json file")
 	}
 }
@@ -90,7 +89,7 @@ func TestBuildManifest_MCP_LiteralSecretFailsBuild(t *testing.T) {
 	writeMCPFixture(t, kbRoot, "leaky",
 		`{"type":"http","url":"https://example.com/mcp","headers":{"Authorization":"Bearer sk-live-hardcoded"}}`)
 
-	if _, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, false); err == nil {
+	if _, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{}); err == nil {
 		t.Fatal("expected BuildManifest to fail on a literal secret in headers")
 	}
 }
@@ -101,7 +100,7 @@ func TestBuildManifest_MCP_LiteralSecretFailsBuild(t *testing.T) {
 // TestBuildManifest_MCP_ScansAndAlwaysUnsigned).
 func signedMCPManifest(t *testing.T, kbRoot, name string) provisioning.Manifest {
 	t.Helper()
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -116,7 +115,7 @@ func signedMCPManifest(t *testing.T, kbRoot, name string) provisioning.Manifest 
 func TestApply_MCP_UnsignedNeedsApproval(t *testing.T) {
 	kbRoot := t.TempDir()
 	writeMCPFixture(t, kbRoot, "wiki-tools", `{"type":"http","url":"https://tools.example.com/mcp"}`)
-	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}

--- a/internal/provisioning/provisioning_test.go
+++ b/internal/provisioning/provisioning_test.go
@@ -79,7 +79,7 @@ func TestContentHashDir_OrdineFile(t *testing.T) {
 // --- BuildManifest ---
 
 func TestBuildManifest_BundledSkillInventory(t *testing.T) {
-	m, err := provisioning.BuildManifest(skillbundle.FS, nil, false)
+	m, err := provisioning.BuildManifest(skillbundle.FS, nil, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest bundled skills: %v", err)
 	}
@@ -100,11 +100,11 @@ func TestBuildManifest_BundledSkillInventory(t *testing.T) {
 func TestBuildManifest_RevisioneDeterministica(t *testing.T) {
 	bundleFS := makeBundleFS("Body.")
 
-	m1, err := provisioning.BuildManifest(bundleFS, nil, false)
+	m1, err := provisioning.BuildManifest(bundleFS, nil, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest 1: %v", err)
 	}
-	m2, err := provisioning.BuildManifest(bundleFS, nil, false)
+	m2, err := provisioning.BuildManifest(bundleFS, nil, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest 2: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestBuildManifest_RevisioneDeterministica(t *testing.T) {
 
 func TestBuildManifest_TemplatesAreIgnored(t *testing.T) {
 	root := t.TempDir()
-	baseline, err := provisioning.BuildManifest(nil, map[string]string{"kb": root}, false)
+	baseline, err := provisioning.BuildManifest(nil, map[string]string{"kb": root}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,7 +128,7 @@ func TestBuildManifest_TemplatesAreIgnored(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, "templates", "note.md"), []byte("---\ntype: Note\ntitle: Note\n---\n# Note\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	withTemplate, err := provisioning.BuildManifest(nil, map[string]string{"kb": root}, false)
+	withTemplate, err := provisioning.BuildManifest(nil, map[string]string{"kb": root}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -146,17 +146,17 @@ func TestBuildManifest_CambioContenuto(t *testing.T) {
 	bundleFS1 := makeBundleFS("Original body.")
 	bundleFS2 := makeBundleFS("Modified body.")
 
-	m1, _ := provisioning.BuildManifest(bundleFS1, nil, false)
-	m2, _ := provisioning.BuildManifest(bundleFS2, nil, false)
+	m1, _ := provisioning.BuildManifest(bundleFS1, nil, provisioning.BuildOptions{})
+	m2, _ := provisioning.BuildManifest(bundleFS2, nil, provisioning.BuildOptions{})
 
 	if m1.Revision == m2.Revision {
 		t.Error("BuildManifest: different content must produce a different revision")
 	}
 }
 
-func TestBuildManifest_SkillBundleSigned(t *testing.T) {
+func TestBuildManifest_SkillBundleBuiltIn(t *testing.T) {
 	bundleFS := makeBundleFS("Body.")
-	m, err := provisioning.BuildManifest(bundleFS, nil, false)
+	m, err := provisioning.BuildManifest(bundleFS, nil, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -164,38 +164,26 @@ func TestBuildManifest_SkillBundleSigned(t *testing.T) {
 		t.Fatal("BuildManifest: no artifacts")
 	}
 	for _, a := range m.Artifacts {
-		if a.Source == "bundle" && !a.Signed {
-			t.Errorf("bundle skill %q must have Signed:true", a.Name)
+		if a.Source == "bundle" && (!a.BuiltIn || a.Signed || a.Signature != nil) {
+			t.Errorf("bundle skill %q must use built-in trust, got %+v", a.Name, a)
 		}
 	}
 }
 
-func TestBuildManifest_KBSkillAutoTrust(t *testing.T) {
+func TestBuildManifest_KBSkillUnsignedWithoutSigner(t *testing.T) {
 	// Create a test KB with a skill.
 	kbRoot := t.TempDir()
 	skillDir := filepath.Join(kbRoot, "skills", "my-skill")
 	os.MkdirAll(skillDir, 0o755)
 	os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: my-skill\ndescription: Test\n---\nBody.\n"), 0o644)
 
-	// autoTrust=false → Signed:false
-	m1, err := provisioning.BuildManifest(nil, map[string]string{"test-kb": kbRoot}, false)
+	m1, err := provisioning.BuildManifest(nil, map[string]string{"test-kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
-		t.Fatalf("BuildManifest autoTrust=false: %v", err)
+		t.Fatalf("BuildManifest: %v", err)
 	}
 	for _, a := range m1.Artifacts {
 		if a.Source == "kb:test-kb" && a.Signed {
-			t.Errorf("KB skill %q with autoTrust=false must have Signed:false", a.Name)
-		}
-	}
-
-	// autoTrust=true → Signed:true
-	m2, err := provisioning.BuildManifest(nil, map[string]string{"test-kb": kbRoot}, true)
-	if err != nil {
-		t.Fatalf("BuildManifest autoTrust=true: %v", err)
-	}
-	for _, a := range m2.Artifacts {
-		if a.Source == "kb:test-kb" && !a.Signed {
-			t.Errorf("KB skill %q with autoTrust=true must have Signed:true", a.Name)
+			t.Errorf("KB skill %q without signer must have Signed:false", a.Name)
 		}
 	}
 }
@@ -213,7 +201,7 @@ func TestBuildManifest_ExecutableSkillChangesHashAndApplyMode(t *testing.T) {
 	if err := os.WriteFile(script, []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	m1, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m1, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,7 +219,7 @@ func TestBuildManifest_ExecutableSkillChangesHashAndApplyMode(t *testing.T) {
 		t.Fatal("script executable bit was not read")
 	}
 	base := t.TempDir()
-	if _, err := provisioning.Apply(m1, provisioning.ApplyOptions{KBRoots: map[string]string{"kb": kbRoot}, Provider: configurator.ProviderClaudeCode, BaseDir: base, Lock: provisioning.Lock{}}); err != nil {
+	if _, err := provisioning.Apply(m1, provisioning.ApplyOptions{AutoTrust: true, KBRoots: map[string]string{"kb": kbRoot}, Provider: configurator.ProviderClaudeCode, BaseDir: base, Lock: provisioning.Lock{}}); err != nil {
 		t.Fatal(err)
 	}
 	info, err := os.Stat(filepath.Join(base, ".claude", "skills", "run", "run.sh"))
@@ -241,7 +229,7 @@ func TestBuildManifest_ExecutableSkillChangesHashAndApplyMode(t *testing.T) {
 	if err := os.Chmod(script, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	m2, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, true)
+	m2, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -319,7 +307,7 @@ func TestBuildManifest_DedupBundleVsKB(t *testing.T) {
 	os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
 		[]byte("---\nname: kb-create\ndescription: KB version\n---\nKB body.\n"), 0o644)
 
-	m, err := provisioning.BuildManifest(bundleFS, map[string]string{"mia-kb": kbRoot}, true)
+	m, err := provisioning.BuildManifest(bundleFS, map[string]string{"mia-kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -340,7 +328,7 @@ func TestBuildManifest_DedupBundleVsKB(t *testing.T) {
 	}
 
 	// The revision must remain deterministic even with the collision.
-	m2, _ := provisioning.BuildManifest(bundleFS, map[string]string{"mia-kb": kbRoot}, true)
+	m2, _ := provisioning.BuildManifest(bundleFS, map[string]string{"mia-kb": kbRoot}, provisioning.BuildOptions{})
 	if m.Revision != m2.Revision {
 		t.Errorf("dedup: non-deterministic revision: %q != %q", m.Revision, m2.Revision)
 	}
@@ -469,7 +457,7 @@ func TestApply_ScriveTrusted(t *testing.T) {
 	baseDir := t.TempDir()
 	bundleFS := makeBundleFS("Body skill bundled.")
 
-	m, err := provisioning.BuildManifest(bundleFS, nil, false)
+	m, err := provisioning.BuildManifest(bundleFS, nil, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -519,7 +507,7 @@ func TestApply_SaltaNonSigned(t *testing.T) {
 	os.MkdirAll(skillDir, 0o755)
 	os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: kb-skill\ndescription: Test\n---\nBody.\n"), 0o644)
 
-	m, err := provisioning.BuildManifest(nil, map[string]string{"mia-kb": kbRoot}, false)
+	m, err := provisioning.BuildManifest(nil, map[string]string{"mia-kb": kbRoot}, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -594,7 +582,7 @@ func TestApply_DryRun(t *testing.T) {
 	baseDir := t.TempDir()
 	bundleFS := makeBundleFS("Body dry run.")
 
-	m, err := provisioning.BuildManifest(bundleFS, nil, false)
+	m, err := provisioning.BuildManifest(bundleFS, nil, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -632,7 +620,7 @@ func TestApply_Idempotente(t *testing.T) {
 	baseDir := t.TempDir()
 	bundleFS := makeBundleFS("Idempotent body.")
 
-	m, err := provisioning.BuildManifest(bundleFS, nil, false)
+	m, err := provisioning.BuildManifest(bundleFS, nil, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -671,7 +659,7 @@ func TestApply_OpenCode_Materializza(t *testing.T) {
 	baseDir := t.TempDir()
 	bundleFS := makeBundleFS("OpenCode test body.")
 
-	m, err := provisioning.BuildManifest(bundleFS, nil, false)
+	m, err := provisioning.BuildManifest(bundleFS, nil, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -715,7 +703,7 @@ func TestApply_Codex_Materializza(t *testing.T) {
 	baseDir := t.TempDir()
 	bundleFS := makeBundleFS("Codex test body.")
 
-	m, err := provisioning.BuildManifest(bundleFS, nil, false)
+	m, err := provisioning.BuildManifest(bundleFS, nil, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -756,7 +744,7 @@ func TestApply_Kiro_Materializza(t *testing.T) {
 	baseDir := t.TempDir()
 	bundleFS := makeBundleFS("Kiro test body.")
 
-	m, err := provisioning.BuildManifest(bundleFS, nil, false)
+	m, err := provisioning.BuildManifest(bundleFS, nil, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -797,7 +785,7 @@ func TestApply_ScriveLockfile(t *testing.T) {
 	baseDir := t.TempDir()
 	bundleFS := makeBundleFS("Lock test body.")
 
-	m, err := provisioning.BuildManifest(bundleFS, nil, false)
+	m, err := provisioning.BuildManifest(bundleFS, nil, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}
@@ -961,7 +949,7 @@ func TestApply_SkipLockWrite(t *testing.T) {
 	baseDir := t.TempDir()
 	bundleFS := makeBundleFS("Skip lock body.")
 
-	m, err := provisioning.BuildManifest(bundleFS, nil, false)
+	m, err := provisioning.BuildManifest(bundleFS, nil, provisioning.BuildOptions{})
 	if err != nil {
 		t.Fatalf("BuildManifest: %v", err)
 	}

--- a/internal/provisioning/signing_test.go
+++ b/internal/provisioning/signing_test.go
@@ -1,0 +1,78 @@
+package provisioning_test
+
+import (
+	"crypto/ed25519"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BeppeTemp/cartographer/internal/artifactsig"
+	"github.com/BeppeTemp/cartographer/internal/provisioning"
+)
+
+func TestBuildManifestSignatureVerificationAndRotation(t *testing.T) {
+	root := t.TempDir()
+	for _, kbName := range []string{"signed", "unsigned"} {
+		dir := filepath.Join(root, kbName, "skills", "example")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: example\ndescription: test\n---\nbody\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	first, err := artifactsig.ParseSeed(strings.Repeat("04", ed25519.SeedSize))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := artifactsig.ParseSeed(strings.Repeat("05", ed25519.SeedSize))
+	if err != nil {
+		t.Fatal(err)
+	}
+	roots := map[string]string{"signed": filepath.Join(root, "signed"), "unsigned": filepath.Join(root, "unsigned")}
+	firstManifest, err := provisioning.BuildManifest(nil, roots, provisioning.BuildOptions{Signers: map[string]ed25519.PrivateKey{"signed": first}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rotatedManifest, err := provisioning.BuildManifest(nil, roots, provisioning.BuildOptions{Signers: map[string]ed25519.PrivateKey{"signed": second}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstManifest.Revision != rotatedManifest.Revision {
+		t.Fatalf("signature rotation changed revision: %s != %s", firstManifest.Revision, rotatedManifest.Revision)
+	}
+	var signed, unsigned provisioning.Artifact
+	for _, artifact := range firstManifest.Artifacts {
+		switch artifact.Source {
+		case "kb:signed":
+			signed = artifact
+		case "kb:unsigned":
+			unsigned = artifact
+		}
+	}
+	if signed.Signature == nil || signed.Signed {
+		t.Fatalf("signed artifact must carry an unverified signature: %+v", signed)
+	}
+	if unsigned.Signature != nil || unsigned.Signed {
+		t.Fatalf("unsigned artifact = %+v", unsigned)
+	}
+	verified, err := provisioning.VerifiedManifest(firstManifest, map[string][]ed25519.PublicKey{"signed": {first.Public().(ed25519.PublicKey)}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, artifact := range verified.Artifacts {
+		if artifact.Source == "kb:signed" && !artifact.Signed {
+			t.Fatal("valid signed artifact was not verified")
+		}
+		if artifact.Source == "kb:unsigned" && artifact.Signed {
+			t.Fatal("unsigned artifact became verified")
+		}
+	}
+	if _, err := provisioning.VerifiedManifest(rotatedManifest, map[string][]ed25519.PublicKey{"signed": {second.Public().(ed25519.PublicKey)}}); err != nil {
+		t.Fatalf("rotated key did not verify: %v", err)
+	}
+	if _, err := provisioning.VerifiedManifest(firstManifest, map[string][]ed25519.PublicKey{"signed": {first.Public().(ed25519.PublicKey), first.Public().(ed25519.PublicKey)}}); err == nil || !strings.Contains(err.Error(), "duplicate signing key ID") {
+		t.Fatalf("duplicate key ID error = %v", err)
+	}
+}

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -27,6 +27,7 @@ overrides the default base port.
 | `08_git_multiclone` | Remote pull/rebase visibility across clones |
 | `09_git_conflict` | Conflict registry, degraded marker and conflict listing |
 | `10_scoped_tokens` | Per-KB `r`/`rw` scope enforcement |
+| `11_signed_provisioning` | Signed artifact verification and fail-closed unpinned rotation |
 
 The numbering is retained to preserve historical references. Removed gaps were
 LLM-driven scenarios; model behavior is evaluated during real usage, not in the

--- a/test/e2e/lib/server.sh
+++ b/test/e2e/lib/server.sh
@@ -4,6 +4,7 @@
 # Optional environment variables for server_start:
 #   E2E_AUTH    "true" | "false" (default: false) — enables bearer token auth
 #   E2E_TOKENS  token string (required if E2E_AUTH=true)
+#   E2E_CONFIG  server YAML path; when set it replaces --kb/--http flags
 
 # HTTP port for the E2E tests. High port unlikely to collide with common
 # services on either the conventional HTTP port or Cartographer's local default.
@@ -33,12 +34,14 @@ server_start() {
     local auth="${E2E_AUTH:-false}"
     local tokens="${E2E_TOKENS:-}"
 
-    CARTOGRAPHER_AUTH="${auth}" \
-    CARTOGRAPHER_TOKENS="${tokens}" \
-        "$bin" serve \
-        --kb "$kb_paths" \
-        --init \
-        --http ":${E2E_HTTP_PORT}" \
+	local args=(serve --kb "$kb_paths" --init --http ":${E2E_HTTP_PORT}")
+	if [[ -n "${E2E_CONFIG:-}" ]]; then
+		args=(serve --config "$E2E_CONFIG")
+	fi
+
+	CARTOGRAPHER_AUTH="${auth}" \
+	CARTOGRAPHER_TOKENS="${tokens}" \
+		"$bin" "${args[@]}" \
         >"${E2E_TMP_DIR:-/tmp}/cartographer_e2e.log" 2>&1 &
 
     echo "$!" > "$_SERVER_PID_FILE"

--- a/test/e2e/scenarios/11_signed_provisioning.sh
+++ b/test/e2e/scenarios/11_signed_provisioning.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# scenarios/11_signed_provisioning.sh — signed provisioning and fail-closed rotation.
+set -uo pipefail
+
+SCENARIO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_DIR="$(cd "${SCENARIO_DIR}/.." && pwd)"
+source "${E2E_DIR}/lib/assert.sh"
+source "${E2E_DIR}/lib/kb.sh"
+source "${E2E_DIR}/lib/server.sh"
+
+SCENARIO_NAME="11_signed_provisioning"
+BIN="${REPO_ROOT}/bin/cartographer"
+KB_DIR="${E2E_TMP_DIR}/${SCENARIO_NAME}/kb"
+SANDBOX_DIR="${E2E_TMP_DIR}/${SCENARIO_NAME}/sandbox"
+CONFIG="${E2E_TMP_DIR}/${SCENARIO_NAME}/server.yaml"
+SERVER_URL="http://127.0.0.1:${E2E_HTTP_PORT}/mcp"
+FIRST_SEED="9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60"
+FIRST_PUBLIC="d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+SECOND_SEED="4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb"
+
+write_config() { cat >"${CONFIG}" <<EOF
+http: ":${E2E_HTTP_PORT}"
+init: true
+kbs:
+  - path: ${KB_DIR}
+    artifact_signing_seed: $1
+EOF
+}
+
+mkdir -p "${E2E_TMP_DIR}/${SCENARIO_NAME}" "${SANDBOX_DIR}"
+kb_make "${KB_DIR}"
+mkdir -p "${KB_DIR}/skills/signed"
+cat >"${KB_DIR}/skills/signed/SKILL.md" <<'EOF'
+---
+name: signed
+description: Signed provisioning E2E fixture
+---
+signed content
+EOF
+write_config "${FIRST_SEED}"
+export E2E_CONFIG="${CONFIG}"
+server_start "${KB_DIR}"
+server_wait_health 20
+trap 'server_stop' EXIT
+
+if (cd "${SANDBOX_DIR}" && HOME="${SANDBOX_DIR}" "${BIN}" connect claude --server-url "${SERVER_URL}" --pin-key "kb=${FIRST_PUBLIC}") >"${SANDBOX_DIR}/connect.out" 2>&1; then _assert_pass "signed connect succeeds"; else _assert_fail "signed connect fails: $(cat "${SANDBOX_DIR}/connect.out")"; fi
+PROVIDER_FILE="${SANDBOX_DIR}/.claude/skills/signed/SKILL.md"
+LOCK_FILE="${SANDBOX_DIR}/.cartographer-sync.lock.json"
+assert_file_exists "${PROVIDER_FILE}"
+assert_file_exists "${LOCK_FILE}"
+cp "${PROVIDER_FILE}" "${SANDBOX_DIR}/provider.before"
+cp "${LOCK_FILE}" "${SANDBOX_DIR}/lock.before"
+
+server_stop
+write_config "${SECOND_SEED}"
+server_start "${KB_DIR}"
+server_wait_health 20
+if sync_output=$(cd "${SANDBOX_DIR}" && HOME="${SANDBOX_DIR}" "${BIN}" sync 2>&1); then _assert_fail "sync unexpectedly accepts artifacts signed by an unpinned key"; else _assert_pass "sync rejects artifacts signed by an unpinned key"; [[ "${sync_output}" == *"unknown signing key"* ]] && _assert_pass "unknown key error is actionable" || _assert_fail "missing actionable unknown-key error: ${sync_output}"; fi
+cmp -s "${SANDBOX_DIR}/provider.before" "${PROVIDER_FILE}" && _assert_pass "failed signed sync leaves provider file unchanged" || _assert_fail "failed signed sync changed provider file"
+cmp -s "${SANDBOX_DIR}/lock.before" "${LOCK_FILE}" && _assert_pass "failed signed sync leaves lockfile unchanged" || _assert_fail "failed signed sync changed lockfile"
+[[ "${E2E_FAILURES}" -eq 0 ]] && exit 0
+exit 1


### PR DESCRIPTION
## Summary

- sign KB provisioning artifacts with a canonical, domain-separated Ed25519 envelope
- pin public keys on clients and verify received content before any materialization
- preserve explicit unsigned authorization without changing verification state

## Validation

- `rtk make vet`
- `rtk make test`
- `rtk make e2e`
- `rtk git diff --check`

Closes #54

Generated with Codex