### PR TITLE
fix(client): propagate MCP trust states to status and TUI output

### DIFF
--- a/cmd/cartographer/clientsync.go
+++ b/cmd/cartographer/clientsync.go
@@ -143,33 +143,13 @@ func pinnedPublicKeys(cfg *clientconfig.Config) (map[string][]ed25519.PublicKey,
 	return pins, nil
 }
 
-// upgradeTrustedManifest remains the status-path compatibility hook. Trust is
-// authorization consumed by ApplyOptions, never a mutation of verification.
-func upgradeTrustedManifest(m provisioning.Manifest, trust bool) provisioning.Manifest { return m }
-
-// upgradeTrustedManifest returns a copy of m with every kb:-sourced artifact
-// upgraded to Signed:true when trust is true; m unchanged (same slice) when
-// trust is false. This is the single place the trust decision (persistent
-// cfg.Trust from .cartographer.yaml, or a one-time --auto-trust flag) is
-// applied to a manifest — used both by materializeForProviders, before
-// provisioning.Apply, and by callers that only need an honest diff/status
-// (cmdStatus, the TUI dashboard) without materializing anything. sync_pull
-// never accepts an auto_trust argument (unlike the local sync_apply MCP
-// tool): the trust decision is entirely client-side (see docs/sync.md
-// §Sicurezza — gate di firma).
-//
-// Kind "mcp" (D69, WP5) is excluded from this blanket upgrade: a third-party
-// MCP server is an endpoint that receives the agent's data, a stricter policy
-// than the other kinds — it always needs its own approval at first appearance
-// and at every hash change, even with AutoTrust/cfg.Trust on.
 // materializeForProviders applies manifest m for each provider in providers,
 // persisting a single v2 LockFile at <targetDir>/.cartographer-sync.lock.json (one
-// Lock entry per provider). autoTrust upgrades kb:-sourced artifacts to Signed:true
-// before materialization (see upgradeTrustedManifest) — callers pass
-// cfg.Trust || --auto-trust so the persisted per-server decision and the
-// one-time flag both apply. searchRoots/paths come from the loaded
-// clientconfig.Config (cfg.SearchRoots/cfg.Paths) and drive placeholder
-// expansion (D75 WP3) — this is the one place cmd/cartographer turns
+// Lock entry per provider). autoTrust is explicit authorization for eligible
+// unsigned KB artifacts, passed to ApplyOptions.AutoTrust; it never changes an
+// artifact's Signed verification result. searchRoots/paths come from the loaded
+// clientconfig.Config (cfg.SearchRoots/cfg.Paths) and drive placeholder expansion
+// (D75 WP3) — this is the one place cmd/cartographer turns
 // ApplyOptions.ExpandPlaceholders on; internal/mcpserver never does.
 func materializeForProviders(m provisioning.Manifest, providers []string, targetDir string, autoTrust, dryRun bool, searchRoots []string, paths map[string]string, approvalHashes ...map[string]string) (map[string]provisioning.AppliedResult, error) {
 	lockPath := lockFilePath(targetDir)
@@ -253,6 +233,7 @@ func ensureBootstrapForProviders(providers []string, targetDir string, dryRun bo
 // resolved settings.json path in printHookRegistered (D57).
 func printApplySummary(dir string, results map[string]provisioning.AppliedResult) {
 	needsApproval := false
+	needsMCPApproval := false
 	for _, p := range sortedKeys(results) {
 		r := results[p]
 		for _, w := range r.Written {
@@ -265,7 +246,11 @@ func printApplySummary(dir string, results map[string]provisioning.AppliedResult
 			fmt.Printf("[%s] pruned %s\n", p, pr.Path)
 		}
 		for _, na := range r.NeedsApproval {
-			needsApproval = true
+			if na.Kind == "mcp" {
+				needsMCPApproval = true
+			} else {
+				needsApproval = true
+			}
 			fmt.Printf("[%s] needs_approval: %s/%s [%s]\n", p, na.Kind, na.Name, na.Source)
 		}
 		for _, ua := range r.Unsupported {
@@ -277,6 +262,9 @@ func printApplySummary(dir string, results map[string]provisioning.AppliedResult
 	}
 	if needsApproval {
 		fmt.Printf("to approve the unsigned artifacts run: %s\n", autoTrustCommand())
+	}
+	if needsMCPApproval {
+		fmt.Println("MCP artifacts require a point approval: cartographer approve mcp <name> --kb <kb>, then cartographer sync")
 	}
 }
 

--- a/cmd/cartographer/status.go
+++ b/cmd/cartographer/status.go
@@ -101,17 +101,27 @@ func renderStatus(output string, s statusSnapshot, code int) int {
 		if p.Kinds != "" {
 			fmt.Printf("  %s\n", p.Kinds)
 		}
-		unsigned := false
+		unsigned, mcpPending := false, false
 		for _, a := range p.Added {
-			fmt.Printf("  + %s/%s [%s] signed=%v\n", a.Kind, a.Name, a.Source, a.Signed)
-			unsigned = unsigned || !a.Signed
+			trust := statusArtifactTrust(a)
+			fmt.Printf("  + %s/%s [%s] trust=%s\n", a.Kind, a.Name, a.Source, trust)
+			if a.Kind == "mcp" && (trust == "needs_approval" || trust == "approval_stale") {
+				mcpPending = true
+			} else {
+				unsigned = unsigned || trust == "needs_approval"
+			}
 			if a.Kind == "hook" {
 				fmt.Printf("    new hook: after the sync, add the entry to settings.json manually (see hook.json in .claude/hooks/%s/)\n", a.Name)
 			}
 		}
 		for _, a := range p.Updated {
-			fmt.Printf("  ~ %s/%s [%s] signed=%v\n", a.Kind, a.Name, a.Source, a.Signed)
-			unsigned = unsigned || !a.Signed
+			trust := statusArtifactTrust(a)
+			fmt.Printf("  ~ %s/%s [%s] trust=%s\n", a.Kind, a.Name, a.Source, trust)
+			if a.Kind == "mcp" && (trust == "needs_approval" || trust == "approval_stale") {
+				mcpPending = true
+			} else {
+				unsigned = unsigned || trust == "needs_approval"
+			}
 			if a.Kind == "hook" {
 				fmt.Printf("    hook updated: after the sync, verify the entry in settings.json (see hook.json in .claude/hooks/%s/)\n", a.Name)
 			}
@@ -122,8 +132,21 @@ func renderStatus(output string, s statusSnapshot, code int) int {
 		if unsigned {
 			fmt.Printf("  to approve the unsigned artifacts run: %s\n", autoTrustCommand())
 		}
+		if mcpPending {
+			fmt.Println("  MCP requires point approval: cartographer approve mcp <name> --kb <kb>")
+		}
 	}
 	return code
+}
+
+func statusArtifactTrust(a statusArtifact) string {
+	if a.Trust != "" {
+		return a.Trust
+	}
+	if a.Signed {
+		return "verified"
+	}
+	return "needs_approval"
 }
 
 // printVersionStatus reports the binary versions before the artifact status.

--- a/cmd/cartographer/status_snapshot.go
+++ b/cmd/cartographer/status_snapshot.go
@@ -42,6 +42,7 @@ type statusArtifact struct {
 	Source string `json:"source,omitempty"`
 	Path   string `json:"path,omitempty"`
 	Signed bool   `json:"signed,omitempty"`
+	Trust  string `json:"trust,omitempty"`
 }
 
 type serviceSnapshot struct {
@@ -147,7 +148,6 @@ func snapshotForConfig(dir string, cfg *clientconfig.Config, includeService bool
 		}
 		return s
 	}
-	m = upgradeTrustedManifest(m, cfg.Trust)
 	s.Artifacts = len(m.Artifacts)
 	lockFile, err := provisioning.ReadLockFile(lockFilePath(dir))
 	if err != nil {
@@ -170,7 +170,7 @@ func snapshotForConfig(dir string, cfg *clientconfig.Config, includeService bool
 			continue
 		}
 		p.State = "drift"
-		p.Added, p.Updated, p.Removed = snapshotArtifacts(d.Added), snapshotArtifacts(d.Updated), snapshotRemoved(d.Removed)
+		p.Added, p.Updated, p.Removed = snapshotArtifacts(d.Added, cfg), snapshotArtifacts(d.Updated, cfg), snapshotRemoved(d.Removed)
 		s.State = "drift"
 	}
 	if s.Server != "" && s.Client != "" && s.Client != "dev" && s.Server != "dev" && s.Client != s.Server && s.State == "in_sync" {
@@ -179,10 +179,27 @@ func snapshotForConfig(dir string, cfg *clientconfig.Config, includeService bool
 	return s
 }
 
-func snapshotArtifacts(artifacts []provisioning.Artifact) []statusArtifact {
+func snapshotArtifacts(artifacts []provisioning.Artifact, cfg *clientconfig.Config) []statusArtifact {
 	out := make([]statusArtifact, len(artifacts))
 	for i, a := range artifacts {
-		out[i] = statusArtifact{Kind: a.Kind, Name: a.Name, Source: a.Source, Signed: a.Signed}
+		trust := "needs_approval"
+		if a.BuiltIn {
+			trust = "built_in"
+		} else if a.Signed {
+			trust = "verified"
+		} else if a.Kind == "mcp" {
+			source := strings.TrimPrefix(a.Source, "kb:")
+			if approval, ok := cfg.MCPApprovals[source][a.Name]; ok {
+				if approval.ContentHash == a.ContentHash {
+					trust = "approved"
+				} else {
+					trust = "approval_stale"
+				}
+			}
+		} else if cfg.Trust && strings.HasPrefix(a.Source, "kb:") {
+			trust = "trusted"
+		}
+		out[i] = statusArtifact{Kind: a.Kind, Name: a.Name, Source: a.Source, Signed: a.Signed, Trust: trust}
 	}
 	return out
 }

--- a/cmd/cartographer/status_snapshot_test.go
+++ b/cmd/cartographer/status_snapshot_test.go
@@ -5,8 +5,11 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/BeppeTemp/cartographer/internal/client"
+	"github.com/BeppeTemp/cartographer/internal/clientconfig"
+	"github.com/BeppeTemp/cartographer/internal/provisioning"
 )
 
 func TestStatusJSONSchemaAndStates(t *testing.T) {
@@ -54,9 +57,34 @@ func TestClassifyNetworkErrorAndOutputValidation(t *testing.T) {
 func TestStatusTableRetainsDriftDetails(t *testing.T) {
 	s := statusSnapshot{Schema: statusSchema, Reachable: true, Client: "v1", Server: "v1", ServerURL: "http://x/mcp", State: "drift", Providers: []providerStatus{{Name: "claude", Connected: true, State: "drift", Revision: "new", LockRevision: "old", Kinds: "skill 0/1", Added: []statusArtifact{{Kind: "hook", Name: "h", Source: "kb:x", Signed: false}}, Updated: []statusArtifact{{Kind: "skill", Name: "s", Source: "kb:x", Signed: true}}, Removed: []statusArtifact{{Kind: "agent", Name: "a", Path: "a.json"}}}}}
 	out := withStdout(t, func() { renderStatus("table", s, 1) })
-	for _, want := range []string{"drift (manifest new, lock old)", "skill 0/1", "+ hook/h [kb:x] signed=false", "new hook:", "~ skill/s [kb:x] signed=true", "- agent/a (a.json)", "cartographer sync --auto-trust"} {
+	for _, want := range []string{"drift (manifest new, lock old)", "skill 0/1", "+ hook/h [kb:x] trust=needs_approval", "new hook:", "~ skill/s [kb:x] trust=verified", "- agent/a (a.json)", "cartographer sync --auto-trust"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("missing %q in %s", want, out)
 		}
+	}
+}
+
+func TestSnapshotArtifactsMCPApprovalStates(t *testing.T) {
+	cfg := clientconfig.Default()
+	if err := cfg.ApproveMCP("kb", "approved", "same", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.ApproveMCP("kb", "stale", "old", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	arts := snapshotArtifacts([]provisioning.Artifact{{Kind: "mcp", Name: "approved", Source: "kb:kb", ContentHash: "same"}, {Kind: "mcp", Name: "stale", Source: "kb:kb", ContentHash: "new"}, {Kind: "mcp", Name: "pending", Source: "kb:kb", ContentHash: "x"}, {Kind: "mcp", Name: "verified", Source: "kb:kb", ContentHash: "x", Signed: true}}, cfg)
+	want := []string{"approved", "approval_stale", "needs_approval", "verified"}
+	for i := range want {
+		if arts[i].Trust != want[i] {
+			t.Errorf("%s trust=%q want %q", arts[i].Name, arts[i].Trust, want[i])
+		}
+	}
+}
+
+func TestSnapshotArtifactsBuiltIn(t *testing.T) {
+	cfg := clientconfig.Default()
+	arts := snapshotArtifacts([]provisioning.Artifact{{Kind: "hook", Name: "bootstrap", Source: "kb:kb", BuiltIn: true}}, cfg)
+	if got := arts[0].Trust; got != "built_in" {
+		t.Errorf("trust=%q want built_in", got)
 	}
 }

--- a/cmd/cartographer/tui.go
+++ b/cmd/cartographer/tui.go
@@ -271,11 +271,33 @@ func loadRemoteStatusCmd(dir string) tea.Cmd {
 		statuses := make(map[string]string, len(cfg.Agents))
 		for _, p := range s.Providers {
 			if p.Connected {
-				statuses[p.Name] = strings.ReplaceAll(p.State, "_", "-")
+				statuses[p.Name] = formatTUIProviderStatus(p)
 			}
 		}
 		return remoteStatusMsg{statuses: statuses, snapshot: s}
 	}
+}
+
+// formatTUIProviderStatus retains the compact dashboard state while making
+// the MCP approval outcome visible without suggesting generic auto-trust.
+func formatTUIProviderStatus(p providerStatus) string {
+	base := strings.ReplaceAll(p.State, "_", "-")
+	counts := map[string]int{}
+	for _, a := range append(append([]statusArtifact{}, p.Added...), p.Updated...) {
+		if a.Kind == "mcp" && a.Trust != "" {
+			counts[a.Trust]++
+		}
+	}
+	var parts []string
+	for _, state := range []string{"verified", "approved", "approval_stale", "needs_approval"} {
+		if counts[state] > 0 {
+			parts = append(parts, fmt.Sprintf("%s %d", strings.ReplaceAll(state, "_", "-"), counts[state]))
+		}
+	}
+	if len(parts) == 0 {
+		return base
+	}
+	return base + " (" + strings.Join(parts, ", ") + ")"
 }
 
 // probeCmd runs probeServer (connect.go) against opts for provider, before

--- a/cmd/cartographer/tui_test.go
+++ b/cmd/cartographer/tui_test.go
@@ -617,6 +617,16 @@ func TestFormatDiffStatus(t *testing.T) {
 	}
 }
 
+func TestFormatTUIProviderStatusShowsMCPApprovalStates(t *testing.T) {
+	p := providerStatus{Name: "claude", Connected: true, State: "drift", Added: []statusArtifact{{Kind: "mcp", Trust: "approved"}, {Kind: "mcp", Trust: "approval_stale"}, {Kind: "mcp", Trust: "needs_approval"}}, Updated: []statusArtifact{{Kind: "mcp", Trust: "verified"}}}
+	got := formatTUIProviderStatus(p)
+	for _, want := range []string{"approved 1", "approval-stale 1", "needs-approval 1", "verified 1"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("%q missing %q", got, want)
+		}
+	}
+}
+
 func TestFormatKindStatus(t *testing.T) {
 	m := provisioning.Manifest{
 		Revision: "rev1",

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -167,7 +167,11 @@ cartographer status
 Exit code: `0` all providers in sync, `1` at least one provider in drift, `2` error (no
 `.cartographer.yaml`, server unreachable, ...). For every provider it also prints per-kind
 counts (`provisioning.KindCounts`), e.g. `skill 4/5 · agent 2/2 · hook 1/1`. On drift it
-prints the diff (added/updated/removed, with `signed`). Before the artifact report it prints the
+prints the diff (added/updated/removed, with a `trust` state: `built_in`, `verified`, `trusted`,
+`approved`, `approval_stale` or `needs_approval` — see [D115](decisions/sync-provisioning.md#d115--mcp-allow-list-and-hash-bound-local-approval)
+for the MCP-specific approval states). MCP artifacts in `needs_approval`/`approval_stale` get their own
+`cartographer approve mcp <name> --kb <kb>` hint, separate from the `--auto-trust` suggestion for
+the other kinds. Before the artifact report it prints the
 client and server versions. A non-`dev` mismatch is a warning only (it does not change the exit
 code); on loopback, an installed local service also gets a `cartographer service restart` hint.
 For an unavailable endpoint, the table names the configured endpoint once and

--- a/docs/decisions/sync-provisioning.md
+++ b/docs/decisions/sync-provisioning.md
@@ -101,9 +101,11 @@ friction that verifies nothing.
 **Decision.** Trust becomes an explicit choice made once at `connect`, persisted:
 `clientconfig.Config.Trust bool` (default `true`), toggle in the connect form shared CLI/TUI.
 `sync`/`status`/TUI use `cfg.Trust` as default; `--auto-trust` remains a one-off override
-(`cfg.Trust || --auto-trust`). `status`/TUI apply the same upgrade (`upgradeTrustedManifest`)
-before the diff, so as not to show a false "needs approval". No symmetric `--no-trust`:
-revoking is rare, manually setting `trust: false` in `.cartographer.yaml` is enough.
+(`cfg.Trust || --auto-trust`) at materialization time. `status`/TUI never mutate `Signed`: they
+report a separate `trust` state per artifact (`snapshotArtifacts`, D115) that reads `cfg.Trust`
+read-only to report `trusted` instead of `needs_approval`, so as not to show a false pending
+approval without pretending the artifact was cryptographically verified. No symmetric
+`--no-trust`: revoking is rare, manually setting `trust: false` in `.cartographer.yaml` is enough.
 **Rationale.** The signature placeholder (D40) stays identical server-side; this decision concerns
 only who/when decides to trust (the user, at connect, persisted — not relitigated at every sync).
 **Discarded alternatives.** A symmetric CLI `--no-trust`: no real use case, it would only have
@@ -374,15 +376,14 @@ clean provider configs (`TestRoundTrip_ConnectDisconnect_NessunResiduo`).
 
 **WP5 — Trust and remote sync.** An MCP server is an endpoint that receives the agent's data:
 Before D114/D115, `BuildManifest` marked the `mcp` kind **always** `Signed:false`, regardless of `autoTrust` — unlike
-skill/agent/hook/instructions, which `autoTrust` signs. The remote client
-(`upgradeTrustedManifest`, `cmd/cartographer/clientsync.go`) likewise excludes `mcp` from
-its generic upgrade via `cfg.Trust`/`--auto-trust`: a stricter policy than the other kinds,
+skill/agent/hook/instructions, which `autoTrust` signs. The remote client likewise excluded `mcp`
+from its generic upgrade via `cfg.Trust`/`--auto-trust`: a stricter policy than the other kinds,
 `NeedsApproval` at first appearance and at every hash change, even with `AutoTrust` active.
-**Deviation from the plan**: there is (yet) no mechanism to mark a single `mcp` artifact
-`Signed:true` once approved — the only generic gate today is `cfg.Trust`/`--auto-trust`, which
-`mcp` always ignores by construction. A persisted point approval (of what exactly,
-for which hash) requires a new tool/state beyond this iteration: deferred together
-with the allow-list below. `sync_pull`/`tools_sync.go` and the HTTP client do not filter by kind (verified):
+**Deviation from the plan, since resolved**: this iteration had no mechanism to mark a single
+`mcp` artifact as approved — the only generic gate was `cfg.Trust`/`--auto-trust`, which `mcp`
+ignores by construction. The persisted point approval (of what exactly, for which hash) arrived
+with D115 as `cfg.MCPApprovals`; the client-side upgrade hook it describes no longer exists,
+since D114 made `Signed` an exclusively cryptographic result. `sync_pull`/`tools_sync.go` and the HTTP client do not filter by kind (verified):
 an `mcp` artifact travels as a single `ArtifactFile`, same schema as an agent.
 
 **Server-side allow-list**: **not implemented** (optional in the plan, tied to the Phase 3


### PR DESCRIPTION
The D115 approval gate decides between six trust states; the client could only show a boolean. This propagates the real state to every client surface.

- `statusArtifact` gains a `Trust` field and `snapshotArtifacts(artifacts, cfg)` computes `built_in` / `verified` / `trusted` / `approved` / `approval_stale` / `needs_approval`, with `statusArtifactTrust` falling back safely on unknown input.
- `renderStatus` and the TUI render that state instead of `signed=%v`.
- The remediation hint now points at `cartographer approve mcp <name> --kb <kb>`, kept distinct from the blanket `--auto-trust`.
- Removes the no-op `upgradeTrustedManifest` and the two contradictory comment blocks preceding it.
- `docs/decisions/sync-provisioning.md` no longer states in the present tense that no per-artifact approval mechanism exists: D115 superseded that.

Tests: `TestSnapshotArtifactsMCPApprovalStates`, `TestSnapshotArtifactsBuiltIn`, `TestFormatTUIProviderStatusShowsMCPApprovalStates`.

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)