### PR TITLE
feat(git): add the server Git profile with working-branch pull requests

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -75,6 +75,17 @@ git:
   # bursts of writes coalesce into one push, out_debounce after the last one.
   # Default 3s, 0 = synchronous inline push, no worker (rollback flag).
   # out_debounce: 3s
+  # profile (D117): local (default) | server. The server profile adds a GitHub PR
+  # boundary and makes every field below required (per-KB overrides: git_profile,
+  # git_base_branch, git_working_branch, git_forge, github_owner, ...).
+  # profile: server
+  # base_branch: main             # protected; Cartographer never pushes it directly
+  # working_branch: cartographer/wiki-kb   # optional, default cartographer/<kb-name>
+  # forge: github
+  # github_owner: example-org     # must match the origin remote path exactly
+  # github_repository: wiki
+  # github_api_url: https://api.github.com
+  # github_token_env: CARTOGRAPHER_GITHUB_TOKEN
 sops:
   # default age key for decrypting secret refs (per-KB overridable):
   # age_key_file: /etc/kb-sops/keys.age

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -11,27 +11,51 @@ clones can synchronize through the same remote, but high-contention
 multi-writer operation is not a supported scaling model; partition KBs across
 instances instead.
 
-## Local commit
+## Git profiles
 
-When `git.auto_commit` is enabled, successful write tools are wrapped by
-`gitWrap` and produce one commit per logical operation. Multi-file operations
-are committed together. Individual file replacement is atomic.
+`git.profile: local` is the default and the historical behavior. When
+`git.auto_commit` is enabled, successful write tools are wrapped by `gitWrap` and
+produce one commit per logical operation, on the branch currently checked out in
+the KB clone. Multi-file operations are committed together, individual file
+replacement is atomic, and Cartographer creates no working branch, opens no pull
+request and never merges into `main`: repository review policy belongs to the
+remote hosting workflow.
 
-Cartographer writes to the branch currently checked out in the KB clone. It
-does not create working branches, open pull requests or merge into `main`.
-Repository review policy belongs to the remote hosting workflow.
+`git.profile: server` (D117) is an opt-in GitHub review boundary. It requires a
+base branch, a dedicated working branch, GitHub owner/repository/API URL and the
+name of an environment variable holding a token. On mount Cartographer fetches
+`origin`, checks out or creates the dedicated branch from the remote base, and
+refuses dirty, detached, ambiguous, mismatched or shared-working-branch checkouts.
+The `origin` path must exactly match the configured `github_owner/github_repository`
+for both HTTPS and SSH remotes (credentials are never logged). The base branch is
+never a push target.
+
+Each successful server-profile push creates or reuses exactly one open PR from the
+working branch to the base. `pr_status` and `sync_status` expose the non-secret PR
+identity and forge degradation. `pr_finalize(head_sha)` is an advanced operator
+action: it requires the caller's current PR head, satisfied reviews and checks, a
+fresh rebase and validation, then uses force-with-lease only on the working branch
+before requesting a GitHub squash merge. After the merge the clean working branch is
+reset to the fetched base for the next PR cycle.
+
+If a forge timeout happens after the merge request, the profile enters
+`merge_uncertain`: new writes are refused until startup or `pr_status` verifies the
+merged PR's resulting commit on the base and safely resets the working branch. It
+never opens a replacement PR during that recovery.
 
 ## Remote synchronization
 
 When `git.sync` is enabled and `origin` exists:
 
-1. `SyncIn` fetches and runs pull/rebase/autostash before a write. A freshness
+1. `SyncIn` fetches and runs pull/rebase/autostash before a local-profile write;
+   server profile rebases the dedicated working branch onto `origin/<base>`. A freshness
    window can skip repeated fetches within the configured interval.
 2. The write and local commit run under the same KB lock.
 3. `SyncOut` queues a debounced background push. Sync-sensitive operations and
    graceful HTTP shutdown flush pending work.
 4. A rejected push retries through fetch + pull/rebase + push, with bounded
-   backoff. Cartographer never force-pushes automatically.
+   backoff. Server profile incorporates a concurrent working-branch update and
+   replays it on the base; automatic force is never used outside finalization.
 
 `sync_status` is the authoritative read-only view of replication: it reports
 whether sync is disabled, no remote exists, a push is pending, or the latest
@@ -58,16 +82,19 @@ registry and `sync_check` reports `open_conflicts`.
 - `theirs` — retain the remote version;
 - `edit` — use the supplied complete reconciled file.
 
-After every registered conflict has a resolution, Cartographer performs one
-merge transaction, materializes the selected contents, commits and attempts
-the push. On failure it aborts the merge and keeps the registry so resolution
-can be retried.
+After every registered conflict has a resolution, Local Core performs one merge
+transaction, materializes the selected contents, commits and attempts the push.
+On failure it aborts the merge and keeps the registry so resolution can be
+retried. Server profile instead commits the selected content on its working
+branch, rebases that branch onto the current base and updates the PR; it never
+merges or pushes the base.
 
 ## Optimistic content concurrency
 
-`concept_read` returns normalized content hashes. Write tools that accept
-`if_match` reject an update with `stale_write` when the stored content no
-longer matches.
+`concept_read` returns normalized content hashes. In server profile they reflect
+the working branch after its latest base rebase, not a frozen PR-open snapshot.
+Write tools that accept `if_match` reject an update with `stale_write` when the
+stored content no longer matches.
 
 There are no advisory per-concept leases or session locks. Concurrency safety
 comes from the KB mutex, content hashes and git conflict handling.

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -106,6 +106,8 @@ Tools marked **[A]** (advanced, `advancedToolNames` in `internal/mcpserver/visib
 | `sync_apply(base_dir, [dry_run], [auto_trust])` **[A]** | Materializes verified or built-in artifacts into `base_dir`; `auto_trust` is explicit unsigned authorization and never sets `signed`. A local signer is verified before applying. |
 | `sync_pull()` **[R]** **[A]** | Read-only, no parameters. Returns base64 file contents plus optional detached Ed25519 signature (`algorithm`, `key_id`, envelope version, value). Remote clients recompute hashes and verify pinned keys before materialization. KB-provided MCP descriptors appear only when the server-side allow-list permits them. |
 | `sync_status()` **[R]** **[A]** | Read-only. Returns local Git replication state (`disabled`, `no_remote`, `clean`, `pending`, or `failed`), the last error/attempt, HEAD, best-effort unpushed count, identity warning, and push mode. |
+| `pr_status()` **[R]** **[A]** | Read-only, server Git profile only (D117). Returns the profile, base/working branches, current PR identity and last forge error; reconciles a `merge_uncertain` state first. Never returns the forge token. |
+| `pr_finalize(head_sha)` **[A]** | Server Git profile only (D117). Squash-merges the open PR after checking that `head_sha` matches the current remote head, reviews/checks are satisfied, and a fresh rebase plus validation succeed. Force-with-lease touches only the working branch; the base is never pushed. |
 
 ### KB-root artifacts
 

--- a/docs/decisions/concurrency-git.md
+++ b/docs/decisions/concurrency-git.md
@@ -120,3 +120,27 @@ e) Per-phase telemetry on stderr for every write, in `gitWrap`: `cartographer: t
 **Decision.** Git replication state is exposed through the read-only `sync_status` tool. Failed commits and pushes remain non-fatal to local writes but are retained until a real push succeeds; debounced writes report pending rather than pretending their future push succeeded. When Cartographer has no complete configured author pair, commits use Git's own resolved identity; the placeholder is retained only as Git's final fallback.
 
 **Rationale.** Local durability and remote replication are separate states. Reporting their distinction preserves offline operation while making enterprise forge push-rule failures actionable without log scraping.
+
+---
+
+<a id="d117"></a>
+## D117 — Server Git profile uses a dedicated working branch and GitHub PR boundary
+
+**Decision.** Keep Local Core as the default `git.profile: local`. The opt-in `server`
+profile requires an explicit protected base, a dedicated working branch, GitHub
+repository/API coordinates and a token environment variable. It mounts only a clean,
+attached checkout, fetches `origin`, resumes a verified working branch or creates it
+from the remote base, and never repairs ambiguity by discarding files or commits.
+
+Writes rebase the working branch onto the base and push only that branch. The server
+uses an injected stdlib-HTTP GitHub forge boundary to maintain exactly one open PR,
+persisting only non-secret identity/state under `.cartographer/`. Finalization requires
+a current caller head plus review/check readiness, rebases and validates, uses
+force-with-lease solely for the working branch, then requests a squash merge. Local
+reconciliation failures remain degraded and recoverable; the base branch is never a Git
+push target.
+
+**Rationale.** A long-lived server needs reviewability without treating a protected
+branch as its synchronization transport. Separating Git transport from the forge API
+keeps the contract testable with local fixtures today and leaves a narrow extension
+point for another forge later.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -104,6 +104,14 @@ git:
   out_debounce: 3s              # (git.out_debounce) debounce of the per-KB async push after the
                                 # commit: N writes in quick succession = 1 push. Default 3s, 0 = push
                                 # synchronously inline, no worker (rollback flag, D76)
+  # profile: server             # (git.profile) local (default) | server (D117): the fields below
+  # base_branch: main           # become required. Protected review target, never directly pushed.
+  # working_branch: cartographer/wiki  # optional; defaults to cartographer/<kb-name>
+  # forge: github               # only supported forge today
+  # github_owner: example-org   # must match the origin remote path exactly (HTTPS or SSH)
+  # github_repository: wiki
+  # github_api_url: https://api.github.com
+  # github_token_env: CARTOGRAPHER_GITHUB_TOKEN  # the value stays in this process environment only
 search:
   ollama_url: ""               # (search.ollama_url) enables semantic search
   ollama_model: nomic-embed-text

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -26,6 +26,16 @@ Provisioning signature coverage includes deterministic Ed25519 envelopes, strict
 key parsing and identity separation, plus remote `sync_pull` verification and
 tampering rejection before `Apply`.
 
+Server Git profile coverage (D117) uses local two-clone remotes plus an injected
+fake forge over `httptest`: branch startup and resume, PR create/reuse and
+duplicate handling, base rebases, conflict registry resolution, stale caller
+heads, review/check rejection, finalize leases, base-SHA races and post-merge
+reconciliation after an uncertain outcome. CI never calls GitHub. Release
+validation may additionally run an opt-in sandbox smoke against a disposable
+protected repository and token; that smoke must assert the protected base stays
+unchanged until the forge confirms the squash merge, and must exercise a
+timeout-after-merge restart.
+
 CLI JSON tests decode stdout as JSON and assert that diagnostics remain on
 stderr. Golden help is limited to 80 columns. Bubble Tea view/update tests use
 60, 80 and 120-column window messages, strip ANSI sequences before measuring

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -121,6 +121,17 @@ type KBSpec struct {
 	CommitterEmail string `yaml:"committer_email,omitempty"`
 	SopsAgeKeyFile string `yaml:"sops_age_key_file,omitempty"`
 
+	// GitProfile and the server-git fields override their git: counterparts
+	// for this KB. Empty values retain the global/local defaults (D117).
+	GitProfile       string `yaml:"git_profile,omitempty"`
+	GitBaseBranch    string `yaml:"git_base_branch,omitempty"`
+	GitWorkingBranch string `yaml:"git_working_branch,omitempty"`
+	GitForge         string `yaml:"git_forge,omitempty"`
+	GitHubOwner      string `yaml:"github_owner,omitempty"`
+	GitHubRepository string `yaml:"github_repository,omitempty"`
+	GitHubAPIURL     string `yaml:"github_api_url,omitempty"`
+	GitHubTokenEnv   string `yaml:"github_token_env,omitempty"`
+
 	// AllowArtifactWrite enables the artifact_write/artifact_delete MCP tools
 	// (D71) for this KB — writing a provisioning artifact (skill/agent/hook/
 	// mcp) injects instructions a client agent will execute, so the
@@ -166,6 +177,16 @@ type GitConfig struct {
 	// before actually pushing (see kb.KB.SyncOutDebounce). Zero disables
 	// the worker: pushes stay synchronous and inline, as before D76/WP4.
 	SyncOutDebounce time.Duration
+	// Profile selects "local" (the backwards-compatible default) or "server"
+	// (D117: dedicated working branch + GitHub PR boundary).
+	Profile          string
+	BaseBranch       string
+	WorkingBranch    string
+	Forge            string
+	GitHubOwner      string
+	GitHubRepository string
+	GitHubAPIURL     string
+	GitHubTokenEnv   string
 }
 
 // SopsConfig controls the default SOPS age key used to decrypt secret refs.
@@ -239,17 +260,25 @@ type rawAuth struct {
 }
 
 type rawGit struct {
-	Autocommit     *bool  `yaml:"autocommit"`
-	Sync           *bool  `yaml:"sync"`
-	SSHKey         string `yaml:"ssh_key"`
-	KnownHosts     string `yaml:"known_hosts"`
-	AuthorName     string `yaml:"author_name"`
-	AuthorEmail    string `yaml:"author_email"`
-	CommitterName  string `yaml:"committer_name"`
-	CommitterEmail string `yaml:"committer_email"`
-	TokenDir       string `yaml:"token_dir"`
-	InWindow       string `yaml:"in_window"`
-	OutDebounce    string `yaml:"out_debounce"`
+	Autocommit       *bool  `yaml:"autocommit"`
+	Sync             *bool  `yaml:"sync"`
+	SSHKey           string `yaml:"ssh_key"`
+	KnownHosts       string `yaml:"known_hosts"`
+	AuthorName       string `yaml:"author_name"`
+	AuthorEmail      string `yaml:"author_email"`
+	CommitterName    string `yaml:"committer_name"`
+	CommitterEmail   string `yaml:"committer_email"`
+	TokenDir         string `yaml:"token_dir"`
+	InWindow         string `yaml:"in_window"`
+	OutDebounce      string `yaml:"out_debounce"`
+	Profile          string `yaml:"profile"`
+	BaseBranch       string `yaml:"base_branch"`
+	WorkingBranch    string `yaml:"working_branch"`
+	Forge            string `yaml:"forge"`
+	GitHubOwner      string `yaml:"github_owner"`
+	GitHubRepository string `yaml:"github_repository"`
+	GitHubAPIURL     string `yaml:"github_api_url"`
+	GitHubTokenEnv   string `yaml:"github_token_env"`
 }
 
 type rawSearch struct {
@@ -302,6 +331,16 @@ func Load(path string) (*Config, error) {
 	cfg.Git.CommitterName = raw.Git.CommitterName
 	cfg.Git.CommitterEmail = raw.Git.CommitterEmail
 	cfg.Git.TokenDir = raw.Git.TokenDir
+	if raw.Git.Profile != "" {
+		cfg.Git.Profile = normalizeGitProfile(raw.Git.Profile)
+	}
+	cfg.Git.BaseBranch = raw.Git.BaseBranch
+	cfg.Git.WorkingBranch = raw.Git.WorkingBranch
+	cfg.Git.Forge = raw.Git.Forge
+	cfg.Git.GitHubOwner = raw.Git.GitHubOwner
+	cfg.Git.GitHubRepository = raw.Git.GitHubRepository
+	cfg.Git.GitHubAPIURL = raw.Git.GitHubAPIURL
+	cfg.Git.GitHubTokenEnv = raw.Git.GitHubTokenEnv
 	if raw.Git.InWindow != "" {
 		cfg.Git.SyncInWindow = parseDuration(raw.Git.InWindow, cfg.Git.SyncInWindow)
 	}
@@ -358,6 +397,9 @@ func FromEnv(cfg *Config) {
 	}
 	if v := os.Getenv("CARTOGRAPHER_GIT_SYNC"); v != "" {
 		cfg.Git.Sync = parseBool(v, cfg.Git.Sync)
+	}
+	if v := os.Getenv("CARTOGRAPHER_GIT_PROFILE"); v != "" {
+		cfg.Git.Profile = normalizeGitProfile(v)
 	}
 	if v := os.Getenv("CARTOGRAPHER_GIT_TOKEN_DIR"); v != "" {
 		cfg.Git.TokenDir = v
@@ -445,6 +487,15 @@ func ApplyFlags(cfg *Config, o FlagOverrides) {
 	if o.ToolsProfile != nil {
 		cfg.ToolsProfile = normalizeToolsProfile(*o.ToolsProfile)
 	}
+}
+
+// NormalizeGitProfile canonicalizes the profile spelling. It intentionally
+// leaves invalid values visible so server startup can fail fast rather than
+// silently turn a requested review boundary into direct pushes.
+func NormalizeGitProfile(v string) string { return normalizeGitProfile(v) }
+
+func normalizeGitProfile(v string) string {
+	return strings.ToLower(strings.TrimSpace(v))
 }
 
 // normalizeToolsProfile maps a tools-profile spelling onto the canonical

--- a/internal/gitx/gitx.go
+++ b/internal/gitx/gitx.go
@@ -306,6 +306,92 @@ func Fetch(dir, remote string, env ...string) error {
 	return nil
 }
 
+// RemoteBranchExists reports whether refs/remotes/<remote>/<branch> exists.
+// Call Fetch first when the answer must reflect the forge's current state.
+func RemoteBranchExists(dir, remote, branch string) bool {
+	if remote == "" {
+		remote = "origin"
+	}
+	_, err := runGit(dir, "rev-parse", "--verify", "refs/remotes/"+remote+"/"+branch)
+	return err == nil
+}
+
+// CheckoutNewBranch checks out branch at start. It never resets an existing
+// branch; callers that see an existing branch must make an explicit, safe
+// decision instead of discarding history.
+func CheckoutNewBranch(dir, branch, start string, env ...string) error {
+	out, err := runGitEnv(dir, env, "checkout", "-b", branch, start)
+	if err != nil {
+		return fmt.Errorf("git checkout -b %s %s: %w: %s", branch, start, err, out)
+	}
+	return nil
+}
+
+// IsAncestor reports whether ancestor is reachable from descendant.
+func IsAncestor(dir, ancestor, descendant string) (bool, error) {
+	out, err := runGit(dir, "merge-base", "--is-ancestor", ancestor, descendant)
+	if err == nil {
+		return true, nil
+	}
+	if strings.TrimSpace(out) == "" {
+		return false, nil
+	}
+	return false, fmt.Errorf("git merge-base --is-ancestor %s %s: %w: %s", ancestor, descendant, err, out)
+}
+
+// RebaseOntoAutostash rebases the checked-out branch onto remote/branch. It
+// preserves a dirty tree with Git's autostash and returns the same structured
+// conflict error used by PullRebaseAutostash.
+func RebaseOntoAutostash(dir, remote, branch string, env ...string) error {
+	if remote == "" {
+		remote = "origin"
+	}
+	localSHA, _ := HeadSHA(dir)
+	target := remote + "/" + branch
+	out, err := runGitEnv(dir, env, "rebase", "--autostash", target)
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(out, "CONFLICT") || strings.Contains(out, "could not apply") || strings.Contains(out, "error: could not") {
+		files, _ := UnmergedFiles(dir)
+		remoteSHA, _ := HeadSHAAt(dir, target)
+		_, _ = runGit(dir, "rebase", "--abort")
+		return &RebaseConflictError{Files: files, LocalSHA: localSHA, RemoteSHA: remoteSHA, Remote: remote, Branch: branch}
+	}
+	return fmt.Errorf("git rebase --autostash %s: %w: %s", target, err, out)
+}
+
+// HeadSHAAt returns the commit SHA for ref.
+func HeadSHAAt(dir, ref string) (string, error) {
+	out, err := runGit(dir, "rev-parse", ref)
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse %s: %w: %s", ref, err, out)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// PushForceWithLease updates branch only if the remote still points at
+// expectedSHA. It is intended exclusively for an unprotected working branch.
+func PushForceWithLease(dir, remote, branch, expectedSHA string, env ...string) error {
+	lease := "--force-with-lease=refs/heads/" + branch + ":" + expectedSHA
+	out, err := runGitEnv(dir, env, "push", lease, remote, "HEAD:refs/heads/"+branch)
+	if err != nil {
+		return fmt.Errorf("git push %s %s: %w: %s", lease, branch, err, out)
+	}
+	return nil
+}
+
+// ResetHardTo resets a clean working tree to ref. It is deliberately narrow:
+// server-profile callers check cleanliness before using it for post-merge
+// reconciliation.
+func ResetHardTo(dir, ref string, env ...string) error {
+	out, err := runGitEnv(dir, env, "reset", "--hard", ref)
+	if err != nil {
+		return fmt.Errorf("git reset --hard %s: %w: %s", ref, err, out)
+	}
+	return nil
+}
+
 // Push pushes the current branch to the remote. Never force-pushes.
 // Returns error on non-fast-forward (caller should rebase and retry).
 // env carries extra per-KB variables (e.g. GIT_SSH_COMMAND) — see runGitEnv.

--- a/internal/gitx/gitx.go
+++ b/internal/gitx/gitx.go
@@ -34,12 +34,24 @@ func Clone(remote, dest string, env ...string) error {
 	return nil
 }
 
+// DefaultBranch is the branch a freshly initialized KB is created on. The
+// server Git profile compares the checked-out branch against a configured base
+// branch, so inheriting the host's init.defaultBranch would make a KB unusable
+// on any machine configured for "master".
+const DefaultBranch = "main"
+
 // Init initializes a git repository in the directory, if one does not already exist.
-// Configures merge.conflictStyle=zdiff3 locally.
+// Pins the initial branch to DefaultBranch and configures merge.conflictStyle=zdiff3
+// locally. Existing repositories keep whatever branch they are on.
 func Init(dir string) error {
 	if !IsRepo(dir) {
 		if out, err := runGit(dir, "init"); err != nil {
 			return fmt.Errorf("git init: %w: %s", err, out)
+		}
+		// The repository has no commits yet, so moving HEAD is safe and does
+		// not depend on a git version that supports "init -b".
+		if out, err := runGit(dir, "symbolic-ref", "HEAD", "refs/heads/"+DefaultBranch); err != nil {
+			return fmt.Errorf("git symbolic-ref HEAD: %w: %s", err, out)
 		}
 	}
 	// Configure zdiff3 for more readable diffs during merge conflicts.

--- a/internal/kb/conflicts.go
+++ b/internal/kb/conflicts.go
@@ -23,13 +23,17 @@ const (
 
 // Conflict describes a rebase conflict detected on a specific concept.
 type Conflict struct {
-	ConceptID  string   `json:"concept_id"`
-	Path       string   `json:"path"`       // git-relative file path (e.g. "data/shared/notes/c.md")
-	LocalSHA   string   `json:"local_sha"`  // HEAD SHA before the failed rebase
-	RemoteSHA  string   `json:"remote_sha"` // SHA of <remote>/<branch> after fetch
-	Branch     string   `json:"branch"`
-	Files      []string `json:"files"`       // all conflicting git paths in the same rebase
-	DetectedAt string   `json:"detected_at"` // RFC3339 UTC
+	ConceptID     string   `json:"concept_id"`
+	Path          string   `json:"path"`       // git-relative file path (e.g. "data/shared/notes/c.md")
+	LocalSHA      string   `json:"local_sha"`  // HEAD SHA before the failed rebase
+	RemoteSHA     string   `json:"remote_sha"` // SHA of <remote>/<branch> after fetch
+	Branch        string   `json:"branch"`
+	BaseBranch    string   `json:"base_branch,omitempty"`    // server profile only (D117)
+	WorkingBranch string   `json:"working_branch,omitempty"` // server profile only (D117)
+	PRNumber      int      `json:"pr_number,omitempty"`      // server profile only (D117)
+	PRURL         string   `json:"pr_url,omitempty"`         // server profile only (D117)
+	Files         []string `json:"files"`                    // all conflicting git paths in the same rebase
+	DetectedAt    string   `json:"detected_at"`              // RFC3339 UTC
 
 	// Step 4 — recorded resolution (empty until the agent calls git_conflict_resolve).
 	ResolutionStrategy string `json:"resolution_strategy,omitempty"` // "ours" | "theirs" | "edit"
@@ -215,6 +219,9 @@ func (k *KB) resolvedContent(c Conflict) (string, error) {
 // PendingConflictCount). Returns the resolved concept IDs. On any git failure the merge is
 // aborted and the pre-merge working tree (including the degraded markers) is restored.
 func (k *KB) FinalizeConflicts() ([]string, error) {
+	if k.ServerGit != nil {
+		return k.finalizeServerConflicts()
+	}
 	conflicts, err := k.loadConflicts()
 	if err != nil {
 		return nil, err
@@ -315,6 +322,57 @@ func (k *KB) FinalizeConflicts() ([]string, error) {
 	}
 
 	// Clear the registry.
+	for _, c := range conflicts {
+		_ = k.ClearConflict(c.ConceptID)
+	}
+	return ids, nil
+}
+
+// finalizeServerConflicts keeps the server profile on its dedicated working
+// branch: it never performs the Local Core merge/push-to-current-branch flow.
+// Resolution is committed on the working branch, rebased onto the current
+// base, and pushed/PR-updated by SyncOut — it never merges or pushes base
+// directly (D117).
+func (k *KB) finalizeServerConflicts() ([]string, error) {
+	conflicts, err := k.loadConflicts()
+	if err != nil {
+		return nil, err
+	}
+	if len(conflicts) == 0 {
+		return nil, nil
+	}
+	for _, c := range conflicts {
+		if c.ResolutionStrategy == "" {
+			return nil, fmt.Errorf("FinalizeConflicts: conflict on %q has no recorded resolution", c.ConceptID)
+		}
+	}
+	ids := make([]string, 0, len(conflicts))
+	for _, c := range conflicts {
+		content, cerr := k.resolvedContent(c)
+		if cerr != nil {
+			return nil, cerr
+		}
+		abs := filepath.Join(k.Root, filepath.FromSlash(c.Path))
+		if werr := writeFileAtomic(abs, []byte(content)); werr != nil {
+			return nil, fmt.Errorf("FinalizeConflicts: write %s: %w", c.Path, werr)
+		}
+		ids = append(ids, c.ConceptID)
+	}
+	authorName, authorEmail := k.gitAuthor()
+	msg := "resolve git conflict: " + strings.Join(ids, ", ")
+	if err := gitx.Commit(k.Root, msg, authorName, authorEmail, k.GitEnv...); err != nil && !errors.Is(err, gitx.ErrNothingToCommit) {
+		return nil, fmt.Errorf("FinalizeConflicts: commit: %w", err)
+	}
+	if err := gitx.Fetch(k.Root, "origin", k.GitEnv...); err != nil {
+		return nil, err
+	}
+	if err := gitx.RebaseOntoAutostash(k.Root, "origin", k.ServerGit.BaseBranch, k.GitEnv...); err != nil {
+		k.RecordServerRebaseConflict(err)
+		return nil, err
+	}
+	if err := k.SyncOut(); err != nil {
+		return nil, fmt.Errorf("FinalizeConflicts server push/PR update: %w", err)
+	}
 	for _, c := range conflicts {
 		_ = k.ClearConflict(c.ConceptID)
 	}

--- a/internal/kb/forge.go
+++ b/internal/kb/forge.go
@@ -1,0 +1,242 @@
+package kb
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// PullRequest is the non-secret forge state retained for a server-profile KB.
+type PullRequest struct {
+	Number   int    `json:"number"`
+	URL      string `json:"url"`
+	HeadSHA  string `json:"head_sha"`
+	BaseSHA  string `json:"base_sha,omitempty"`
+	State    string `json:"state"`
+	Merged   bool   `json:"merged"`
+	MergeSHA string `json:"merge_sha,omitempty"`
+}
+
+// MergeResult is the forge-confirmed squash merge outcome. SHA is the commit
+// GitHub reports as merged and must later be observed on the protected base.
+type MergeResult struct {
+	Merged bool
+	SHA    string
+}
+
+// Forge isolates the review boundary from Git transport. Implementations must
+// not retain or expose credentials in errors.
+type Forge interface {
+	FindOpenPR(context.Context, string, string, string, string) ([]PullRequest, error)
+	GetPR(context.Context, string, string, int) (PullRequest, error)
+	CreatePR(context.Context, string, string, string, string, string, string) (PullRequest, error)
+	PRReady(context.Context, string, string, int) (bool, error)
+	MergeSquash(context.Context, string, string, int, string) (MergeResult, error)
+}
+
+// GitHubForge is GitHub's REST implementation of Forge. The stdlib client is
+// intentionally injected so tests use httptest and production has no gh CLI
+// dependency.
+type GitHubForge struct {
+	APIURL string
+	Token  string
+	Client *http.Client
+}
+
+func (g *GitHubForge) client() *http.Client {
+	if g.Client != nil {
+		return g.Client
+	}
+	return &http.Client{Timeout: 10 * time.Second}
+}
+
+func (g *GitHubForge) request(ctx context.Context, method, endpoint string, body any, out any) error {
+	var r io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("github request: marshal: %w", err)
+		}
+		r = bytes.NewReader(data)
+	}
+	u, err := url.Parse(strings.TrimRight(g.APIURL, "/") + endpoint)
+	if err != nil {
+		return fmt.Errorf("github request URL: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), r)
+	if err != nil {
+		return fmt.Errorf("github request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("User-Agent", "cartographer-server-git")
+	if g.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+g.Token)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := g.client().Do(req)
+	if err != nil {
+		return fmt.Errorf("github %s %s: %w", method, endpoint, err)
+	}
+	defer resp.Body.Close()
+	data, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if readErr != nil {
+		return fmt.Errorf("github %s %s: read response: %w", method, endpoint, readErr)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		message := redactForgeError(strings.TrimSpace(string(data)), g.Token)
+		return fmt.Errorf("github %s %s: HTTP %d: %s", method, endpoint, resp.StatusCode, message)
+	}
+	if out != nil && len(data) != 0 {
+		if err := json.Unmarshal(data, out); err != nil {
+			return fmt.Errorf("github %s %s: decode response: %w", method, endpoint, err)
+		}
+	}
+	return nil
+}
+
+func redactForgeError(message, token string) string {
+	if token == "" {
+		return message
+	}
+	return strings.ReplaceAll(message, token, "[redacted]")
+}
+
+type githubPR struct {
+	Number         int    `json:"number"`
+	HTMLURL        string `json:"html_url"`
+	State          string `json:"state"`
+	Merged         bool   `json:"merged"`
+	MergeCommitSHA string `json:"merge_commit_sha"`
+	Head           struct {
+		SHA string `json:"sha"`
+	} `json:"head"`
+	Base struct {
+		SHA string `json:"sha"`
+	} `json:"base"`
+}
+
+func asPR(p githubPR) PullRequest {
+	return PullRequest{Number: p.Number, URL: p.HTMLURL, HeadSHA: p.Head.SHA, BaseSHA: p.Base.SHA, State: p.State, Merged: p.Merged, MergeSHA: p.MergeCommitSHA}
+}
+
+func (g *GitHubForge) FindOpenPR(ctx context.Context, owner, repo, head, base string) ([]PullRequest, error) {
+	var all []PullRequest
+	for page := 1; ; page++ {
+		var prs []githubPR
+		endpoint := fmt.Sprintf("/repos/%s/%s/pulls?state=open&head=%s&base=%s&per_page=100&page=%d", pathEscape(owner), pathEscape(repo), url.QueryEscape(owner+":"+head), url.QueryEscape(base), page)
+		if err := g.request(ctx, http.MethodGet, endpoint, nil, &prs); err != nil {
+			return nil, err
+		}
+		for _, pr := range prs {
+			all = append(all, asPR(pr))
+		}
+		if len(prs) < 100 {
+			return all, nil
+		}
+	}
+}
+
+func (g *GitHubForge) CreatePR(ctx context.Context, owner, repo, head, base, title, body string) (PullRequest, error) {
+	var result githubPR
+	if err := g.request(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/%s/pulls", pathEscape(owner), pathEscape(repo)), map[string]string{"head": head, "base": base, "title": title, "body": body}, &result); err != nil {
+		return PullRequest{}, err
+	}
+	// The label is harmless metadata, but is part of the operational contract.
+	if err := g.request(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/%s/issues/%d/labels", pathEscape(owner), pathEscape(repo), result.Number), map[string][]string{"labels": {"cartographer"}}, nil); err != nil {
+		return PullRequest{}, err
+	}
+	return asPR(result), nil
+}
+
+func (g *GitHubForge) GetPR(ctx context.Context, owner, repo string, number int) (PullRequest, error) {
+	var pr githubPR
+	if err := g.request(ctx, http.MethodGet, fmt.Sprintf("/repos/%s/%s/pulls/%d", pathEscape(owner), pathEscape(repo), number), nil, &pr); err != nil {
+		return PullRequest{}, err
+	}
+	return asPR(pr), nil
+}
+
+func (g *GitHubForge) PRReady(ctx context.Context, owner, repo string, number int) (bool, error) {
+	type review struct {
+		State string `json:"state"`
+		User  struct {
+			Login string `json:"login"`
+		} `json:"user"`
+	}
+	latest := map[string]string{}
+	for page := 1; ; page++ {
+		var reviews []review
+		if err := g.request(ctx, http.MethodGet, fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews?per_page=100&page=%d", pathEscape(owner), pathEscape(repo), number, page), nil, &reviews); err != nil {
+			return false, err
+		}
+		// GitHub returns reviews newest first; retain the first observation of
+		// each reviewer across pages so a historic approval cannot mask a later
+		// changes-requested/dismissal state.
+		for _, r := range reviews {
+			if _, seen := latest[r.User.Login]; !seen {
+				latest[r.User.Login] = strings.ToUpper(r.State)
+			}
+		}
+		if len(reviews) < 100 {
+			break
+		}
+	}
+	approved := false
+	for _, state := range latest {
+		if state == "APPROVED" {
+			approved = true
+		}
+	}
+	if !approved {
+		return false, nil
+	}
+	pr, err := g.GetPR(ctx, owner, repo, number)
+	if err != nil {
+		return false, err
+	}
+	var checks struct {
+		TotalCount int `json:"total_count"`
+		CheckRuns  []struct {
+			Conclusion string `json:"conclusion"`
+			Status     string `json:"status"`
+		} `json:"check_runs"`
+	}
+	if err := g.request(ctx, http.MethodGet, fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs?per_page=100", pathEscape(owner), pathEscape(repo), pathEscape(pr.HeadSHA)), nil, &checks); err != nil {
+		return false, err
+	}
+	if checks.TotalCount == 0 {
+		return true, nil
+	}
+	for _, c := range checks.CheckRuns {
+		if c.Status != "completed" || c.Conclusion != "success" {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (g *GitHubForge) MergeSquash(ctx context.Context, owner, repo string, number int, sha string) (MergeResult, error) {
+	var response struct {
+		Merged bool   `json:"merged"`
+		SHA    string `json:"sha"`
+	}
+	err := g.request(ctx, http.MethodPut, fmt.Sprintf("/repos/%s/%s/pulls/%d/merge", pathEscape(owner), pathEscape(repo), number), map[string]string{"sha": sha, "merge_method": "squash"}, &response)
+	if err != nil {
+		return MergeResult{}, err
+	}
+	if !response.Merged || response.SHA == "" {
+		return MergeResult{}, fmt.Errorf("github squash merge was not confirmed")
+	}
+	return MergeResult{Merged: true, SHA: response.SHA}, nil
+}
+
+func pathEscape(s string) string { return url.PathEscape(s) }

--- a/internal/kb/forge_test.go
+++ b/internal/kb/forge_test.go
@@ -1,0 +1,195 @@
+package kb
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestGitHubForgeCreatesLabeledPR(t *testing.T) {
+	var sawCreate, sawLabel bool
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer secret" {
+			t.Errorf("authorization = %q", r.Header.Get("Authorization"))
+		}
+		switch r.URL.Path {
+		case "/repos/acme/wiki/pulls":
+			sawCreate = r.Method == http.MethodPost
+			_, _ = w.Write([]byte(`{"number":7,"html_url":"https://example/pr/7","state":"open","head":{"sha":"abc"}}`))
+		case "/repos/acme/wiki/issues/7/labels":
+			sawLabel = r.Method == http.MethodPost
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer s.Close()
+	g := &GitHubForge{APIURL: s.URL, Token: "secret", Client: s.Client()}
+	pr, err := g.CreatePR(context.Background(), "acme", "wiki", "cartographer/kb", "main", "title", "body")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pr.Number != 7 || !sawCreate || !sawLabel {
+		t.Fatalf("pr=%#v create=%v label=%v", pr, sawCreate, sawLabel)
+	}
+}
+
+func TestGitHubForgePaginatesOpenPRsAndUsesScopedQuery(t *testing.T) {
+	var pages []string
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pages = append(pages, r.URL.RawQuery)
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		if page == 1 {
+			prs := make([]string, 100)
+			for i := range prs {
+				prs[i] = fmt.Sprintf(`{"number":%d,"state":"open","head":{"sha":"h%d"}}`, i+1, i+1)
+			}
+			_, _ = w.Write([]byte("[" + strings.Join(prs, ",") + "]"))
+			return
+		}
+		_, _ = w.Write([]byte(`[{"number":101,"state":"open","head":{"sha":"h101"}}]`))
+	}))
+	defer s.Close()
+	prs, err := (&GitHubForge{APIURL: s.URL, Client: s.Client()}).FindOpenPR(context.Background(), "acme", "wiki", "work", "main")
+	if err != nil || len(prs) != 101 {
+		t.Fatalf("FindOpenPR = %d, %v", len(prs), err)
+	}
+	if len(pages) != 2 || !strings.Contains(pages[0], "state=open") || !strings.Contains(pages[0], "head=acme%3Awork") || !strings.Contains(pages[0], "base=main") {
+		t.Fatalf("unexpected pagination queries: %q", pages)
+	}
+}
+
+func TestGitHubForgeReadyChecksLatestReviewsAndChecks(t *testing.T) {
+	for _, tc := range []struct {
+		name, reviews, checks string
+		want                  bool
+	}{
+		{"approval success", `[{"state":"APPROVED","user":{"login":"a"}}]`, `{"total_count":1,"check_runs":[{"status":"completed","conclusion":"success"}]}`, true},
+		{"latest request changes", `[{"state":"CHANGES_REQUESTED","user":{"login":"a"}},{"state":"APPROVED","user":{"login":"a"}}]`, `{"total_count":0}`, false},
+		{"pending check", `[{"state":"APPROVED","user":{"login":"a"}}]`, `{"total_count":1,"check_runs":[{"status":"in_progress","conclusion":""}]}`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.Contains(r.URL.Path, "/reviews"):
+					_, _ = w.Write([]byte(tc.reviews))
+				case strings.Contains(r.URL.Path, "/check-runs"):
+					_, _ = w.Write([]byte(tc.checks))
+				case strings.Contains(r.URL.Path, "/pulls/1"):
+					_, _ = w.Write([]byte(`{"number":1,"state":"open","head":{"sha":"head"}}`))
+				default:
+					t.Fatalf("unexpected request %s", r.URL.String())
+				}
+			}))
+			defer s.Close()
+			got, err := (&GitHubForge{APIURL: s.URL, Client: s.Client()}).PRReady(context.Background(), "a", "b", 1)
+			if err != nil || got != tc.want {
+				t.Fatalf("PRReady = %v, %v; want %v", got, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestGitHubForgeMergeEndpointAndErrors(t *testing.T) {
+	var mergeBody string
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/repos/a/b/pulls/9/merge" {
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		mergeBody = string(body)
+		_, _ = w.Write([]byte(`{"merged":true,"sha":"merge-sha"}`))
+	}))
+	defer s.Close()
+	got, err := (&GitHubForge{APIURL: s.URL, Client: s.Client()}).MergeSquash(context.Background(), "a", "b", 9, "head-sha")
+	if err != nil || !got.Merged || got.SHA != "merge-sha" || !strings.Contains(mergeBody, `"merge_method":"squash"`) || !strings.Contains(mergeBody, `"sha":"head-sha"`) {
+		t.Fatalf("MergeSquash = %#v, %v; body=%s", got, err, mergeBody)
+	}
+}
+
+func TestGitHubForgeNeverUpdatesRefsOrBase(t *testing.T) {
+	var requests []string
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		if strings.Contains(r.URL.Path, "/git/refs") || strings.Contains(r.URL.Path, "/branches/") {
+			t.Fatalf("forge attempted protected-ref endpoint: %s %s", r.Method, r.URL.Path)
+		}
+		switch {
+		case r.URL.Path == "/repos/a/b/pulls" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`[]`))
+		case r.URL.Path == "/repos/a/b/pulls" && r.Method == http.MethodPost:
+			_, _ = w.Write([]byte(`{"number":1,"state":"open","head":{"sha":"head"}}`))
+		case r.URL.Path == "/repos/a/b/issues/1/labels":
+			w.WriteHeader(http.StatusOK)
+		case strings.Contains(r.URL.Path, "/reviews"):
+			_, _ = w.Write([]byte(`[{"state":"APPROVED","user":{"login":"r"}}]`))
+		case r.URL.Path == "/repos/a/b/pulls/1":
+			_, _ = w.Write([]byte(`{"number":1,"state":"open","head":{"sha":"head"}}`))
+		case strings.Contains(r.URL.Path, "/check-runs"):
+			_, _ = w.Write([]byte(`{"total_count":0}`))
+		case r.URL.Path == "/repos/a/b/pulls/1/merge":
+			_, _ = w.Write([]byte(`{"merged":true,"sha":"merge"}`))
+		default:
+			t.Fatalf("unexpected forge request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer s.Close()
+	g := &GitHubForge{APIURL: s.URL, Client: s.Client()}
+	if _, err := g.FindOpenPR(context.Background(), "a", "b", "work", "main"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := g.CreatePR(context.Background(), "a", "b", "work", "main", "t", "b"); err != nil {
+		t.Fatal(err)
+	}
+	if ok, err := g.PRReady(context.Background(), "a", "b", 1); err != nil || !ok {
+		t.Fatalf("PRReady=%v, %v", ok, err)
+	}
+	if _, err := g.MergeSquash(context.Background(), "a", "b", 1, "head"); err != nil {
+		t.Fatal(err)
+	}
+	if len(requests) == 0 {
+		t.Fatal("expected forge requests")
+	}
+}
+
+func TestGitHubForgeRedactsOnlyNonEmptyToken(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("token secret failed"))
+	}))
+	defer s.Close()
+	_, err := (&GitHubForge{APIURL: s.URL, Token: "secret", Client: s.Client()}).FindOpenPR(context.Background(), "a", "b", "h", "base")
+	if err == nil || contains(err.Error(), "secret") {
+		t.Fatalf("error was not redacted: %v", err)
+	}
+	_, err = (&GitHubForge{APIURL: s.URL, Client: s.Client()}).FindOpenPR(context.Background(), "a", "b", "h", "base")
+	if err == nil || !contains(err.Error(), "token secret failed") {
+		t.Fatalf("empty token corrupted error: %v", err)
+	}
+}
+
+func TestGitHubForgeReadyUsesLatestReview(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case contains(r.URL.Path, "/reviews"):
+			_, _ = w.Write([]byte(`[{"state":"CHANGES_REQUESTED","user":{"login":"reviewer"}},{"state":"APPROVED","user":{"login":"reviewer"}}]`))
+		case contains(r.URL.Path, "/pulls/1"):
+			_, _ = w.Write([]byte(`{"number":1,"state":"open","head":{"sha":"head"}}`))
+		default:
+			t.Fatalf("unexpected request %s", r.URL.String())
+		}
+	}))
+	defer s.Close()
+	ready, err := (&GitHubForge{APIURL: s.URL, Client: s.Client()}).PRReady(context.Background(), "a", "b", 1)
+	if err != nil || ready {
+		t.Fatalf("ready=%v err=%v", ready, err)
+	}
+}
+
+func contains(s, part string) bool { return strings.Contains(s, part) }

--- a/internal/kb/gitsync.go
+++ b/internal/kb/gitsync.go
@@ -90,6 +90,9 @@ func (k *KB) lastSyncInAt() time.Time {
 // is. lastSyncIn is only updated after a fetch+pull that actually succeeds.
 // Callers must hold the git lock.
 func (k *KB) SyncIn() (bool, error) {
+	if err := k.ServerWritesBlocked(); err != nil {
+		return false, err
+	}
 	if !k.SyncInDue() {
 		return false, nil
 	}
@@ -99,6 +102,20 @@ func (k *KB) SyncIn() (bool, error) {
 	// Fetch first to update remote refs.
 	if err := gitx.Fetch(k.Root, remote, k.GitEnv...); err != nil {
 		return true, fmt.Errorf("SyncIn fetch: %w", err)
+	}
+	if k.ServerGit != nil {
+		if branch != k.ServerGit.WorkingBranch {
+			return true, fmt.Errorf("SyncIn server profile: checked out %q, expected %q", branch, k.ServerGit.WorkingBranch)
+		}
+		if err := gitx.RebaseOntoAutostash(k.Root, remote, k.ServerGit.BaseBranch, k.GitEnv...); err != nil {
+			k.RecordServerRebaseConflict(err)
+			return true, err
+		}
+		k.setLastSyncIn(time.Now())
+		if headAfter, err := gitx.HeadSHA(k.Root); err == nil && headAfter != headBefore && k.OnSyncIn != nil {
+			k.OnSyncIn()
+		}
+		return true, nil
 	}
 	if err := gitx.PullRebaseAutostash(k.Root, remote, branch, k.GitEnv...); err != nil {
 		return true, err
@@ -129,6 +146,13 @@ func (k *KB) SyncOut() error {
 	if !ok {
 		k.setGitStatus("no_remote", nil, 0)
 		return nil
+	}
+	if k.ServerGit != nil {
+		if err := k.ServerWritesBlocked(); err != nil {
+			k.setGitStatus("degraded", err, 0)
+			return err
+		}
+		return k.syncOutServer(remote)
 	}
 
 	maxAttempts := syncOutMaxAttempts
@@ -201,6 +225,66 @@ func (k *KB) SyncOut() error {
 
 	err := fmt.Errorf("SyncOut: push failed after %d attempts", maxAttempts)
 	k.setGitStatus("failed", err, maxAttempts)
+	return err
+}
+
+// syncOutServer pushes only the dedicated working branch (D117): a
+// non-fast-forward rejection fetches and rebases the working branch onto the
+// remote working branch first (never onto itself as base), then re-rebases
+// onto the current base before retrying.
+func (k *KB) syncOutServer(remote string) error {
+	branch, _ := gitx.Branch(k.Root)
+	if branch != k.ServerGit.WorkingBranch {
+		err := fmt.Errorf("SyncOut server profile: checked out %q, expected %q", branch, k.ServerGit.WorkingBranch)
+		k.setGitStatus("failed", err, 1)
+		return err
+	}
+	for attempt := 1; attempt <= syncOutMaxAttempts; attempt++ {
+		pushErr := gitx.Push(k.Root, remote, branch, k.GitEnv...)
+		if pushErr == nil {
+			ctx, cancel := serverGitContext()
+			forgeErr := k.syncServerPR(ctx)
+			cancel()
+			if forgeErr != nil {
+				return forgeErr
+			}
+			k.setGitStatus("clean", nil, attempt)
+			return nil
+		}
+		errMsg := pushErr.Error()
+		isRejected := strings.Contains(errMsg, "non-fast-forward") ||
+			strings.Contains(errMsg, "[rejected]") ||
+			strings.Contains(errMsg, "Updates were rejected")
+		if !isRejected {
+			if attempt == syncOutMaxAttempts {
+				k.setGitStatus("failed", pushErr, attempt)
+				return pushErr
+			}
+		} else {
+			if fetchErr := gitx.Fetch(k.Root, remote, k.GitEnv...); fetchErr != nil {
+				if attempt == syncOutMaxAttempts {
+					k.setGitStatus("failed", fetchErr, attempt)
+					return fetchErr
+				}
+			} else {
+				// First incorporate a concurrent update to the working branch, then
+				// rebase onto base again. The working branch is never used as base.
+				if rebaseErr := gitx.PullRebaseAutostash(k.Root, remote, branch, k.GitEnv...); rebaseErr != nil {
+					k.RecordServerRebaseConflict(rebaseErr)
+					k.setGitStatus("failed", rebaseErr, attempt)
+					return rebaseErr
+				}
+				if rebaseErr := gitx.RebaseOntoAutostash(k.Root, remote, k.ServerGit.BaseBranch, k.GitEnv...); rebaseErr != nil {
+					k.RecordServerRebaseConflict(rebaseErr)
+					k.setGitStatus("failed", rebaseErr, attempt)
+					return rebaseErr
+				}
+			}
+		}
+		syncOutSleep(syncOutInitialBackoff * time.Duration(1<<(attempt-1)))
+	}
+	err := fmt.Errorf("SyncOut server profile: push failed after %d attempts", syncOutMaxAttempts)
+	k.setGitStatus("failed", err, syncOutMaxAttempts)
 	return err
 }
 

--- a/internal/kb/kb.go
+++ b/internal/kb/kb.go
@@ -45,6 +45,14 @@ type KB struct {
 	// pre-existing behaviour.
 	GitEnv []string
 
+	// ServerGit is non-nil only for the opt-in server profile. Its dedicated
+	// working branch is the only branch this process may push (D117).
+	ServerGit *ServerGitConfig
+	// ServerMergeLint is wired by the MCP layer to run the full lint during a
+	// server-profile PR finalization. Keeping it injectable avoids a kb↔lint
+	// import cycle while preserving an in-lock gate.
+	ServerMergeLint func() error
+
 	// SopsAgeKeyFile is the path to the SOPS age key file used to decrypt
 	// this KB's secrets (e.g. via service_get resolve_secrets). Empty means
 	// no per-KB key is configured — secret resolution fails clearly instead

--- a/internal/kb/servergit.go
+++ b/internal/kb/servergit.go
@@ -1,0 +1,476 @@
+package kb
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/BeppeTemp/cartographer/internal/gitx"
+	"github.com/BeppeTemp/cartographer/internal/okf"
+)
+
+const serverGitStateFilename = "server-git.json"
+
+// ServerGitConfig is the resolved, non-secret configuration for the server
+// profile. Token material belongs only in Forge and is never persisted.
+type ServerGitConfig struct {
+	BaseBranch    string
+	WorkingBranch string
+	Owner         string
+	Repository    string
+	Forge         Forge
+}
+
+// ServerGitState is local operational state, deliberately outside history.
+type ServerGitState struct {
+	Profile        string `json:"profile"`
+	BaseBranch     string `json:"base_branch"`
+	WorkingBranch  string `json:"working_branch"`
+	PRNumber       int    `json:"pr_number,omitempty"`
+	PRURL          string `json:"pr_url,omitempty"`
+	PRHeadSHA      string `json:"pr_head_sha,omitempty"`
+	PRBaseSHA      string `json:"pr_base_sha,omitempty"`
+	LastForgeError string `json:"last_forge_error,omitempty"`
+	Phase          string `json:"phase,omitempty"` // open | merge_uncertain
+	MergeSHA       string `json:"merge_sha,omitempty"`
+}
+
+func (k *KB) serverGitStatePath() string {
+	return filepath.Join(k.cartographerDirPath(), serverGitStateFilename)
+}
+
+func (k *KB) loadServerGitState() (ServerGitState, error) {
+	var state ServerGitState
+	data, err := os.ReadFile(k.serverGitStatePath())
+	if errors.Is(err, os.ErrNotExist) {
+		return state, nil
+	}
+	if err != nil {
+		return state, fmt.Errorf("server git state: read: %w", err)
+	}
+	if err := json.Unmarshal(data, &state); err != nil {
+		return state, fmt.Errorf("server git state: decode: %w", err)
+	}
+	return state, nil
+}
+
+func (k *KB) saveServerGitState(state ServerGitState) error {
+	if err := k.ensureCartographerDir(); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("server git state: encode: %w", err)
+	}
+	return writeFileAtomic(k.serverGitStatePath(), data)
+}
+
+// ConfigureServerGit validates and mounts a dedicated working branch. It is
+// intentionally fail-fast: ambiguous local state is never repaired by reset.
+func (k *KB) ConfigureServerGit(cfg ServerGitConfig) error {
+	if cfg.BaseBranch == "" || cfg.WorkingBranch == "" || cfg.Owner == "" || cfg.Repository == "" || cfg.Forge == nil {
+		return fmt.Errorf("server git profile requires base_branch, working_branch, github owner/repository, and forge")
+	}
+	if cfg.BaseBranch == cfg.WorkingBranch {
+		return fmt.Errorf("server git profile base_branch and working_branch must differ")
+	}
+	if !gitx.IsRepo(k.Root) {
+		return fmt.Errorf("server git profile requires a git repository")
+	}
+	if status, err := gitx.Status(k.Root); err != nil {
+		return err
+	} else if strings.TrimSpace(status) != "" {
+		return fmt.Errorf("server git profile refuses dirty startup state")
+	}
+	if _, ok := k.hasRemote(); !ok {
+		return fmt.Errorf("server git profile requires origin")
+	}
+	// Keep the transport and review boundaries tied to the same repository.
+	// This deliberately returns no URL: remotes may embed credentials and config
+	// errors must never turn those into logs or persisted state.
+	remoteURL, err := gitx.RemoteURL(k.Root, "origin")
+	if err != nil || !githubRemoteMatches(remoteURL, cfg.Owner, cfg.Repository) {
+		return fmt.Errorf("server git profile origin does not match configured GitHub repository")
+	}
+	if branch, _ := gitx.Branch(k.Root); branch == "" {
+		return fmt.Errorf("server git profile refuses detached HEAD")
+	}
+	if err := gitx.Fetch(k.Root, "origin", k.GitEnv...); err != nil {
+		return fmt.Errorf("server git profile fetch: %w", err)
+	}
+	if !gitx.RemoteBranchExists(k.Root, "origin", cfg.BaseBranch) {
+		return fmt.Errorf("server git profile base branch origin/%s is missing", cfg.BaseBranch)
+	}
+	state, err := k.loadServerGitState()
+	if err != nil {
+		return err
+	}
+	if gitx.RemoteBranchExists(k.Root, "origin", cfg.WorkingBranch) {
+		// Validate the published branch itself, not merely a possibly stale local
+		// checkout. Otherwise an unrelated remote rewrite can be hidden by an old
+		// local working branch and later be pushed/merged by mistake.
+		remoteOK, remoteErr := gitx.IsAncestor(k.Root, "origin/"+cfg.BaseBranch, "origin/"+cfg.WorkingBranch)
+		if (remoteErr != nil || !remoteOK) && state.Phase != "merge_uncertain" {
+			return fmt.Errorf("server git profile remote working branch %q does not descend from origin/%s; operator action required", cfg.WorkingBranch, cfg.BaseBranch)
+		}
+		if !gitx.BranchExists(k.Root, cfg.WorkingBranch) {
+			if err := gitx.CheckoutNewBranch(k.Root, cfg.WorkingBranch, "origin/"+cfg.WorkingBranch, k.GitEnv...); err != nil {
+				return err
+			}
+		} else if err := gitx.Checkout(k.Root, cfg.WorkingBranch); err != nil {
+			return err
+		}
+		ok, err := gitx.IsAncestor(k.Root, "origin/"+cfg.BaseBranch, "HEAD")
+		if (err != nil || !ok) && state.Phase != "merge_uncertain" {
+			return fmt.Errorf("server git profile working branch %q does not descend from origin/%s; operator action required", cfg.WorkingBranch, cfg.BaseBranch)
+		}
+	} else {
+		if gitx.BranchExists(k.Root, cfg.WorkingBranch) {
+			return fmt.Errorf("server git profile local working branch %q has no remote counterpart; operator action required", cfg.WorkingBranch)
+		}
+		if err := gitx.CheckoutNewBranch(k.Root, cfg.WorkingBranch, "origin/"+cfg.BaseBranch, k.GitEnv...); err != nil {
+			return err
+		}
+	}
+	k.ServerGit = &cfg
+	state.Profile, state.BaseBranch, state.WorkingBranch = "server", cfg.BaseBranch, cfg.WorkingBranch
+	if err := k.saveServerGitState(state); err != nil {
+		return err
+	}
+	if state.Phase == "merge_uncertain" {
+		ctx, cancel := serverGitContext()
+		defer cancel()
+		_ = k.reconcileUncertainMerge(ctx, state)
+	}
+	return nil
+}
+
+// githubRemoteMatches recognizes GitHub's HTTPS and SSH remote spellings.
+// It intentionally accepts an enterprise hostname too: the configured GitHub
+// API endpoint controls the forge, while owner/repository is the invariant
+// shared by API and transport. Userinfo is ignored so a token can never affect
+// matching or appear in an error.
+func githubRemoteMatches(remote, owner, repository string) bool {
+	remote = strings.TrimSpace(remote)
+	if remote == "" || owner == "" || repository == "" {
+		return false
+	}
+	remote = strings.TrimSuffix(strings.TrimRight(remote, "/"), ".git")
+	path := ""
+	switch {
+	case strings.Contains(remote, "://"):
+		// URL parsing is intentionally avoided here because scp-like SSH URLs
+		// are not URLs; for URL forms the final two path components are enough.
+		if slash := strings.Index(remote, "://"); slash >= 0 {
+			scheme := remote[:slash]
+			if scheme != "https" && scheme != "ssh" {
+				return false
+			}
+			rest := remote[slash+3:]
+			if i := strings.IndexByte(rest, '/'); i >= 0 {
+				path = rest[i+1:]
+			}
+		}
+	case strings.Contains(remote, ":"):
+		// git@host:owner/repository (the host/user portion cannot carry a
+		// repository path, so only the right hand side is considered).
+		path = remote[strings.LastIndex(remote, ":")+1:]
+	}
+	path = strings.Trim(path, "/")
+	return path == owner+"/"+repository
+}
+
+// ServerGitStatus returns the persisted PR metadata alongside the current
+// profile. It is safe for local-profile KBs too.
+func (k *KB) ServerGitStatus() ServerGitState {
+	state, _ := k.loadServerGitState()
+	if k.ServerGit != nil {
+		state.Profile, state.BaseBranch, state.WorkingBranch = "server", k.ServerGit.BaseBranch, k.ServerGit.WorkingBranch
+	} else if state.Profile == "" {
+		state.Profile = "local"
+	}
+	return state
+}
+
+func (k *KB) syncServerPR(ctx context.Context) error {
+	if k.ServerGit == nil {
+		return nil
+	}
+	cfg := k.ServerGit
+	state := k.ServerGitStatus()
+	if state.Phase == "merge_uncertain" {
+		return k.reconcileUncertainMerge(ctx, state)
+	}
+	prs, err := cfg.Forge.FindOpenPR(ctx, cfg.Owner, cfg.Repository, cfg.WorkingBranch, cfg.BaseBranch)
+	if err != nil {
+		return k.recordForgeError(err)
+	}
+	if len(prs) > 1 {
+		return k.recordForgeError(fmt.Errorf("server git profile found %d open PRs for %s -> %s", len(prs), cfg.WorkingBranch, cfg.BaseBranch))
+	}
+	var pr PullRequest
+	if len(prs) == 1 {
+		pr = prs[0]
+	} else {
+		pr, err = cfg.Forge.CreatePR(ctx, cfg.Owner, cfg.Repository, cfg.WorkingBranch, cfg.BaseBranch, "Cartographer: "+filepath.Base(k.Root), "Automated KB changes from Cartographer. Review and squash-merge through this PR.")
+		if err != nil {
+			return k.recordForgeError(err)
+		}
+	}
+	state.PRNumber, state.PRURL, state.PRHeadSHA, state.PRBaseSHA, state.LastForgeError = pr.Number, pr.URL, pr.HeadSHA, pr.BaseSHA, ""
+	state.Phase, state.MergeSHA = "open", ""
+	return k.saveServerGitState(state)
+}
+
+// ServerWritesBlocked prevents a second PR cycle while the result of a prior
+// merge request is unknown. Only status reconciliation may clear it.
+func (k *KB) ServerWritesBlocked() error {
+	if k.ServerGit == nil {
+		return nil
+	}
+	state := k.ServerGitStatus()
+	if state.Phase == "merge_uncertain" {
+		return fmt.Errorf("server git profile is degraded: merge outcome is uncertain; reconcile with pr_status before new writes")
+	}
+	return nil
+}
+
+// RecordServerRebaseConflict persists server-specific metadata before the
+// caller returns the structured git conflict. Non-concept files remain a
+// fail-closed error because the agent-facing registry cannot safely edit them.
+func (k *KB) RecordServerRebaseConflict(err error) {
+	var rce *gitx.RebaseConflictError
+	if !errors.As(err, &rce) || k.ServerGit == nil {
+		return
+	}
+	state := k.ServerGitStatus()
+	for _, file := range rce.Files {
+		id, concept := GitPathToConceptID(file)
+		if !concept {
+			// A conflict outside data/ cannot be exposed as a concept, but it
+			// must still stop server finalization. Retain a stable path-keyed
+			// registry entry so it can be explicitly resolved; silently skipping
+			// it would make a later PR look safe while Git remains conflicted.
+			id = "git-path:" + filepath.ToSlash(file)
+		}
+		c := Conflict{ConceptID: id, Path: file, LocalSHA: rce.LocalSHA, RemoteSHA: rce.RemoteSHA, Branch: rce.Branch, BaseBranch: k.ServerGit.BaseBranch, WorkingBranch: k.ServerGit.WorkingBranch, PRNumber: state.PRNumber, PRURL: state.PRURL, Files: rce.Files}
+		_ = k.RegisterConflict(c)
+		if concept {
+			_ = k.MarkDegraded(id)
+		}
+	}
+}
+
+// ReconcileServerPR retries a previously failed PR lookup/create from a
+// status request. It does not change Git refs and is a no-op for Local Core.
+func (k *KB) ReconcileServerPR() error {
+	if k.ServerGit == nil {
+		return nil
+	}
+	return k.WithGitLock(func() error {
+		ctx, cancel := serverGitContext()
+		defer cancel()
+		return k.syncServerPR(ctx)
+	})
+}
+
+func (k *KB) recordForgeError(err error) error {
+	state := k.ServerGitStatus()
+	state.LastForgeError = err.Error()
+	_ = k.saveServerGitState(state)
+	k.SetGitStatus("degraded", err)
+	return err
+}
+
+func (k *KB) markMergeUncertain(state ServerGitState, sha string, err error) error {
+	state.Phase, state.MergeSHA, state.LastForgeError = "merge_uncertain", sha, err.Error()
+	_ = k.saveServerGitState(state)
+	k.SetGitStatus("degraded", err)
+	return err
+}
+
+func (k *KB) reconcileUncertainMerge(ctx context.Context, state ServerGitState) error {
+	if state.PRNumber == 0 {
+		return k.recordForgeError(fmt.Errorf("merge outcome uncertain without PR identity"))
+	}
+	pr, err := k.ServerGit.Forge.GetPR(ctx, k.ServerGit.Owner, k.ServerGit.Repository, state.PRNumber)
+	if err != nil {
+		return k.recordForgeError(err)
+	}
+	if strings.EqualFold(pr.State, "open") {
+		return k.recordForgeError(fmt.Errorf("merge outcome remains uncertain for open PR #%d", pr.Number))
+	}
+	if !pr.Merged {
+		return k.recordForgeError(fmt.Errorf("merge outcome is unmerged %q for PR #%d", pr.State, pr.Number))
+	}
+	if err := gitx.Fetch(k.Root, "origin", k.GitEnv...); err != nil {
+		return k.recordForgeError(fmt.Errorf("merged PR reconciliation fetch: %w", err))
+	}
+	baseHead, err := gitx.HeadSHAAt(k.Root, "origin/"+k.ServerGit.BaseBranch)
+	if err != nil {
+		return k.recordForgeError(err)
+	}
+	mergeSHA := pr.MergeSHA
+	if mergeSHA == "" {
+		mergeSHA = state.MergeSHA
+	}
+	if mergeSHA == "" {
+		mergeSHA = baseHead
+	}
+	ok, err := gitx.IsAncestor(k.Root, mergeSHA, "origin/"+k.ServerGit.BaseBranch)
+	if err != nil || !ok {
+		return k.recordForgeError(fmt.Errorf("merged PR result %s is not present on origin/%s", mergeSHA, k.ServerGit.BaseBranch))
+	}
+	if status, _ := gitx.Status(k.Root); strings.TrimSpace(status) != "" {
+		return k.recordForgeError(fmt.Errorf("merged PR reconciliation requires a clean working tree"))
+	}
+	oldHead, _ := gitx.HeadSHAAt(k.Root, "origin/"+k.ServerGit.WorkingBranch)
+	if err := gitx.ResetHardTo(k.Root, baseHead, k.GitEnv...); err != nil {
+		return k.recordForgeError(err)
+	}
+	if err := gitx.PushForceWithLease(k.Root, "origin", k.ServerGit.WorkingBranch, oldHead, k.GitEnv...); err != nil {
+		return k.recordForgeError(err)
+	}
+	state.PRNumber, state.PRURL, state.PRHeadSHA, state.PRBaseSHA, state.LastForgeError, state.Phase, state.MergeSHA = 0, "", "", "", "", "", ""
+	return k.saveServerGitState(state)
+}
+
+// FinalizeServerPR enforces review, a caller-supplied PR head, rebase and a
+// force-with-lease update of only the dedicated working branch before asking
+// the forge for a squash merge.
+func (k *KB) FinalizeServerPR(ctx context.Context, expectedHead string) error {
+	if k.ServerGit == nil {
+		return fmt.Errorf("server git profile is not enabled")
+	}
+	if expectedHead == "" {
+		return fmt.Errorf("head_sha is required")
+	}
+	if cs, err := k.ListConflicts(); err != nil {
+		return err
+	} else if len(cs) != 0 {
+		return fmt.Errorf("cannot finalize PR with %d unresolved conflict(s)", len(cs))
+	}
+	return k.WithGitLock(func() error {
+		state := k.ServerGitStatus()
+		if state.Phase == "merge_uncertain" {
+			return fmt.Errorf("cannot finalize while merge outcome is uncertain")
+		}
+		if state.PRNumber == 0 {
+			return fmt.Errorf("no open server-profile PR")
+		}
+		pr, err := k.ServerGit.Forge.GetPR(ctx, k.ServerGit.Owner, k.ServerGit.Repository, state.PRNumber)
+		if err != nil {
+			return k.recordForgeError(err)
+		}
+		if !strings.EqualFold(pr.State, "open") || pr.HeadSHA != expectedHead {
+			return fmt.Errorf("stale or closed PR: expected open head %s, current state=%s head=%s", expectedHead, pr.State, pr.HeadSHA)
+		}
+		if state.PRHeadSHA != expectedHead {
+			return fmt.Errorf("stale PR head: expected %s, current %s", expectedHead, state.PRHeadSHA)
+		}
+		if state.PRBaseSHA != "" && pr.BaseSHA != "" && state.PRBaseSHA != pr.BaseSHA {
+			return fmt.Errorf("stale PR base: expected %s, current %s", state.PRBaseSHA, pr.BaseSHA)
+		}
+		if state.PRBaseSHA == "" && pr.BaseSHA != "" {
+			state.PRBaseSHA = pr.BaseSHA
+			if err := k.saveServerGitState(state); err != nil {
+				return err
+			}
+		}
+		ready, err := k.ServerGit.Forge.PRReady(ctx, k.ServerGit.Owner, k.ServerGit.Repository, state.PRNumber)
+		if err != nil {
+			return k.recordForgeError(err)
+		}
+		if !ready {
+			return fmt.Errorf("PR reviews or checks are not satisfied")
+		}
+		if err := gitx.Fetch(k.Root, "origin", k.GitEnv...); err != nil {
+			return err
+		}
+		remoteHead, err := gitx.HeadSHAAt(k.Root, "origin/"+k.ServerGit.WorkingBranch)
+		if err != nil {
+			return err
+		}
+		if remoteHead != expectedHead {
+			return fmt.Errorf("stale PR head after fetch: expected %s, current %s", expectedHead, remoteHead)
+		}
+		if err := gitx.RebaseOntoAutostash(k.Root, "origin", k.ServerGit.BaseBranch, k.GitEnv...); err != nil {
+			k.RecordServerRebaseConflict(err)
+			return err
+		}
+		if errs, err := k.Validate(""); err != nil {
+			return err
+		} else if len(errs) != 0 {
+			return fmt.Errorf("finalize PR validation failed: %d error(s)", len(errs))
+		}
+		changes, err := gitx.DiffNameStatus(k.Root, "origin/"+k.ServerGit.BaseBranch, "HEAD")
+		if err != nil {
+			return fmt.Errorf("finalize PR changed concepts: %w", err)
+		}
+		var ids []string
+		for _, change := range changes {
+			if id, ok := GitPathToConceptID(change.Path); ok {
+				ids = append(ids, id)
+			}
+		}
+		if len(ids) != 0 {
+			conceptIDs := make([]okf.ConceptID, len(ids))
+			for i, id := range ids {
+				conceptIDs[i] = okf.ConceptID(id)
+			}
+			gate, err := k.CommitGate(conceptIDs)
+			if err != nil {
+				return err
+			}
+			if !gate.Pass {
+				return fmt.Errorf("finalize PR commit gate failed")
+			}
+		}
+		if k.ServerMergeLint != nil {
+			if err := k.ServerMergeLint(); err != nil {
+				return fmt.Errorf("finalize PR lint: %w", err)
+			}
+		}
+		if err := gitx.PushForceWithLease(k.Root, "origin", k.ServerGit.WorkingBranch, expectedHead, k.GitEnv...); err != nil {
+			return err
+		}
+		newHead, err := gitx.HeadSHA(k.Root)
+		if err != nil {
+			return err
+		}
+		// Re-read the forge immediately before merge. A base advance can race
+		// rebase/gates; GitHub's PR is the merge authority for both head and base.
+		latest, err := k.ServerGit.Forge.GetPR(ctx, k.ServerGit.Owner, k.ServerGit.Repository, state.PRNumber)
+		if err != nil {
+			return k.recordForgeError(err)
+		}
+		if !strings.EqualFold(latest.State, "open") || latest.HeadSHA != newHead {
+			return fmt.Errorf("stale PR before merge: expected open head %s, current state=%s head=%s", newHead, latest.State, latest.HeadSHA)
+		}
+		if pr.BaseSHA != "" && latest.BaseSHA != "" && latest.BaseSHA != pr.BaseSHA {
+			return fmt.Errorf("stale PR base before merge: expected %s, current %s", pr.BaseSHA, latest.BaseSHA)
+		}
+		merged, mergeErr := k.ServerGit.Forge.MergeSquash(ctx, k.ServerGit.Owner, k.ServerGit.Repository, state.PRNumber, newHead)
+		if mergeErr != nil {
+			return k.markMergeUncertain(state, newHead, fmt.Errorf("squash merge outcome uncertain: %w", mergeErr))
+		}
+		if !merged.Merged {
+			return k.markMergeUncertain(state, newHead, fmt.Errorf("squash merge outcome uncertain"))
+		}
+		state.Phase, state.MergeSHA = "merge_uncertain", merged.SHA
+		if err := k.saveServerGitState(state); err != nil {
+			return err
+		}
+		return k.reconcileUncertainMerge(ctx, state)
+	})
+}
+
+// serverGitContext bounds forge calls while preserving the operation lock.
+func serverGitContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 15*time.Second)
+}

--- a/internal/kb/servergit_finalize_test.go
+++ b/internal/kb/servergit_finalize_test.go
@@ -1,0 +1,345 @@
+package kb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BeppeTemp/cartographer/internal/gitx"
+)
+
+func finalState(t *testing.T, k *KB, number int, head string) {
+	t.Helper()
+	if err := k.saveServerGitState(ServerGitState{Profile: "server", BaseBranch: "main", WorkingBranch: "cartographer/kb", PRNumber: number, PRHeadSHA: head, Phase: "open"}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readyForge(head string, ready bool) *scriptedForge {
+	return &scriptedForge{
+		find:   func() ([]PullRequest, error) { return nil, errors.New("unused") },
+		create: func() (PullRequest, error) { return PullRequest{}, errors.New("unused") },
+		get:    func() (PullRequest, error) { return PullRequest{Number: 9, State: "open", HeadSHA: head}, nil },
+		ready:  func() (bool, error) { return ready, nil },
+		merge:  func() (MergeResult, error) { return MergeResult{}, errors.New("must not merge") },
+	}
+}
+
+func TestFinalizeServerPRRejectsStaleCallerAndForgeHead(t *testing.T) {
+	k, _, head := serverGitFinalizeFixture(t)
+	base, _ := gitx.HeadSHAAt(k.Root, "origin/main")
+	f := readyForge(head, true)
+	k.ServerGit.Forge = f
+	finalState(t, k, 9, head)
+	if err := k.FinalizeServerPR(context.Background(), "stale"); err == nil || !strings.Contains(err.Error(), "stale") {
+		t.Fatalf("stale caller error = %v", err)
+	}
+	f.get = func() (PullRequest, error) { return PullRequest{Number: 9, State: "open", HeadSHA: "new-head"}, nil }
+	if err := k.FinalizeServerPR(context.Background(), head); err == nil || !strings.Contains(err.Error(), "stale") {
+		t.Fatalf("stale forge head error = %v", err)
+	}
+	if got, _ := gitx.HeadSHAAt(k.Root, "origin/main"); got != base {
+		t.Fatalf("base changed on stale finalization: %s -> %s", base, got)
+	}
+}
+
+func TestFinalizeServerPRValidationLintAndGateFailuresDoNotPush(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		want    string
+		prepare func(t *testing.T, k *KB)
+	}{
+		{"validation", "validation failed", func(t *testing.T, k *KB) {
+			if err := os.WriteFile(filepath.Join(k.Root, "data", "invalid.md"), []byte("not markdown frontmatter\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"lint", "lint failed", func(t *testing.T, k *KB) { k.ServerMergeLint = func() error { return errors.New("lint failed") } }},
+		{"commit gate", "commit gate", func(t *testing.T, k *KB) {
+			if err := os.WriteFile(filepath.Join(k.Root, "data", "blocker.md"), []byte("---\ntype: Contradiction\nresolution_status: open\ninvolves: [change]\n---\nblocked\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			k, _, head := serverGitFinalizeFixture(t)
+			before, _ := gitx.HeadSHAAt(k.Root, "origin/cartographer/kb")
+			f := readyForge(head, true)
+			k.ServerGit.Forge = f
+			finalState(t, k, 9, head)
+			tc.prepare(t, k)
+			if err := k.FinalizeServerPR(context.Background(), head); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %q failure, got %v", tc.want, err)
+			}
+			after, _ := gitx.HeadSHAAt(k.Root, "origin/cartographer/kb")
+			if after != before {
+				t.Fatalf("working remote changed on %s failure: %s -> %s", tc.name, before, after)
+			}
+		})
+	}
+}
+
+func TestFinalizeServerPRLeaseFailureDoesNotCallForgeMerge(t *testing.T) {
+	k, bare, head := serverGitFinalizeFixture(t)
+	mergeCalls := 0
+	f := readyForge(head, true)
+	f.merge = func() (MergeResult, error) { mergeCalls++; return MergeResult{}, nil }
+	k.ServerGit.Forge = f
+	finalState(t, k, 9, head)
+	// The injected lint runs after fetch/head verification and replaces the
+	// remote working ref, exercising the actual force-with-lease failure.
+	k.ServerMergeLint = func() error {
+		other := filepath.Join(t.TempDir(), "other")
+		serverGitRun(t, filepath.Dir(other), "clone", bare, other)
+		serverGitRun(t, other, "checkout", "cartographer/kb")
+		if err := os.WriteFile(filepath.Join(other, "lease.txt"), []byte("race\n"), 0o644); err != nil {
+			return err
+		}
+		serverGitRun(t, other, "add", "lease.txt")
+		serverGitRun(t, other, "-c", "user.name=test", "-c", "user.email=test@example.test", "commit", "-m", "lease race")
+		serverGitRun(t, other, "push", "origin", "cartographer/kb")
+		serverGitRun(t, bare, "update-server-info")
+		return nil
+	}
+	if err := k.FinalizeServerPR(context.Background(), head); err == nil || !strings.Contains(err.Error(), "force-with-lease") {
+		t.Fatalf("lease failure = %v", err)
+	}
+	if mergeCalls != 0 {
+		t.Fatalf("MergeSquash called after lease failure: %d", mergeCalls)
+	}
+}
+
+func TestFinalizeServerPRRejectsRemoteHeadRaceBeforeRebase(t *testing.T) {
+	k, bare, head := serverGitFinalizeFixture(t)
+	f := readyForge(head, true)
+	f.ready = func() (bool, error) {
+		other := filepath.Join(t.TempDir(), "other")
+		serverGitRun(t, filepath.Dir(other), "clone", bare, other)
+		serverGitRun(t, other, "checkout", "cartographer/kb")
+		if err := os.WriteFile(filepath.Join(other, "head-race.txt"), []byte("race\n"), 0o644); err != nil {
+			return false, err
+		}
+		serverGitRun(t, other, "add", "head-race.txt")
+		serverGitRun(t, other, "-c", "user.name=test", "-c", "user.email=test@example.test", "commit", "-m", "head race")
+		serverGitRun(t, other, "push", "origin", "cartographer/kb")
+		serverGitRun(t, bare, "update-server-info")
+		return true, nil
+	}
+	k.ServerGit.Forge = f
+	finalState(t, k, 9, head)
+	if err := k.FinalizeServerPR(context.Background(), head); err == nil || !strings.Contains(err.Error(), "stale PR head after fetch") {
+		t.Fatalf("remote head race = %v", err)
+	}
+}
+
+func TestFinalizeServerPRRejectsBaseRaceBeforeMerge(t *testing.T) {
+	k, bare, head := serverGitFinalizeFixture(t)
+	base, err := gitx.HeadSHAAt(k.Root, "origin/main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var gets, mergeCalls int
+	advancedBase := ""
+	f := readyForge(head, true)
+	f.get = func() (PullRequest, error) {
+		gets++
+		currentBase := base
+		if gets > 1 {
+			currentBase = advancedBase
+		}
+		return PullRequest{Number: 9, State: "open", HeadSHA: head, BaseSHA: currentBase}, nil
+	}
+	f.merge = func() (MergeResult, error) { mergeCalls++; return MergeResult{}, nil }
+	k.ServerGit.Forge = f
+	finalState(t, k, 9, head)
+	k.ServerMergeLint = func() error {
+		other := filepath.Join(t.TempDir(), "other")
+		serverGitRun(t, filepath.Dir(other), "clone", bare, other)
+		if err := os.WriteFile(filepath.Join(other, "data", "base-race.md"), []byte("---\ntype: Note\n---\nrace\n"), 0o644); err != nil {
+			return err
+		}
+		serverGitRun(t, other, "add", "data/base-race.md")
+		serverGitRun(t, other, "-c", "user.name=test", "-c", "user.email=test@example.test", "commit", "-m", "base race")
+		serverGitRun(t, other, "push", "origin", "main")
+		serverGitRun(t, bare, "update-server-info")
+		var err error
+		advancedBase, err = gitx.HeadSHA(k.Root) // overwritten below from the other clone ref
+		if err != nil {
+			return err
+		}
+		advancedBase, err = gitx.HeadSHAAt(other, "HEAD")
+		return err
+	}
+	if err := k.FinalizeServerPR(context.Background(), head); err == nil || !strings.Contains(err.Error(), "stale PR base before merge") {
+		t.Fatalf("base race error = %v", err)
+	}
+	if mergeCalls != 0 {
+		t.Fatalf("MergeSquash called after base race: %d", mergeCalls)
+	}
+}
+
+func TestMergeUncertainRestartReconcilesOnlyConfirmedMerge(t *testing.T) {
+	k, bare, head := serverGitFinalizeFixture(t)
+	merged := false
+	f := readyForge(head, true)
+	f.get = func() (PullRequest, error) {
+		if merged {
+			return PullRequest{Number: 9, State: "closed", Merged: true, MergeSHA: head}, nil
+		}
+		return PullRequest{Number: 9, State: "open", HeadSHA: head}, nil
+	}
+	f.merge = func() (MergeResult, error) {
+		serverGitRun(t, k.Root, "push", bare, "HEAD:main") // fake forge did merge
+		serverGitRun(t, bare, "update-server-info")
+		merged = true
+		return MergeResult{}, errors.New("timeout after merge")
+	}
+	k.ServerGit.Forge = f
+	finalState(t, k, 9, head)
+	if err := k.FinalizeServerPR(context.Background(), head); err == nil {
+		t.Fatal("expected uncertain result after fake timeout")
+	}
+	if k.ServerGitStatus().Phase != "merge_uncertain" {
+		t.Fatalf("state = %#v", k.ServerGitStatus())
+	}
+	// New object simulates restart; recovery consumes only persisted non-secret
+	// data and the forge-confirmed base result.
+	restarted, err := Open(k.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restarted.GitEnv = append(restarted.GitEnv, "GIT_SSL_NO_VERIFY=true")
+	restarted.ServerGit = &ServerGitConfig{BaseBranch: "main", WorkingBranch: "cartographer/kb", Owner: "example", Repository: "wiki", Forge: f}
+	if err := restarted.ReconcileServerPR(); err != nil {
+		t.Fatal(err)
+	}
+	if state := restarted.ServerGitStatus(); state.Phase != "" || state.PRNumber != 0 {
+		t.Fatalf("recovery did not start new cycle: %#v", state)
+	}
+}
+
+func TestMergeUncertainOpenUnmergedAndUnknownRemainBlocked(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		pr   PullRequest
+		err  error
+	}{
+		{"open", PullRequest{Number: 9, State: "open"}, nil},
+		{"unmerged", PullRequest{Number: 9, State: "closed"}, nil},
+		{"unknown", PullRequest{}, errors.New("forge unavailable")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			k := &KB{Root: t.TempDir()}
+			f := &scriptedForge{
+				find: func() ([]PullRequest, error) { return nil, fmt.Errorf("unused") }, create: func() (PullRequest, error) { return PullRequest{}, fmt.Errorf("unused") },
+				get: func() (PullRequest, error) { return tc.pr, tc.err }, ready: func() (bool, error) { return false, nil }, merge: func() (MergeResult, error) { return MergeResult{}, nil },
+			}
+			k.ServerGit = &ServerGitConfig{BaseBranch: "main", WorkingBranch: "work", Owner: "a", Repository: "b", Forge: f}
+			if err := k.saveServerGitState(ServerGitState{Profile: "server", BaseBranch: "main", WorkingBranch: "work", PRNumber: 9, Phase: "merge_uncertain"}); err != nil {
+				t.Fatal(err)
+			}
+			if err := k.ReconcileServerPR(); err == nil {
+				t.Fatal("expected reconciliation to remain blocked")
+			}
+			if err := k.ServerWritesBlocked(); err == nil {
+				t.Fatal("writes became unblocked")
+			}
+		})
+	}
+}
+
+func registerResolvedServerConflict(t *testing.T, k *KB) {
+	t.Helper()
+	head, err := gitx.HeadSHA(k.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(filepath.Join(k.Root, "data", "change.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := k.RegisterConflict(Conflict{ConceptID: "change", Path: "data/change.md", LocalSHA: head, RemoteSHA: head, Branch: "main", BaseBranch: "main", WorkingBranch: "cartographer/kb", ResolutionStrategy: "edit", ResolutionBody: string(content)}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFinalizeServerConflictsKeepsRegistryOnRebasePushAndForgeFailure(t *testing.T) {
+	t.Run("rebase", func(t *testing.T) {
+		k, bare, _ := serverGitFinalizeFixture(t)
+		registerResolvedServerConflict(t, k)
+		other := filepath.Join(t.TempDir(), "other")
+		serverGitRun(t, filepath.Dir(other), "clone", bare, other)
+		if err := os.WriteFile(filepath.Join(other, "data", "change.md"), []byte("---\ntype: Note\n---\nbase race\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		serverGitRun(t, other, "add", "data/change.md")
+		serverGitRun(t, other, "-c", "user.name=test", "-c", "user.email=test@example.test", "commit", "-m", "base race")
+		serverGitRun(t, other, "push", "origin", "main")
+		serverGitRun(t, bare, "update-server-info")
+		if _, err := k.finalizeServerConflicts(); err == nil {
+			t.Fatal("expected rebase failure")
+		}
+		if cs, _ := k.ListConflicts(); len(cs) == 0 {
+			t.Fatal("registry cleared after rebase failure")
+		}
+	})
+	t.Run("push", func(t *testing.T) {
+		k, _, _ := serverGitFinalizeFixture(t)
+		registerResolvedServerConflict(t, k)
+		k.GitSync = true
+		serverGitRun(t, k.Root, "remote", "set-url", "--push", "origin", filepath.Join(t.TempDir(), "missing.git"))
+		if _, err := k.finalizeServerConflicts(); err == nil {
+			t.Fatal("expected push failure")
+		}
+		if cs, _ := k.ListConflicts(); len(cs) == 0 {
+			t.Fatal("registry cleared after push failure")
+		}
+	})
+	t.Run("forge", func(t *testing.T) {
+		k, _, _ := serverGitFinalizeFixture(t)
+		registerResolvedServerConflict(t, k)
+		k.GitSync = true
+		boom := errors.New("forge down")
+		k.ServerGit.Forge = &scriptedForge{
+			find: func() ([]PullRequest, error) { return nil, boom }, create: func() (PullRequest, error) { return PullRequest{}, boom },
+			get: func() (PullRequest, error) { return PullRequest{}, boom }, ready: func() (bool, error) { return false, boom }, merge: func() (MergeResult, error) { return MergeResult{}, boom },
+		}
+		if _, err := k.finalizeServerConflicts(); err == nil {
+			t.Fatal("expected forge failure")
+		}
+		if cs, _ := k.ListConflicts(); len(cs) == 0 {
+			t.Fatal("registry cleared after forge failure")
+		}
+	})
+}
+
+func TestFinalizeServerConflictsResolvesSyntheticUnrelatedPathID(t *testing.T) {
+	k, _, _ := serverGitFinalizeFixture(t)
+	head, err := gitx.HeadSHA(k.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const id = "git-path:README.md"
+	if err := k.RegisterConflict(Conflict{ConceptID: id, Path: "README.md", LocalSHA: head, RemoteSHA: head, Branch: "main", BaseBranch: "main", WorkingBranch: "cartographer/kb"}); err != nil {
+		t.Fatal(err)
+	}
+	// This is the same agent-facing API used for a concept conflict: the
+	// synthetic ID makes unrelated paths explicit rather than silently skipped.
+	if err := k.RecordResolution(id, "edit", "resolved by operator\n"); err != nil {
+		t.Fatal(err)
+	}
+	ids, err := k.finalizeServerConflicts()
+	if err != nil || len(ids) != 1 || ids[0] != id {
+		t.Fatalf("finalize ids=%#v err=%v", ids, err)
+	}
+	if data, err := os.ReadFile(filepath.Join(k.Root, "README.md")); err != nil || string(data) != "resolved by operator\n" {
+		t.Fatalf("resolved unrelated path = %q, %v", data, err)
+	}
+	if cs, err := k.ListConflicts(); err != nil || len(cs) != 0 {
+		t.Fatalf("registry = %#v, %v", cs, err)
+	}
+}

--- a/internal/kb/servergit_integration_test.go
+++ b/internal/kb/servergit_integration_test.go
@@ -25,7 +25,7 @@ func newServerGitMount(t *testing.T) (*KB, string) {
 	if err := os.MkdirAll(filepath.Dir(bare), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	serverGitRun(t, filepath.Dir(bare), "init", "--bare", bare)
+	serverGitInitBare(t, bare)
 	serverGitRemote(t, k, bare)
 	return k, bare
 }

--- a/internal/kb/servergit_integration_test.go
+++ b/internal/kb/servergit_integration_test.go
@@ -1,0 +1,356 @@
+package kb
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/BeppeTemp/cartographer/internal/gitx"
+	"github.com/BeppeTemp/cartographer/internal/okf"
+)
+
+// newServerGitMount is deliberately HTTPS-backed (served from httptest by the
+// shared helper) while all Git objects remain local temp fixtures.
+func newServerGitMount(t *testing.T) (*KB, string) {
+	t.Helper()
+	root := t.TempDir()
+	k, err := Init(filepath.Join(root, "kb"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bare := filepath.Join(root, "remote", "example", "wiki.git")
+	if err := os.MkdirAll(filepath.Dir(bare), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	serverGitRun(t, filepath.Dir(bare), "init", "--bare", bare)
+	serverGitRemote(t, k, bare)
+	return k, bare
+}
+
+func TestServerGitTwoCloneBaseAdvanceAndConflictRegistry(t *testing.T) {
+	t.Run("clean base advance never updates protected base", func(t *testing.T) {
+		k, bare := newServerGitMount(t)
+		if err := k.ConfigureServerGit(serverConfig()); err != nil {
+			t.Fatal(err)
+		}
+		other := filepath.Join(t.TempDir(), "other")
+		serverGitRun(t, filepath.Dir(other), "clone", bare, other)
+		if err := os.WriteFile(filepath.Join(other, "data", "from-base.md"), []byte("---\ntype: Note\n---\nbase\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		serverGitRun(t, other, "add", "data/from-base.md")
+		serverGitRun(t, other, "-c", "user.name=test", "-c", "user.email=test@example.test", "commit", "-m", "base advance")
+		serverGitRun(t, other, "push", "origin", "main")
+		serverGitRun(t, bare, "update-server-info")
+		baseBefore, _ := gitx.HeadSHAAt(k.Root, "origin/main")
+		k.GitSync = true
+		if _, err := k.SyncIn(); err != nil {
+			t.Fatal(err)
+		}
+		baseAfter, _ := gitx.HeadSHAAt(k.Root, "origin/main")
+		if baseBefore == baseAfter {
+			t.Fatal("fixture did not fetch advanced base")
+		}
+		if changed, _ := gitx.HeadSHAAt(k.Root, "origin/main"); changed != baseAfter {
+			t.Fatal("protected base ref was changed locally")
+		}
+	})
+
+	t.Run("concept and unrelated conflicts remain fail closed", func(t *testing.T) {
+		k, bare := newServerGitMount(t)
+		// Seed a real concept before creating the server working branch.
+		if err := os.WriteFile(filepath.Join(k.Root, "data", "shared.md"), []byte("---\ntype: Note\n---\nbase\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(k.Root, "README.md"), []byte("base\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		serverGitRun(t, k.Root, "add", "data/shared.md", "README.md")
+		serverGitRun(t, k.Root, "commit", "-m", "seed")
+		serverGitRun(t, k.Root, "push", "origin", "main")
+		serverGitRun(t, bare, "update-server-info")
+		if err := k.ConfigureServerGit(serverConfig()); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(k.Root, "data", "shared.md"), []byte("---\ntype: Note\n---\nworking\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		serverGitRun(t, k.Root, "add", "data/shared.md")
+		if err := os.WriteFile(filepath.Join(k.Root, "README.md"), []byte("working\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		serverGitRun(t, k.Root, "add", "README.md")
+		serverGitRun(t, k.Root, "commit", "-m", "working edit")
+		other := filepath.Join(t.TempDir(), "other")
+		serverGitRun(t, filepath.Dir(other), "clone", bare, other)
+		if err := os.WriteFile(filepath.Join(other, "data", "shared.md"), []byte("---\ntype: Note\n---\nbase edit\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(other, "README.md"), []byte("base edit\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		serverGitRun(t, other, "add", "data/shared.md", "README.md")
+		serverGitRun(t, other, "-c", "user.name=test", "-c", "user.email=test@example.test", "commit", "-m", "base conflict")
+		serverGitRun(t, other, "push", "origin", "main")
+		serverGitRun(t, bare, "update-server-info")
+		k.GitSync = true
+		if _, err := k.SyncIn(); err == nil {
+			t.Fatal("expected rebase conflict")
+		}
+		conflicts, err := k.ListConflicts()
+		if err != nil || len(conflicts) != 2 {
+			t.Fatalf("concept conflict registry = %#v, %v", conflicts, err)
+		}
+		ids := map[string]bool{}
+		for _, c := range conflicts {
+			ids[c.ConceptID] = true
+		}
+		if !ids["shared"] || !ids["git-path:README.md"] {
+			t.Fatalf("missing fail-closed conflict entries: %#v", conflicts)
+		}
+		// The state is local-only and survives a fresh KB object.
+		restarted, err := Open(k.Root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		conflicts, err = restarted.ListConflicts()
+		if err != nil || len(conflicts) != 2 {
+			t.Fatalf("restart registry = %#v, %v", conflicts, err)
+		}
+	})
+}
+
+func TestServerConflictResolutionStrategiesMaterializeExpectedContent(t *testing.T) {
+	root := t.TempDir()
+	k, err := Init(filepath.Join(root, "kb"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(k.Root, "data", "choice.md")
+	if err := os.WriteFile(path, []byte("ours\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	serverGitRun(t, k.Root, "add", "data/choice.md")
+	serverGitRun(t, k.Root, "commit", "-m", "ours")
+	ours, _ := gitx.HeadSHA(k.Root)
+	if err := os.WriteFile(path, []byte("theirs\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	serverGitRun(t, k.Root, "add", "data/choice.md")
+	serverGitRun(t, k.Root, "commit", "-m", "theirs")
+	theirs, _ := gitx.HeadSHA(k.Root)
+	for _, tc := range []struct{ strategy, body, want string }{
+		{"ours", "", "ours\n"}, {"theirs", "", "theirs\n"}, {"edit", "edited\n", "edited\n"},
+	} {
+		t.Run(tc.strategy, func(t *testing.T) {
+			got, err := k.resolvedContent(Conflict{ConceptID: "choice", Path: "data/choice.md", LocalSHA: ours, RemoteSHA: theirs, ResolutionStrategy: tc.strategy, ResolutionBody: tc.body})
+			if err != nil || got != tc.want {
+				t.Fatalf("resolvedContent = %q, %v; want %q", got, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestServerGitConcurrentWritersAreSerialized(t *testing.T) {
+	k, _ := newServerGitMount(t)
+	var mu sync.Mutex
+	active, maxActive := 0, 0
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := k.WithGitLock(func() error {
+				mu.Lock()
+				active++
+				if active > maxActive {
+					maxActive = active
+				}
+				mu.Unlock()
+				time.Sleep(time.Millisecond)
+				mu.Lock()
+				active--
+				mu.Unlock()
+				return nil
+			}); err != nil {
+				t.Errorf("WithGitLock: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	if maxActive != 1 {
+		t.Fatalf("concurrent server writers entered git section: %d", maxActive)
+	}
+}
+
+func TestServerGitIfMatchTracksRebasedAndExternallyUpdatedWorkingContent(t *testing.T) {
+	k, bare := newServerGitMount(t)
+	seed := "---\ntype: Note\ntitle: Item\n---\nseed\n"
+	if err := os.WriteFile(filepath.Join(k.Root, "data", "item.md"), []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	serverGitRun(t, k.Root, "add", "data/item.md")
+	serverGitRun(t, k.Root, "commit", "-m", "seed item")
+	serverGitRun(t, k.Root, "push", "origin", "main")
+	serverGitRun(t, bare, "update-server-info")
+	if err := k.ConfigureServerGit(serverConfig()); err != nil {
+		t.Fatal(err)
+	}
+	k.GitSync, k.AutoCommit = true, true
+
+	// A base advance is incorporated before a normal write. The hash read after
+	// that rebase is accepted by the real WriteConcept/CommitOp path.
+	baseClone := filepath.Join(t.TempDir(), "base")
+	serverGitRun(t, filepath.Dir(baseClone), "clone", bare, baseClone)
+	if err := os.WriteFile(filepath.Join(baseClone, "data", "base.md"), []byte("---\ntype: Note\n---\nbase\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	serverGitRun(t, baseClone, "add", "data/base.md")
+	serverGitRun(t, baseClone, "-c", "user.name=test", "-c", "user.email=test@example.test", "commit", "-m", "base advance")
+	serverGitRun(t, baseClone, "push", "origin", "main")
+	serverGitRun(t, bare, "update-server-info")
+	if _, err := k.SyncIn(); err != nil {
+		t.Fatal(err)
+	}
+	item, err := k.ReadConcept("item")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fm, err := okf.ParseFrontmatter(item.FrontmatterRaw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := k.WriteConcept("item", fm, "after base rebase\n", item.ContentHash); err != nil {
+		t.Fatalf("post-rebase if_match write: %v", err)
+	}
+	if err := k.CommitOp("post rebase update"); err != nil {
+		t.Fatal(err)
+	}
+	if err := k.SyncOut(); err != nil {
+		t.Fatal(err)
+	}
+	postBase, err := k.ReadConcept("item")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A second writer updates the dedicated working branch. SyncOut takes its
+	// real non-fast-forward rebase path; the prior hash is then stale.
+	workClone := filepath.Join(t.TempDir(), "work")
+	serverGitRun(t, filepath.Dir(workClone), "clone", bare, workClone)
+	serverGitRun(t, workClone, "checkout", "cartographer/kb")
+	if err := os.WriteFile(filepath.Join(workClone, "data", "item.md"), []byte("---\ntype: Note\ntitle: Item\n---\nexternal working update\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	serverGitRun(t, workClone, "add", "data/item.md")
+	serverGitRun(t, workClone, "-c", "user.name=test", "-c", "user.email=test@example.test", "commit", "-m", "external work")
+	serverGitRun(t, workClone, "push", "origin", "cartographer/kb")
+	serverGitRun(t, bare, "update-server-info")
+	if err := os.WriteFile(filepath.Join(k.Root, "data", "local.md"), []byte("---\ntype: Note\n---\nlocal\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := k.CommitOp("local concurrent write"); err != nil {
+		t.Fatal(err)
+	}
+	if err := k.SyncOut(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := k.WriteConcept("item", fm, "must reject\n", postBase.ContentHash); err == nil || !strings.Contains(err.Error(), "stale write") {
+		t.Fatalf("old if_match after remote working update = %v", err)
+	}
+}
+
+func serverConfig() ServerGitConfig {
+	return ServerGitConfig{BaseBranch: "main", WorkingBranch: "cartographer/kb", Owner: "example", Repository: "wiki", Forge: fakeForge{}}
+}
+
+func TestConfigureServerGitStartupFailures(t *testing.T) {
+	t.Run("origin missing", func(t *testing.T) {
+		k, err := Init(filepath.Join(t.TempDir(), "kb"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := k.ConfigureServerGit(serverConfig()); err == nil || !strings.Contains(err.Error(), "origin") {
+			t.Fatalf("ConfigureServerGit error = %v", err)
+		}
+	})
+	t.Run("detached", func(t *testing.T) {
+		k, _ := newServerGitMount(t)
+		serverGitRun(t, k.Root, "checkout", "--detach")
+		if err := k.ConfigureServerGit(serverConfig()); err == nil || !strings.Contains(err.Error(), "detached") {
+			t.Fatalf("ConfigureServerGit error = %v", err)
+		}
+	})
+	t.Run("base missing", func(t *testing.T) {
+		k, _ := newServerGitMount(t)
+		cfg := serverConfig()
+		cfg.BaseBranch = "absent"
+		if err := k.ConfigureServerGit(cfg); err == nil || !strings.Contains(err.Error(), "base branch") {
+			t.Fatalf("ConfigureServerGit error = %v", err)
+		}
+	})
+	t.Run("same branch", func(t *testing.T) {
+		k, _ := newServerGitMount(t)
+		cfg := serverConfig()
+		cfg.WorkingBranch = cfg.BaseBranch
+		if err := k.ConfigureServerGit(cfg); err == nil || !strings.Contains(err.Error(), "must differ") {
+			t.Fatalf("ConfigureServerGit error = %v", err)
+		}
+	})
+	t.Run("local only working branch", func(t *testing.T) {
+		k, _ := newServerGitMount(t)
+		serverGitRun(t, k.Root, "checkout", "-b", "cartographer/kb")
+		serverGitRun(t, k.Root, "checkout", "main")
+		if err := k.ConfigureServerGit(serverConfig()); err == nil || !strings.Contains(err.Error(), "no remote counterpart") {
+			t.Fatalf("ConfigureServerGit error = %v", err)
+		}
+	})
+}
+
+func TestConfigureServerGitRemoteResumeAndRejectsNonDescendant(t *testing.T) {
+	k, bare := newServerGitMount(t)
+	if err := k.ConfigureServerGit(serverConfig()); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(k.Root, "data", "resume.md"), []byte("---\ntype: Note\n---\nresume\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	serverGitRun(t, k.Root, "add", "data/resume.md")
+	serverGitRun(t, k.Root, "commit", "-m", "resume")
+	serverGitRun(t, k.Root, "push", "origin", "cartographer/kb")
+	serverGitRun(t, bare, "update-server-info")
+	// A restart must mount the existing remote working branch, not create a
+	// second local branch or reset the published work.
+	restarted, err := Open(k.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restarted.GitEnv = append(restarted.GitEnv, "GIT_SSL_NO_VERIFY=true")
+	if err := restarted.ConfigureServerGit(serverConfig()); err != nil {
+		t.Fatalf("resume ConfigureServerGit: %v", err)
+	}
+	if branch, _ := gitx.Branch(restarted.Root); branch != "cartographer/kb" {
+		t.Fatalf("branch = %q", branch)
+	}
+
+	// Replace only the remote working ref with unrelated history. Configure
+	// must refuse rather than resetting/merging it into the protected base.
+	other := filepath.Join(t.TempDir(), "other")
+	serverGitRun(t, filepath.Dir(other), "clone", bare, other)
+	serverGitRun(t, other, "checkout", "--orphan", "cartographer/kb")
+	serverGitRun(t, other, "rm", "-rf", ".")
+	if err := os.WriteFile(filepath.Join(other, "unrelated.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	serverGitRun(t, other, "add", "unrelated.txt")
+	serverGitRun(t, other, "-c", "user.name=test", "-c", "user.email=test@example.test", "commit", "-m", "unrelated")
+	serverGitRun(t, other, "push", "--force", "origin", "cartographer/kb")
+	serverGitRun(t, bare, "update-server-info")
+	serverGitRun(t, restarted.Root, "checkout", "main")
+	if err := restarted.ConfigureServerGit(serverConfig()); err == nil || !strings.Contains(err.Error(), "does not descend") {
+		t.Fatalf("non-descendant working branch accepted: %v", err)
+	}
+}

--- a/internal/kb/servergit_test.go
+++ b/internal/kb/servergit_test.go
@@ -1,0 +1,362 @@
+package kb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BeppeTemp/cartographer/internal/gitx"
+)
+
+type fakeForge struct{}
+
+func (fakeForge) FindOpenPR(context.Context, string, string, string, string) ([]PullRequest, error) {
+	return nil, nil
+}
+
+type scriptedForge struct {
+	find   func() ([]PullRequest, error)
+	create func() (PullRequest, error)
+	get    func() (PullRequest, error)
+	ready  func() (bool, error)
+	merge  func() (MergeResult, error)
+}
+
+func (f scriptedForge) FindOpenPR(context.Context, string, string, string, string) ([]PullRequest, error) {
+	return f.find()
+}
+func (f scriptedForge) CreatePR(context.Context, string, string, string, string, string, string) (PullRequest, error) {
+	return f.create()
+}
+func (f scriptedForge) GetPR(context.Context, string, string, int) (PullRequest, error) {
+	return f.get()
+}
+func (f scriptedForge) PRReady(context.Context, string, string, int) (bool, error) { return f.ready() }
+func (f scriptedForge) MergeSquash(context.Context, string, string, int, string) (MergeResult, error) {
+	return f.merge()
+}
+func (fakeForge) CreatePR(context.Context, string, string, string, string, string, string) (PullRequest, error) {
+	return PullRequest{Number: 1, URL: "http://forge/pr/1", State: "open"}, nil
+}
+func (fakeForge) GetPR(context.Context, string, string, int) (PullRequest, error) {
+	return PullRequest{Number: 1, State: "open"}, nil
+}
+func (fakeForge) PRReady(context.Context, string, string, int) (bool, error) { return true, nil }
+func (fakeForge) MergeSquash(context.Context, string, string, int, string) (MergeResult, error) {
+	return MergeResult{Merged: true, SHA: "merged"}, nil
+}
+
+func serverGitRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+}
+
+func branchForTest(dir string) (string, error) {
+	out, err := exec.Command("git", "-C", dir, "branch", "--show-current").Output()
+	return strings.TrimSpace(string(out)), err
+}
+
+// serverGitRemote makes transport identity look like GitHub while keeping all
+// fixture traffic local. fetchurl is deliberately separate from the push URL.
+func serverGitRemote(t *testing.T, k *KB, bare string) {
+	t.Helper()
+	serverGitRun(t, k.Root, "branch", "-M", "main")
+	serverGitRun(t, k.Root, "push", bare, "main:main")
+	serverGitRun(t, bare, "update-server-info")
+	// Dumb HTTPS serves a real local Git repository under the exact owner/repo
+	// path. This exercises the production HTTPS identity check without network.
+	server := httptest.NewTLSServer(http.FileServer(http.Dir(filepath.Dir(filepath.Dir(bare)))))
+	t.Cleanup(server.Close)
+	serverGitRun(t, k.Root, "remote", "add", "origin", server.URL+"/example/wiki.git")
+	serverGitRun(t, k.Root, "remote", "set-url", "--push", "origin", bare)
+	k.GitEnv = append(k.GitEnv, "GIT_SSL_NO_VERIFY=true")
+}
+
+func TestConfigureServerGitCreatesDedicatedBranch(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not in PATH")
+	}
+	root := t.TempDir()
+	k, err := Init(filepath.Join(root, "kb"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bare := filepath.Join(root, "remote", "example", "wiki.git")
+	if err := os.MkdirAll(filepath.Dir(bare), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	serverGitRun(t, filepath.Dir(bare), "init", "--bare", bare)
+	serverGitRemote(t, k, bare)
+	if err := k.ConfigureServerGit(ServerGitConfig{BaseBranch: "main", WorkingBranch: "cartographer/kb", Owner: "example", Repository: "wiki", Forge: fakeForge{}}); err != nil {
+		t.Fatalf("ConfigureServerGit: %v", err)
+	}
+	if branch, _ := branchForTest(k.Root); branch != "cartographer/kb" {
+		t.Fatalf("branch = %q, want cartographer/kb", branch)
+	}
+	state := k.ServerGitStatus()
+	if state.Profile != "server" || state.BaseBranch != "main" || state.WorkingBranch != "cartographer/kb" {
+		t.Fatalf("state = %#v", state)
+	}
+}
+
+func TestConfigureServerGitRefusesDirtyState(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not in PATH")
+	}
+	root := t.TempDir()
+	k, err := Init(filepath.Join(root, "kb"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bare := filepath.Join(root, "remote", "example", "wiki.git")
+	if err := os.MkdirAll(filepath.Dir(bare), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	serverGitRun(t, filepath.Dir(bare), "init", "--bare", bare)
+	serverGitRemote(t, k, bare)
+	if err := k.WriteFileAtomic("data/dirty.md", []byte("dirty")); err != nil {
+		t.Fatal(err)
+	}
+	if err := k.ConfigureServerGit(ServerGitConfig{BaseBranch: "main", WorkingBranch: "cartographer/kb", Owner: "example", Repository: "wiki", Forge: fakeForge{}}); err == nil {
+		t.Fatal("expected dirty startup refusal")
+	}
+}
+
+func TestGitHubRemoteMatches(t *testing.T) {
+	for _, tc := range []struct {
+		name, remote string
+		want         bool
+	}{
+		{"https", "https://github.com/acme/wiki.git", true},
+		{"https slash", "https://github.com/acme/wiki/", true},
+		{"https credentials", "https://token@github.com/acme/wiki.git", true},
+		{"ssh scp", "git@github.com:acme/wiki.git", true},
+		{"ssh url", "ssh://git@github.com/acme/wiki.git", true},
+		{"mismatch", "https://github.com/acme/other.git", false},
+		{"not github transport", "file:///tmp/acme/wiki.git", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := githubRemoteMatches(tc.remote, "acme", "wiki"); got != tc.want {
+				t.Fatalf("githubRemoteMatches(%q) = %v, want %v", tc.remote, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestServerPRLifecyclePersistsOnlyNonSecretState(t *testing.T) {
+	root := t.TempDir()
+	created := 0
+	f := &scriptedForge{
+		find: func() ([]PullRequest, error) { return nil, nil },
+		create: func() (PullRequest, error) {
+			created++
+			return PullRequest{Number: 12, URL: "https://forge/pr/12", HeadSHA: "head", State: "open"}, nil
+		},
+		get:   func() (PullRequest, error) { return PullRequest{}, errors.New("unused") },
+		ready: func() (bool, error) { return false, errors.New("unused") },
+		merge: func() (MergeResult, error) { return MergeResult{}, errors.New("unused") },
+	}
+	k := &KB{Root: root, ServerGit: &ServerGitConfig{BaseBranch: "main", WorkingBranch: "cartographer/kb", Owner: "acme", Repository: "wiki", Forge: f}}
+	if err := k.ReconcileServerPR(); err != nil {
+		t.Fatal(err)
+	}
+	if created != 1 {
+		t.Fatalf("CreatePR calls = %d, want 1", created)
+	}
+	state := k.ServerGitStatus()
+	if state.PRNumber != 12 || state.PRHeadSHA != "head" || state.Phase != "open" {
+		t.Fatalf("state = %#v", state)
+	}
+	data, err := os.ReadFile(k.serverGitStatePath())
+	if err != nil || strings.Contains(string(data), "secret") {
+		t.Fatalf("persisted state leaks secret or unreadable: %q, %v", data, err)
+	}
+	// A restart reloads the persisted PR and an existing open PR is reused.
+	f.find = func() ([]PullRequest, error) {
+		return []PullRequest{{Number: 12, URL: "https://forge/pr/12", HeadSHA: "next", State: "open"}}, nil
+	}
+	if err := k.ReconcileServerPR(); err != nil {
+		t.Fatal(err)
+	}
+	if created != 1 || k.ServerGitStatus().PRHeadSHA != "next" {
+		t.Fatalf("existing PR was not reused: created=%d state=%#v", created, k.ServerGitStatus())
+	}
+}
+
+func TestServerPRLifecycleFailsClosedAndRetriesOnStatus(t *testing.T) {
+	root := t.TempDir()
+	boom := errors.New("forge unavailable")
+	f := &scriptedForge{
+		find:   func() ([]PullRequest, error) { return nil, boom },
+		create: func() (PullRequest, error) { return PullRequest{}, boom },
+		get:    func() (PullRequest, error) { return PullRequest{}, boom },
+		ready:  func() (bool, error) { return false, boom },
+		merge:  func() (MergeResult, error) { return MergeResult{}, boom },
+	}
+	k := &KB{Root: root, ServerGit: &ServerGitConfig{BaseBranch: "main", WorkingBranch: "work", Owner: "a", Repository: "b", Forge: f}}
+	if err := k.ReconcileServerPR(); !errors.Is(err, boom) || k.ServerGitStatus().LastForgeError == "" {
+		t.Fatalf("forge failure was not persisted: %v / %#v", err, k.ServerGitStatus())
+	}
+	f.find = func() ([]PullRequest, error) { return []PullRequest{{Number: 1, HeadSHA: "h", State: "open"}}, nil }
+	if err := k.ReconcileServerPR(); err != nil || k.ServerGitStatus().LastForgeError != "" {
+		t.Fatalf("status retry did not recover: %v / %#v", err, k.ServerGitStatus())
+	}
+	f.find = func() ([]PullRequest, error) { return []PullRequest{{Number: 1}, {Number: 2}}, nil }
+	if err := k.ReconcileServerPR(); err == nil {
+		t.Fatal("expected exact one-open-PR invariant failure")
+	}
+}
+
+func TestServerWritesBlockedDuringMergeUncertainty(t *testing.T) {
+	k := &KB{Root: t.TempDir(), ServerGit: &ServerGitConfig{BaseBranch: "main", WorkingBranch: "work", Owner: "a", Repository: "b", Forge: fakeForge{}}}
+	if err := k.saveServerGitState(ServerGitState{Profile: "server", Phase: "merge_uncertain", PRNumber: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := k.ServerWritesBlocked(); err == nil {
+		t.Fatal("expected merge_uncertain to block writes")
+	}
+	if _, err := k.SyncIn(); err == nil {
+		t.Fatal("SyncIn must block writes before touching refs during uncertainty")
+	}
+}
+
+func TestMergeUncertaintyBlocksPendingServerPush(t *testing.T) {
+	k, _, _ := serverGitFinalizeFixture(t)
+	k.GitSync = true
+	if err := k.saveServerGitState(ServerGitState{Profile: "server", BaseBranch: "main", WorkingBranch: "cartographer/kb", Phase: "merge_uncertain", PRNumber: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := k.SyncOut(); err == nil {
+		t.Fatal("pending server push must be blocked during merge uncertainty")
+	}
+}
+
+func TestRecordServerRebaseConflictRetainsNonConceptPaths(t *testing.T) {
+	k := &KB{Root: t.TempDir(), ServerGit: &ServerGitConfig{BaseBranch: "main", WorkingBranch: "work", Owner: "a", Repository: "b", Forge: fakeForge{}}}
+	k.RecordServerRebaseConflict(&gitx.RebaseConflictError{Files: []string{"README.md", "data/note.md"}, LocalSHA: "local", RemoteSHA: "remote", Remote: "origin", Branch: "main"})
+	conflicts, err := k.ListConflicts()
+	if err != nil || len(conflicts) != 2 {
+		t.Fatalf("conflicts = %#v, %v", conflicts, err)
+	}
+	seen := map[string]bool{}
+	for _, c := range conflicts {
+		seen[c.ConceptID] = true
+	}
+	if !seen["git-path:README.md"] || !seen["note"] {
+		t.Fatalf("non-concept conflict was not retained: %#v", conflicts)
+	}
+}
+
+func serverGitFinalizeFixture(t *testing.T) (*KB, string, string) {
+	t.Helper()
+	root := t.TempDir()
+	k, err := Init(filepath.Join(root, "kb"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bare := filepath.Join(root, "remote", "example", "wiki.git")
+	if err := os.MkdirAll(filepath.Dir(bare), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	serverGitRun(t, filepath.Dir(bare), "init", "--bare", bare)
+	serverGitRemote(t, k, bare)
+	f := fakeForge{}
+	if err := k.ConfigureServerGit(ServerGitConfig{BaseBranch: "main", WorkingBranch: "cartographer/kb", Owner: "example", Repository: "wiki", Forge: f}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(k.Root, "data", "change.md"), []byte("---\ntype: Note\ntitle: Change\n---\nchange\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	serverGitRun(t, k.Root, "add", "data/change.md")
+	serverGitRun(t, k.Root, "commit", "-m", "working change")
+	serverGitRun(t, k.Root, "push", "origin", "cartographer/kb")
+	serverGitRun(t, bare, "update-server-info")
+	if err := gitx.Fetch(k.Root, "origin", k.GitEnv...); err != nil {
+		t.Fatal(err)
+	}
+	head, err := gitx.HeadSHA(k.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return k, bare, head
+}
+
+func TestFinalizeServerPRRequiresApprovalWithoutChangingBase(t *testing.T) {
+	k, _, head := serverGitFinalizeFixture(t)
+	baseBefore, err := gitx.HeadSHAAt(k.Root, "origin/main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := &scriptedForge{
+		find:   func() ([]PullRequest, error) { return nil, fmt.Errorf("unused") },
+		create: func() (PullRequest, error) { return PullRequest{}, fmt.Errorf("unused") },
+		get:    func() (PullRequest, error) { return PullRequest{Number: 4, State: "open", HeadSHA: head}, nil },
+		ready:  func() (bool, error) { return false, nil },
+		merge:  func() (MergeResult, error) { return MergeResult{}, fmt.Errorf("must not merge") },
+	}
+	k.ServerGit.Forge = f
+	if err := k.saveServerGitState(ServerGitState{Profile: "server", BaseBranch: "main", WorkingBranch: "cartographer/kb", PRNumber: 4, PRHeadSHA: head, Phase: "open"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := k.FinalizeServerPR(context.Background(), head); err == nil {
+		t.Fatal("expected approval/check gate failure")
+	}
+	baseAfter, _ := gitx.HeadSHAAt(k.Root, "origin/main")
+	if baseAfter != baseBefore {
+		t.Fatalf("protected base changed without merge: %s -> %s", baseBefore, baseAfter)
+	}
+}
+
+func TestFinalizeServerPRSuccessfulSquashStartsNewCycle(t *testing.T) {
+	k, bare, head := serverGitFinalizeFixture(t)
+	merged := false
+	f := &scriptedForge{
+		find:   func() ([]PullRequest, error) { return nil, fmt.Errorf("unused") },
+		create: func() (PullRequest, error) { return PullRequest{}, fmt.Errorf("unused") },
+		get: func() (PullRequest, error) {
+			if merged {
+				return PullRequest{Number: 5, State: "closed", Merged: true, MergeSHA: head}, nil
+			}
+			return PullRequest{Number: 5, State: "open", HeadSHA: head}, nil
+		},
+		ready: func() (bool, error) { return true, nil },
+		merge: func() (MergeResult, error) {
+			mergeHead, err := gitx.HeadSHA(k.Root)
+			if err != nil {
+				return MergeResult{}, err
+			}
+			// This is the explicit fake-forge merge: production code never pushes
+			// the protected base itself.
+			serverGitRun(t, k.Root, "push", bare, "HEAD:main")
+			serverGitRun(t, bare, "update-server-info")
+			merged = true
+			return MergeResult{Merged: true, SHA: mergeHead}, nil
+		},
+	}
+	k.ServerGit.Forge = f
+	if err := k.saveServerGitState(ServerGitState{Profile: "server", BaseBranch: "main", WorkingBranch: "cartographer/kb", PRNumber: 5, PRHeadSHA: head, Phase: "open"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := k.FinalizeServerPR(context.Background(), head); err != nil {
+		t.Fatal(err)
+	}
+	state := k.ServerGitStatus()
+	if state.PRNumber != 0 || state.Phase != "" {
+		t.Fatalf("new cycle state = %#v", state)
+	}
+	base, _ := gitx.HeadSHAAt(k.Root, "origin/main")
+	work, _ := gitx.HeadSHA(k.Root)
+	if base != work {
+		t.Fatalf("working branch was not reset to merged base: work=%s base=%s", work, base)
+	}
+}

--- a/internal/kb/servergit_test.go
+++ b/internal/kb/servergit_test.go
@@ -257,6 +257,16 @@ func TestRecordServerRebaseConflictRetainsNonConceptPaths(t *testing.T) {
 	}
 }
 
+// serverGitInitBare creates the fake remote and makes it advertise the branch
+// the KB is actually on. Without the symbolic-ref a clone on a host configured
+// for init.defaultBranch=master checks out nothing, and every fixture built on
+// top of it sees an empty worktree.
+func serverGitInitBare(t *testing.T, bare string) {
+	t.Helper()
+	serverGitRun(t, filepath.Dir(bare), "init", "--bare", bare)
+	serverGitRun(t, bare, "symbolic-ref", "HEAD", "refs/heads/"+gitx.DefaultBranch)
+}
+
 func serverGitFinalizeFixture(t *testing.T) (*KB, string, string) {
 	t.Helper()
 	root := t.TempDir()
@@ -268,7 +278,7 @@ func serverGitFinalizeFixture(t *testing.T) (*KB, string, string) {
 	if err := os.MkdirAll(filepath.Dir(bare), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	serverGitRun(t, filepath.Dir(bare), "init", "--bare", bare)
+	serverGitInitBare(t, bare)
 	serverGitRemote(t, k, bare)
 	f := fakeForge{}
 	if err := k.ConfigureServerGit(ServerGitConfig{BaseBranch: "main", WorkingBranch: "cartographer/kb", Owner: "example", Repository: "wiki", Forge: f}); err != nil {

--- a/internal/mcpserver/gitwrap.go
+++ b/internal/mcpserver/gitwrap.go
@@ -219,6 +219,9 @@ func handleConflictError(k *kb.KB, rce *gitx.RebaseConflictError) int {
 			Files:      rce.Files,
 			DetectedAt: now,
 		}
+		if state := k.ServerGitStatus(); state.Profile == "server" {
+			c.BaseBranch, c.WorkingBranch, c.PRNumber, c.PRURL = state.BaseBranch, state.WorkingBranch, state.PRNumber, state.PRURL
+		}
 		if err := k.RegisterConflict(c); err != nil {
 			fmt.Fprintf(os.Stderr, "cartographer: register conflict %q: %v\n", conceptID, err)
 		}

--- a/internal/mcpserver/readonly.go
+++ b/internal/mcpserver/readonly.go
@@ -36,6 +36,7 @@ var readOnlyToolNames = map[string]bool{
 	"template_list":   true,
 	"asset_read":      true,
 	"asset_list":      true,
+	"pr_status":       true,
 }
 
 // ToolRequiresWrite reports whether calling the named tool requires write

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -107,6 +107,8 @@ func RegisterKBTools(s *Server, k *kb.KB, deps Deps) {
 	register(toolConflictsList(k))
 	register(toolSyncStatus(k))
 	register(toolGitConflictResolve(k))
+	register(toolPRStatus(k))
+	register(toolPRFinalize(k))
 	register(toolServiceGet(k))
 	register(toolServiceList(k))
 	// Secret resolution requires rw scope but is still a read-side operation;

--- a/internal/mcpserver/tools_governance.go
+++ b/internal/mcpserver/tools_governance.go
@@ -439,11 +439,19 @@ func toolKBStatus(k *kb.KB) Tool {
 				return errorResult(fmt.Sprintf("kb_status: walk: %v", err)), nil
 			}
 
+			server := k.ServerGitStatus()
 			result := map[string]interface{}{
 				"total":               total,
 				"by_type":             typeCounts,
 				"stale_count":         staleCount,
 				"open_contradictions": openContradictions,
+				"git_profile":         server.Profile,
+				"base_branch":         server.BaseBranch,
+				"working_branch":      server.WorkingBranch,
+				"pr_number":           server.PRNumber,
+				"pr_url":              server.PRURL,
+				"pr_head_sha":         server.PRHeadSHA,
+				"last_forge_error":    server.LastForgeError,
 			}
 			out, _ := json.MarshalIndent(result, "", "  ")
 			return textResult(string(out)), nil
@@ -585,25 +593,33 @@ func toolConflictsList(k *kb.KB) Tool {
 			}
 
 			type conflictJSON struct {
-				ConceptID  string   `json:"concept_id"`
-				Path       string   `json:"path"`
-				LocalSHA   string   `json:"local_sha"`
-				RemoteSHA  string   `json:"remote_sha"`
-				Branch     string   `json:"branch"`
-				Files      []string `json:"files"`
-				DetectedAt string   `json:"detected_at"`
-				Guidance   string   `json:"guidance"`
+				ConceptID     string   `json:"concept_id"`
+				Path          string   `json:"path"`
+				LocalSHA      string   `json:"local_sha"`
+				RemoteSHA     string   `json:"remote_sha"`
+				Branch        string   `json:"branch"`
+				BaseBranch    string   `json:"base_branch,omitempty"`
+				WorkingBranch string   `json:"working_branch,omitempty"`
+				PRNumber      int      `json:"pr_number,omitempty"`
+				PRURL         string   `json:"pr_url,omitempty"`
+				Files         []string `json:"files"`
+				DetectedAt    string   `json:"detected_at"`
+				Guidance      string   `json:"guidance"`
 			}
 			results := make([]conflictJSON, len(conflicts))
 			for i, c := range conflicts {
 				results[i] = conflictJSON{
-					ConceptID:  c.ConceptID,
-					Path:       c.Path,
-					LocalSHA:   c.LocalSHA,
-					RemoteSHA:  c.RemoteSHA,
-					Branch:     c.Branch,
-					Files:      c.Files,
-					DetectedAt: c.DetectedAt,
+					ConceptID:     c.ConceptID,
+					Path:          c.Path,
+					LocalSHA:      c.LocalSHA,
+					RemoteSHA:     c.RemoteSHA,
+					Branch:        c.Branch,
+					BaseBranch:    c.BaseBranch,
+					WorkingBranch: c.WorkingBranch,
+					PRNumber:      c.PRNumber,
+					PRURL:         c.PRURL,
+					Files:         c.Files,
+					DetectedAt:    c.DetectedAt,
 					Guidance: "Read the concept with concept_read, reconcile the content, " +
 						"then rewrite it with concept_write removing status:degraded. " +
 						"See the kb-conflict-resolve skill for the full procedure.",

--- a/internal/mcpserver/tools_servergit.go
+++ b/internal/mcpserver/tools_servergit.go
@@ -1,0 +1,51 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/BeppeTemp/cartographer/internal/kb"
+)
+
+// toolPRStatus exposes the durable, non-secret review boundary state.
+func toolPRStatus(k *kb.KB) Tool {
+	return Tool{Name: "pr_status", ReadOnly: true,
+		Description: "Returns the server Git profile, dedicated branches, current pull request identity and last forge error. Advanced operator tool.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+		Handler: func(args json.RawMessage) (ToolResult, error) {
+			_ = k.ReconcileServerPR()
+			state := k.ServerGitStatus()
+			out, _ := json.MarshalIndent(state, "", "  ")
+			return textResult(string(out)), nil
+		},
+	}
+}
+
+// toolPRFinalize is deliberately separate from normal agent writes: it is an
+// explicit operator action that checks the caller's observed PR head.
+func toolPRFinalize(k *kb.KB) Tool {
+	return Tool{Name: "pr_finalize",
+		Description: "Squash-merges the current reviewed server-profile pull request after checking the supplied remote head SHA, rebase and validation. Advanced operator tool.",
+		InputSchema: json.RawMessage(`{"type":"object","required":["head_sha"],"properties":{"head_sha":{"type":"string","description":"Current remote PR head SHA observed by the operator."}}}`),
+		Handler: func(args json.RawMessage) (ToolResult, error) {
+			// D76/WP4: flush any pending async push before touching git state
+			// directly, so this handler does not race a push scheduled by a
+			// preceding write.
+			flushPendingPush(k, "pr_finalize")
+			var p struct {
+				HeadSHA string `json:"head_sha"`
+			}
+			if err := json.Unmarshal(args, &p); err != nil {
+				return errorResult("invalid params: " + err.Error()), nil
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			if err := k.FinalizeServerPR(ctx, p.HeadSHA); err != nil {
+				return errorResult(fmt.Sprintf("pr_finalize: %v", err)), nil
+			}
+			return textResult("Pull request squash-merged; working branch reset for the next review cycle."), nil
+		},
+	}
+}

--- a/internal/mcpserver/tools_sync.go
+++ b/internal/mcpserver/tools_sync.go
@@ -21,12 +21,16 @@ func toolSyncStatus(k *kb.KB) Tool {
 		Description: "Returns local git commit and remote replication status, including pending or failed pushes. Read-only.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
 		Handler: func(args json.RawMessage) (ToolResult, error) {
+			// A forge outage after a successful push is recoverable; status is an
+			// explicit retry point for the durable PR boundary (D117).
+			_ = k.ReconcileServerPR()
 			s := k.GitStatusSnapshot()
+			server := k.ServerGitStatus()
 			mode := "synchronous"
 			if k.SyncOutDebounce > 0 {
 				mode = "debounced"
 			}
-			out, _ := json.MarshalIndent(map[string]any{"state": s.State, "last_error": s.LastError, "last_attempt_at": s.LastAttemptAt, "head_sha": s.HeadSHA, "unpushed_commits": s.UnpushedCommits, "identity_warning": s.IdentityWarning, "attempts": s.Attempts, "push_mode": mode}, "", "  ")
+			out, _ := json.MarshalIndent(map[string]any{"state": s.State, "last_error": s.LastError, "last_attempt_at": s.LastAttemptAt, "head_sha": s.HeadSHA, "unpushed_commits": s.UnpushedCommits, "identity_warning": s.IdentityWarning, "attempts": s.Attempts, "push_mode": mode, "profile": server.Profile, "base_branch": server.BaseBranch, "working_branch": server.WorkingBranch, "pr_number": server.PRNumber, "pr_url": server.PRURL, "pr_head_sha": server.PRHeadSHA, "last_forge_error": server.LastForgeError}, "", "  ")
 			return textResult(string(out)), nil
 		},
 	}

--- a/internal/mcpserver/visibility.go
+++ b/internal/mcpserver/visibility.go
@@ -53,6 +53,8 @@ var advancedToolNames = map[string]bool{
 	"artifact_list":        true,
 	"artifact_delete":      true,
 	"asset_delete":         true,
+	"pr_status":            true,
+	"pr_finalize":          true,
 }
 
 // ToolAdvanced reports whether the named tool is hidden from tools/list under

--- a/test/e2e/scenarios/08_git_multiclone.sh
+++ b/test/e2e/scenarios/08_git_multiclone.sh
@@ -64,6 +64,9 @@ mcp() {
 # --- Setup: bare remote + clone A initialized as KB ---
 echo "[08] init bare remote + KB on clone A"
 git init --bare "$BARE" >/dev/null 2>&1
+# A KB is always initialized on main; make the remote advertise the same branch
+# so the scenario does not depend on the host's init.defaultBranch.
+git -C "$BARE" symbolic-ref HEAD refs/heads/main
 mkdir -p "$KBA"
 
 # Start instance A on KBA with --init (creates structure + git init + initial commit).

--- a/test/e2e/scenarios/09_git_conflict.sh
+++ b/test/e2e/scenarios/09_git_conflict.sh
@@ -80,6 +80,9 @@ mcp_capture() {
 # --- Setup: bare remote + clone A initialized as KB ---
 echo "[09] init bare remote + KB on clone A"
 git init --bare "$BARE" >/dev/null 2>&1
+# A KB is always initialized on main; make the remote advertise the same branch
+# so the scenario does not depend on the host's init.defaultBranch.
+git -C "$BARE" symbolic-ref HEAD refs/heads/main
 mkdir -p "$KBA"
 
 CARTOGRAPHER_AUTH=false CARTOGRAPHER_GIT_SYNC=true CARTOGRAPHER_SYNC_OUT_DEBOUNCE=0 \


### PR DESCRIPTION
Adds a server-side Git profile in which writes land on a working branch and are finalized through a pull request, alongside the existing local-commit profile.

- Two-clone layout with a lease so concurrent writers cannot interleave, base-SHA race detection, and `if_match` preconditions that stay correct after a rebase.
- Recovery path out of `merge_uncertain`, and token redaction everywhere the remote URL can surface.
- New MCP tools `pr_status` and `pr_finalize`, both classified as advanced in `visibility.go` and gated behind approval.
- Eight `git.*` configuration keys plus per-KB overrides.

Docs: `concurrency.md` replaces the Local commit section with Git profiles, covering SyncIn, retries, conflicts and `if_match` under the server profile; `control-plane.md` lists the two new tools; `deployment.md` and `config.example.yaml` document the keys; `testing.md` covers the two-clone fixture and the fake forge, including the constraint that CI never calls GitHub. Decision entry D117 in `docs/decisions/concurrency-git.md`.

32 tests mapped one-to-one onto the reviewed requirements: two-clone, lease, base-SHA race, post-rebase `if_match`, `merge_uncertain` recovery, concurrent writers, token redaction, gate without approval.

Verified locally after rebase: `gofmt`, `go vet`, `go test ./...` clean, `make e2e` 9/9.

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)