### PR TITLE
fix(client): discover the per-KB tool prefix instead of deriving it

### DIFF
--- a/cmd/cartographer/clientsync.go
+++ b/cmd/cartographer/clientsync.go
@@ -56,34 +56,36 @@ func resolveToken(cfg *clientconfig.Config) string {
 	return os.Getenv(cfg.TokenEnv)
 }
 
-// kbTargets returns the list of KB names to query for cfg: cfg.KBs verbatim, or a
-// single "" entry (the server's default single-KB endpoint, see
-// MultiKBServer.Handler in internal/mcpserver/httpserver.go) when cfg.KBs is empty.
-func kbTargets(cfg *clientconfig.Config) []string {
-	if len(cfg.KBs) == 0 {
-		return []string{""}
-	}
-	return cfg.KBs
-}
-
-// fetchMergedManifest connects to cfg.ServerURL and calls sync_pull once per KB
-// target (cfg.KBs, or the default single-KB endpoint when empty), decoding each
-// artifact's in-memory file contents (base64) and merging everything into a single
-// provisioning.Manifest via provisioning.MergeArtifacts — the same precedence rule
-// (KB source wins over bundle) BuildManifest applies server-side for one KB.
+// fetchMergedManifest connects to cfg.ServerURL, discovers the live per-KB
+// tool-name prefixes from /health (D120: resolveKBTargets), and calls
+// sync_pull — qualified with each target's advertised prefix — once per KB
+// target (cfg.KBs, or the server's default single-KB endpoint when empty),
+// decoding each artifact's in-memory file contents (base64) and merging
+// everything into a single provisioning.Manifest via
+// provisioning.MergeArtifacts — the same precedence rule (KB source wins over
+// bundle) BuildManifest applies server-side for one KB.
 func fetchMergedManifest(cfg *clientconfig.Config) (provisioning.Manifest, error) {
 	token := resolveToken(cfg)
+	health, err := client.New(cfg.ServerURL, token).Health(probeTimeout)
+	if err != nil {
+		return provisioning.Manifest{}, fmt.Errorf("health: %w", err)
+	}
+	targets, err := resolveKBTargets(health, cfg.KBs)
+	if err != nil {
+		return provisioning.Manifest{}, err
+	}
+
 	var all []provisioning.Artifact
 	seen := make(map[string]provisioning.Artifact)
 
-	for _, kbName := range kbTargets(cfg) {
-		c := client.New(cfg.ServerURL, token).WithKB(kbName)
-		raw, err := c.Call("sync_pull", map[string]any{})
+	for _, target := range targets {
+		c := client.New(cfg.ServerURL, token).WithKB(target.Name)
+		raw, err := callTool(c, target, "sync_pull", map[string]any{})
 		if err != nil {
-			if kbName == "" {
+			if target.Name == "" {
 				return provisioning.Manifest{}, fmt.Errorf("sync_pull: %w", err)
 			}
-			return provisioning.Manifest{}, fmt.Errorf("sync_pull (kb=%s): %w", kbName, err)
+			return provisioning.Manifest{}, fmt.Errorf("sync_pull (kb=%s): %w", target.Name, err)
 		}
 
 		var pm pulledManifestJSON

--- a/cmd/cartographer/clientsync_test.go
+++ b/cmd/cartographer/clientsync_test.go
@@ -46,6 +46,10 @@ func TestFetchMergedManifest_PreservesBinaryExecutableFilesThroughApply(t *testi
 		{Path: "SKILL.md", Content: first}, {Path: "run.bin", Content: binary, Executable: true},
 	})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "version": "test"})
+			return
+		}
 		if r.URL.Path != "/mcp" {
 			http.NotFound(w, r)
 			return

--- a/cmd/cartographer/multikb.go
+++ b/cmd/cartographer/multikb.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 
 	"github.com/BeppeTemp/cartographer/internal/client"
 	"github.com/BeppeTemp/cartographer/internal/clientconfig"
+	"github.com/BeppeTemp/cartographer/internal/config"
 	"github.com/BeppeTemp/cartographer/internal/configurator"
 )
 
@@ -13,6 +15,97 @@ import (
 type mcpEntry struct {
 	Name string
 	URL  string
+}
+
+// kbTarget is one resolved remote-KB target for a top-level administrative
+// client operation (fetchMergedManifest, cmdReindex): Name is the KB name to
+// select via WithKB (empty selects the server's default single-KB endpoint,
+// see MultiKBServer.Handler), ToolPrefix is that KB's currently effective
+// tool-name prefix (D102), as advertised by /health (mcpserver.KBInfo.ToolPrefix,
+// D120) — never re-derived client-side from config.ResolveToolPrefix, which
+// would require reading the server's own YAML. Every direct call against a
+// target must go through qualifyTool/callTool so a discovery mismatch is
+// impossible.
+type kbTarget struct {
+	Name       string
+	ToolPrefix string
+}
+
+// qualifyTool returns the tool name to call for a target's advertised
+// prefix: base unchanged for an empty prefix, "<prefix>__<base>" otherwise —
+// the client-side mirror of Server.RegisterTool's own renaming (D102).
+func qualifyTool(prefix, base string) string {
+	if prefix == "" {
+		return base
+	}
+	return prefix + "__" + base
+}
+
+// callTool issues one direct administrative tools/call against target using
+// c (already scoped to target.Name via WithKB), qualifying base with
+// target.ToolPrefix. This is the one seam every Cartographer-owned direct
+// tool call must go through (D120) — see TestNoUnqualifiedProductionToolCalls.
+func callTool(c *client.MCPClient, target kbTarget, base string, args any) (json.RawMessage, error) {
+	return c.Call(qualifyTool(target.ToolPrefix, base), args)
+}
+
+// resolveKBTargets resolves the KB targets for one top-level client
+// operation from a live /health snapshot (D120): the KB names it selects are
+// always the ones the caller already asked for (selectedNames — typically
+// cfg.KBs, or an operator's explicit --kb override), qualified with each
+// KB's currently advertised tool-name prefix rather than a client-side
+// re-derivation. Rules:
+//
+//   - selectedNames non-empty: every name must appear in health.KBs (when
+//     health carries KB metadata at all) — a persisted/explicit name absent
+//     from current health metadata is a stale-selection error naming the KB;
+//     a legacy health response with no kbs field at all preserves the
+//     pre-D120 unprefixed behaviour verbatim (no way to check or qualify);
+//   - selectedNames empty and health advertises exactly one KB: the bare
+//     endpoint, qualified with that KB's advertised prefix;
+//   - selectedNames empty and health advertises zero or 2+ KBs, or omits KB
+//     metadata entirely: the bare endpoint, unqualified — the server's own
+//     "kb parameter required"/"unknown kb" response is the explicit-selection
+//     error that surfaces, exactly as it did before D120; this function never
+//     guesses a KB.
+//
+// A non-empty advertised prefix is validated (config.ValidateToolPrefixShape)
+// before use: malformed server metadata is a protocol error, never silently
+// re-sanitized or retried.
+func resolveKBTargets(health *client.Health, selectedNames []string) ([]kbTarget, error) {
+	haveMetadata := health != nil && health.KBs != nil
+	prefixByName := make(map[string]string, len(selectedNames))
+	if haveMetadata {
+		for _, kb := range *health.KBs {
+			if kb.ToolPrefix != "" {
+				if err := config.ValidateToolPrefixShape(kb.ToolPrefix); err != nil {
+					return nil, fmt.Errorf("server advertised an invalid tool_prefix %q for KB %q: %w", kb.ToolPrefix, kb.Name, err)
+				}
+			}
+			prefixByName[kb.Name] = kb.ToolPrefix
+		}
+	}
+
+	if len(selectedNames) > 0 {
+		targets := make([]kbTarget, 0, len(selectedNames))
+		for _, name := range selectedNames {
+			if !haveMetadata {
+				targets = append(targets, kbTarget{Name: name})
+				continue
+			}
+			prefix, ok := prefixByName[name]
+			if !ok {
+				return nil, fmt.Errorf("configured KB %q is not among the KBs currently advertised by the server (stale selection: check .cartographer.yaml or the server config)", name)
+			}
+			targets = append(targets, kbTarget{Name: name, ToolPrefix: prefix})
+		}
+		return targets, nil
+	}
+
+	if haveMetadata && len(*health.KBs) == 1 {
+		return []kbTarget{{ToolPrefix: (*health.KBs)[0].ToolPrefix}}, nil
+	}
+	return []kbTarget{{}}, nil
 }
 
 // enumerateKBs obtains the mounted KB names from /health. present is false

--- a/cmd/cartographer/reindex.go
+++ b/cmd/cartographer/reindex.go
@@ -44,19 +44,25 @@ func cmdReindex(args []string) int {
 			cfg = loaded
 		}
 	}
-	targetNames := kbTargets(cfg)
+	selected := cfg.KBs
 	if *kbFlag != "" {
-		targetNames = []string{*kbFlag}
+		selected = []string{*kbFlag}
 	}
 
-	if _, err := fetchHealth(strings.TrimSuffix(cfg.ServerURL, "/mcp")); err == nil {
-		for _, name := range targetNames {
-			raw, err := client.New(cfg.ServerURL, resolveToken(cfg)).WithKB(name).Call("reindex", map[string]any{})
+	token := resolveToken(cfg)
+	if health, err := client.New(cfg.ServerURL, token).Health(probeTimeout); err == nil {
+		targets, err := resolveKBTargets(health, selected)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reindex:", err)
+			return 1
+		}
+		for _, target := range targets {
+			raw, err := callTool(client.New(cfg.ServerURL, token).WithKB(target.Name), target, "reindex", map[string]any{})
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "reindex %s: %v\n", displayKBName(name), err)
+				fmt.Fprintf(os.Stderr, "reindex %s: %v\n", displayKBName(target.Name), err)
 				return 1
 			}
-			fmt.Printf("%s: %s\n", displayKBName(name), strings.TrimSpace(string(raw)))
+			fmt.Printf("%s: %s\n", displayKBName(target.Name), strings.TrimSpace(string(raw)))
 		}
 		return 0
 	}

--- a/cmd/cartographer/toolprefix_client_test.go
+++ b/cmd/cartographer/toolprefix_client_test.go
@@ -1,0 +1,222 @@
+package main
+
+// Tests for D120: client-side per-KB tool-name prefix discovery
+// (resolveKBTargets, qualifyTool, callTool) and the guard against future
+// direct administrative tool calls bypassing that seam.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/BeppeTemp/cartographer/internal/client"
+	"github.com/BeppeTemp/cartographer/internal/clientconfig"
+)
+
+func healthWithKBs(kbs ...client.HealthKB) *client.Health {
+	list := append([]client.HealthKB{}, kbs...)
+	return &client.Health{KBs: &list}
+}
+
+func TestQualifyTool(t *testing.T) {
+	if got := qualifyTool("", "sync_pull"); got != "sync_pull" {
+		t.Errorf("qualifyTool(\"\", ...) = %q, want unchanged base name", got)
+	}
+	if got := qualifyTool("ai_team", "sync_pull"); got != "ai_team__sync_pull" {
+		t.Errorf("qualifyTool(prefix, ...) = %q, want ai_team__sync_pull", got)
+	}
+}
+
+func TestResolveKBTargets(t *testing.T) {
+	t.Run("unprefixed and prefixed KB, explicit selection (prefix differs from sanitized KB name)", func(t *testing.T) {
+		health := healthWithKBs(
+			client.HealthKB{Name: "alpha"},
+			client.HealthKB{Name: "beta", ToolPrefix: "custom_name"},
+		)
+		targets, err := resolveKBTargets(health, []string{"alpha", "beta"})
+		if err != nil {
+			t.Fatalf("resolveKBTargets: %v", err)
+		}
+		want := []kbTarget{{Name: "alpha"}, {Name: "beta", ToolPrefix: "custom_name"}}
+		if len(targets) != 2 || targets[0] != want[0] || targets[1] != want[1] {
+			t.Fatalf("targets = %+v, want %+v", targets, want)
+		}
+	})
+
+	t.Run("global kb-name mode: advertised prefix equals the KB name", func(t *testing.T) {
+		health := healthWithKBs(client.HealthKB{Name: "wiki", ToolPrefix: "wiki"})
+		targets, err := resolveKBTargets(health, []string{"wiki"})
+		if err != nil || len(targets) != 1 || targets[0].ToolPrefix != "wiki" {
+			t.Fatalf("targets = %+v, err=%v", targets, err)
+		}
+	})
+
+	t.Run("legacy health without a kbs field: pre-D120 unprefixed behaviour preserved", func(t *testing.T) {
+		targets, err := resolveKBTargets(&client.Health{}, []string{"alpha", "beta"})
+		if err != nil {
+			t.Fatalf("resolveKBTargets: %v", err)
+		}
+		want := []kbTarget{{Name: "alpha"}, {Name: "beta"}}
+		if len(targets) != 2 || targets[0] != want[0] || targets[1] != want[1] {
+			t.Fatalf("targets = %+v, want %+v", targets, want)
+		}
+	})
+
+	t.Run("selected KB missing from current health: stale-selection error naming it", func(t *testing.T) {
+		health := healthWithKBs(client.HealthKB{Name: "alpha"})
+		_, err := resolveKBTargets(health, []string{"alpha", "gone"})
+		if err == nil || !strings.Contains(err.Error(), `"gone"`) || !strings.Contains(err.Error(), "stale selection") {
+			t.Fatalf("error = %v, want a stale-selection error naming %q", err, "gone")
+		}
+	})
+
+	t.Run("malformed advertised prefix: protocol error, never sanitized or retried", func(t *testing.T) {
+		health := healthWithKBs(client.HealthKB{Name: "alpha", ToolPrefix: "9bad"})
+		_, err := resolveKBTargets(health, []string{"alpha"})
+		if err == nil || !strings.Contains(err.Error(), "invalid tool_prefix") {
+			t.Fatalf("error = %v, want an invalid tool_prefix error", err)
+		}
+	})
+
+	t.Run("empty selection, exactly one advertised KB: bare endpoint qualified with its prefix", func(t *testing.T) {
+		health := healthWithKBs(client.HealthKB{Name: "only", ToolPrefix: "only_prefix"})
+		targets, err := resolveKBTargets(health, nil)
+		if err != nil || len(targets) != 1 || targets[0].Name != "" || targets[0].ToolPrefix != "only_prefix" {
+			t.Fatalf("targets = %+v, err=%v", targets, err)
+		}
+	})
+
+	t.Run("empty selection, multiple advertised KBs: bare unqualified endpoint (server's own selection error surfaces)", func(t *testing.T) {
+		health := healthWithKBs(client.HealthKB{Name: "alpha"}, client.HealthKB{Name: "beta", ToolPrefix: "beta"})
+		targets, err := resolveKBTargets(health, nil)
+		if err != nil || len(targets) != 1 || targets[0] != (kbTarget{}) {
+			t.Fatalf("targets = %+v, err=%v, want one unqualified bare target", targets, err)
+		}
+	})
+
+	t.Run("empty selection, no health metadata at all: bare unqualified endpoint", func(t *testing.T) {
+		targets, err := resolveKBTargets(nil, nil)
+		if err != nil || len(targets) != 1 || targets[0] != (kbTarget{}) {
+			t.Fatalf("targets = %+v, err=%v", targets, err)
+		}
+	})
+}
+
+// prefixAwareMCPServer starts an httptest server whose /health advertises the
+// given KBs (name -> tool_prefix, "" for unprefixed) and whose /mcp?kb=<name>
+// endpoint only succeeds a tools/call whose "name" is exactly
+// qualifyTool(prefix, wantBase) for that KB — any other name is answered with
+// isError:true, "tool not found: <name>", mirroring the real server
+// (Server.handleToolsCall) closely enough to prove the qualifier is what
+// reached the wire.
+func prefixAwareMCPServer(t *testing.T, prefixByKB map[string]string, wantBase string, resultFor func(kb string) string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			kbs := make([]map[string]any, 0, len(prefixByKB))
+			for name, prefix := range prefixByKB {
+				entry := map[string]any{"name": name}
+				if prefix != "" {
+					entry["tool_prefix"] = prefix
+				}
+				kbs = append(kbs, entry)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "kbs": kbs})
+			return
+		}
+		kbName := r.URL.Query().Get("kb")
+		var req struct {
+			ID     int `json:"id"`
+			Params struct {
+				Name string `json:"name"`
+			} `json:"params"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		want := qualifyTool(prefixByKB[kbName], wantBase)
+		if req.Params.Name != want {
+			_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": map[string]any{
+				"content": []map[string]string{{"type": "text", "text": "tool not found: " + req.Params.Name}},
+				"isError": true,
+			}})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": map[string]any{
+			"content": []map[string]string{{"type": "text", "text": resultFor(kbName)}},
+		}})
+	}))
+}
+
+// TestFetchMergedManifest_QualifiesSyncPullPerKB proves fetchMergedManifest
+// (WP2) calls sync_pull qualified with each KB's server-advertised prefix:
+// one unprefixed KB, one with an explicit prefix that differs from its
+// sanitized KB name.
+func TestFetchMergedManifest_QualifiesSyncPullPerKB(t *testing.T) {
+	srv := prefixAwareMCPServer(t, map[string]string{"alpha": "", "beta": "custom_name"}, "sync_pull", func(kb string) string {
+		return `{"revision":"rev-` + kb + `","artifacts":[]}`
+	})
+	defer srv.Close()
+
+	cfg := &clientconfig.Config{ServerURL: srv.URL + "/mcp", KBs: []string{"alpha", "beta"}}
+	if _, err := fetchMergedManifest(cfg); err != nil {
+		t.Fatalf("fetchMergedManifest: %v", err)
+	}
+}
+
+// TestCmdReindex_QualifiesReindexPerKB proves the HTTP-owned branch of
+// cmdReindex (WP2) calls the remote reindex tool qualified with each KB's
+// server-advertised prefix.
+func TestCmdReindex_QualifiesReindexPerKB(t *testing.T) {
+	srv := prefixAwareMCPServer(t, map[string]string{"alpha": "", "beta": "custom_name"}, "reindex", func(kb string) string {
+		return "indexed=0 updated=0 removed=0"
+	})
+	defer srv.Close()
+
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	cfg := &clientconfig.Config{ServerURL: srv.URL + "/mcp", KBs: []string{"alpha", "beta"}}
+	if err := clientconfig.Save(dir, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	var code int
+	out := withStdout(t, func() { code = cmdReindex(nil) })
+	if code != 0 {
+		t.Fatalf("cmdReindex exit = %d, output=%s", code, out)
+	}
+	if !strings.Contains(out, "alpha:") || !strings.Contains(out, "beta:") {
+		t.Fatalf("output = %q, want both KBs reported", out)
+	}
+}
+
+// TestNoUnqualifiedProductionToolCalls guards the D120 seam: every
+// Cartographer-owned direct administrative tools/call must be issued through
+// callTool (qualifyTool), never a bare client.MCPClient.Call, so a future
+// direct call cannot silently skip prefix discovery. multikb.go is exempt:
+// it is where callTool itself is defined and legitimately calls c.Call.
+func TestNoUnqualifiedProductionToolCalls(t *testing.T) {
+	callRe := regexp.MustCompile(`[a-zA-Z0-9_]\.Call\(`)
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		if name == "multikb.go" {
+			continue
+		}
+		data, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if callRe.Match(data) {
+			t.Errorf("%s calls MCPClient.Call directly; route direct administrative tool calls through callTool (D120) so prefix discovery cannot be bypassed", name)
+		}
+	}
+}

--- a/cmd/cartographer/tui.go
+++ b/cmd/cartographer/tui.go
@@ -59,12 +59,28 @@ const (
 // manifest has been fetched.
 type dashboardAgent struct {
 	agents.Agent
-	Connected   bool
-	MCPConfigOK bool
+	Connected bool
+	// MCPConfigState is the mcp-config badge for a connected agent: whether
+	// every entry cartographer connect would currently write for this KB set
+	// is present on disk (see mcpConfigStatus).
+	MCPConfigState mcpConfigState
 	// SkillStatus is one of: "not connected", "checking…", "in-sync",
 	// "drift ..." (see formatDiffStatus), "server unreachable", or "error: ...".
 	SkillStatus string
 }
+
+// mcpConfigState is the three-state mcp-config badge (D120): a connected
+// agent's on-disk MCP config may declare every entry cartographer connect
+// would currently write for the configured KB set (in-sync), some but not
+// all of them (partial — e.g. a KB was added to .cartographer.yaml but
+// `cartographer sync` hasn't run yet for this provider), or none (missing).
+type mcpConfigState int
+
+const (
+	mcpConfigMissing mcpConfigState = iota
+	mcpConfigPartial
+	mcpConfigInSync
+)
 
 // Model is the bubbletea model for the dashboard. It holds only data and
 // transitions; every actual side effect (network call, file read/write) is
@@ -185,8 +201,10 @@ func buildRows(dir string) []dashboardAgent {
 
 	connected := map[string]bool{}
 	serverName := "cartographer"
+	var kbs []string
 	if cfg, err := clientconfig.Load(dir); err == nil {
 		serverName = cfg.ServerName
+		kbs = cfg.KBs
 		for _, a := range cfg.Agents {
 			connected[a] = true
 		}
@@ -197,7 +215,7 @@ func buildRows(dir string) []dashboardAgent {
 		row := dashboardAgent{Agent: a}
 		if connected[string(a.Provider)] {
 			row.Connected = true
-			row.MCPConfigOK = mcpConfigStatus(dir, a.Provider, serverName)
+			row.MCPConfigState = mcpConfigStatus(dir, a.Provider, serverName, kbs)
 			row.SkillStatus = "checking…"
 		} else {
 			row.SkillStatus = "not connected"
@@ -216,45 +234,79 @@ func hasConnectedAgent(rows []dashboardAgent) bool {
 	return false
 }
 
-// mcpConfigStatus reports whether provider's MCP config file exists under dir and
-// declares an MCP server named serverName. Dashboard-only presentation check: the
-// actual config generation/writing lives in configurator.Emit/Apply — this just
-// reads back what Emit would have written, to find the file path, and checks the
-// on-disk content.
-func mcpConfigStatus(dir string, provider configurator.Provider, serverName string) bool {
+// mcpConfigStatus reports whether provider's MCP config file under dir declares
+// every entry cartographer connect/sync currently write for kbs (D92/D120: a
+// zero/one-KB set is one bare serverName entry, a multi-KB set is one entry
+// per KB — see entriesForKBs). Dashboard-only presentation check: the actual
+// config generation/writing lives in configurator.Emit/Apply — this just reads
+// back what Emit would have written, to find the file path, and checks which
+// of the expected entry names are present in the on-disk content.
+//
+// Deliberately does not use managedEntryNames: that helper enumerates every
+// name this client may have *ever* owned (for safe removal across KB set
+// changes), which is not the same set as "currently expected" — a KB removed
+// from .cartographer.yaml should not keep counting toward in-sync/partial.
+func mcpConfigStatus(dir string, provider configurator.Provider, serverName string, kbs []string) mcpConfigState {
+	entries, err := entriesForKBs(serverName, "http://placeholder", kbs)
+	if err != nil || len(entries) == 0 {
+		return mcpConfigMissing
+	}
+	expected := entryNames(entries)
+
 	r, err := configurator.Emit(&configurator.ServerConfig{Name: serverName, URL: "http://placeholder"}, provider)
 	if err != nil {
-		return false
+		return mcpConfigMissing
 	}
 	data, err := os.ReadFile(filepath.Join(dir, r.FilePath))
 	if err != nil {
-		return false
+		return mcpConfigMissing
 	}
-	// TOML providers (codex) store the server as a [mcp_servers.<name>] table
-	// merged into config.toml — not JSON, so json.Unmarshal below would always
-	// fail. Match the table header emitCodex writes instead.
+
+	present := 0
+	// TOML providers (codex) store each server as its own [mcp_servers.<name>]
+	// table merged into config.toml — not JSON, so json.Unmarshal below would
+	// always fail. Match the table header emitCodex writes instead.
 	if strings.HasSuffix(r.FilePath, ".toml") {
-		return strings.Contains(string(data), "[mcp_servers."+serverName+"]")
+		for _, name := range expected {
+			if strings.Contains(string(data), "[mcp_servers."+name+"]") {
+				present++
+			}
+		}
+		return mcpConfigStateFromCounts(present, len(expected))
 	}
+
 	var root map[string]json.RawMessage
 	if err := json.Unmarshal(data, &root); err != nil {
-		return false
+		return mcpConfigMissing
 	}
 	// "mcpServers" (claude/kiro) or "mcp" (opencode) — see configurator.go.
+	var servers map[string]json.RawMessage
 	for _, key := range []string{"mcpServers", "mcp"} {
 		raw, ok := root[key]
 		if !ok {
 			continue
 		}
-		var servers map[string]json.RawMessage
-		if err := json.Unmarshal(raw, &servers); err != nil {
-			continue
-		}
-		if _, ok := servers[serverName]; ok {
-			return true
+		if err := json.Unmarshal(raw, &servers); err == nil {
+			break
 		}
 	}
-	return false
+	for _, name := range expected {
+		if _, ok := servers[name]; ok {
+			present++
+		}
+	}
+	return mcpConfigStateFromCounts(present, len(expected))
+}
+
+func mcpConfigStateFromCounts(present, expected int) mcpConfigState {
+	switch {
+	case expected > 0 && present == expected:
+		return mcpConfigInSync
+	case present > 0:
+		return mcpConfigPartial
+	default:
+		return mcpConfigMissing
+	}
 }
 
 // --- tea.Cmd builders ---
@@ -870,9 +922,14 @@ func (m Model) viewList() string {
 			lines = append(lines, "      "+styleSubtitle.Render("binary      ")+styleEvidence.Render(row.Evidence))
 		}
 		if row.Connected {
-			mcpBadge := styleDrift.Render("missing")
-			if row.MCPConfigOK {
+			var mcpBadge string
+			switch row.MCPConfigState {
+			case mcpConfigInSync:
 				mcpBadge = styleConnected.Render("in-sync")
+			case mcpConfigPartial:
+				mcpBadge = styleDrift.Render("partial")
+			default:
+				mcpBadge = styleDrift.Render("missing")
 			}
 			skill := row.SkillStatus
 			if skill == "checking…" && m.loading {

--- a/cmd/cartographer/tui_test.go
+++ b/cmd/cartographer/tui_test.go
@@ -692,7 +692,7 @@ func TestViewList_ExplicitStates(t *testing.T) {
 		version: "test",
 		dir:     "/tmp/does-not-matter",
 		rows: []dashboardAgent{
-			{Agent: agents.Agent{Name: "Claude Code", Installed: true, Evidence: "/bin/claude"}, Connected: true, MCPConfigOK: true, SkillStatus: "in-sync"},
+			{Agent: agents.Agent{Name: "Claude Code", Installed: true, Evidence: "/bin/claude"}, Connected: true, MCPConfigState: mcpConfigInSync, SkillStatus: "in-sync"},
 			{Agent: agents.Agent{Name: "OpenCode", Installed: true, Evidence: "/bin/opencode"}},
 			{Agent: agents.Agent{Name: "Kiro"}},
 		},
@@ -765,7 +765,8 @@ func TestView_StretchesToTerminalWidth(t *testing.T) {
 // TestMCPConfigStatus_CodexTOML pins the fix for the JSON-only check that made
 // Codex always report mcp-config "missing": config.toml is TOML, so the old
 // json.Unmarshal path always failed. mcpConfigStatus must instead match the
-// [mcp_servers.<name>] table emitCodex writes.
+// [mcp_servers.<name>] table emitCodex writes. Zero/one-KB set: exactly one
+// expected entry (the bare server name), so the badge is binary missing/in-sync.
 func TestMCPConfigStatus_CodexTOML(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(dir, ".codex"), 0o755); err != nil {
@@ -777,8 +778,8 @@ func TestMCPConfigStatus_CodexTOML(t *testing.T) {
 	if err := os.WriteFile(tomlPath, []byte("model = \"gpt-5.5\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if mcpConfigStatus(dir, configurator.ProviderCodex, "cartographer") {
-		t.Error("expected false: config.toml has no [mcp_servers.cartographer] table")
+	if got := mcpConfigStatus(dir, configurator.ProviderCodex, "cartographer", nil); got != mcpConfigMissing {
+		t.Errorf("state = %v, want mcpConfigMissing: config.toml has no [mcp_servers.cartographer] table", got)
 	}
 
 	// With the managed block → in-sync.
@@ -786,13 +787,48 @@ func TestMCPConfigStatus_CodexTOML(t *testing.T) {
 	if err := os.WriteFile(tomlPath, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if !mcpConfigStatus(dir, configurator.ProviderCodex, "cartographer") {
-		t.Error("expected true: config.toml declares [mcp_servers.cartographer]")
+	if got := mcpConfigStatus(dir, configurator.ProviderCodex, "cartographer", nil); got != mcpConfigInSync {
+		t.Errorf("state = %v, want mcpConfigInSync: config.toml declares [mcp_servers.cartographer]", got)
+	}
+}
+
+// TestMCPConfigStatus_CodexTOML_MultiKB covers the three-state badge (D120)
+// on the TOML provider across a multi-KB set: none, some, and all of the
+// per-KB [mcp_servers.cartographer-<kb>] tables present.
+func TestMCPConfigStatus_CodexTOML_MultiKB(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tomlPath := filepath.Join(dir, ".codex", "config.toml")
+	kbs := []string{"alpha", "beta"}
+
+	if err := os.WriteFile(tomlPath, []byte("model = \"gpt-5.5\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := mcpConfigStatus(dir, configurator.ProviderCodex, "cartographer", kbs); got != mcpConfigMissing {
+		t.Errorf("none present: state = %v, want mcpConfigMissing", got)
+	}
+
+	if err := os.WriteFile(tomlPath, []byte("[mcp_servers.cartographer-alpha]\nurl = \"http://x\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := mcpConfigStatus(dir, configurator.ProviderCodex, "cartographer", kbs); got != mcpConfigPartial {
+		t.Errorf("one of two present: state = %v, want mcpConfigPartial", got)
+	}
+
+	body := "[mcp_servers.cartographer-alpha]\nurl = \"http://x\"\n[mcp_servers.cartographer-beta]\nurl = \"http://y\"\n"
+	if err := os.WriteFile(tomlPath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := mcpConfigStatus(dir, configurator.ProviderCodex, "cartographer", kbs); got != mcpConfigInSync {
+		t.Errorf("both present: state = %v, want mcpConfigInSync", got)
 	}
 }
 
 // TestMCPConfigStatus_JSONProviders guards the untouched JSON path
-// (claude/opencode): presence of the server under the right key means in-sync.
+// (claude/opencode): presence of the server under the right key means
+// in-sync; a wrong name means missing.
 func TestMCPConfigStatus_JSONProviders(t *testing.T) {
 	dir := t.TempDir()
 	r, err := configurator.Emit(&configurator.ServerConfig{Name: "cartographer", URL: "http://x"}, configurator.ProviderOpenCode)
@@ -806,11 +842,49 @@ func TestMCPConfigStatus_JSONProviders(t *testing.T) {
 	if err := os.WriteFile(full, []byte(`{"mcp":{"cartographer":{"type":"remote"}}}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if !mcpConfigStatus(dir, configurator.ProviderOpenCode, "cartographer") {
-		t.Error("expected true: opencode config declares the server under \"mcp\"")
+	if got := mcpConfigStatus(dir, configurator.ProviderOpenCode, "cartographer", nil); got != mcpConfigInSync {
+		t.Errorf("state = %v, want mcpConfigInSync: opencode config declares the server under \"mcp\"", got)
 	}
-	if mcpConfigStatus(dir, configurator.ProviderOpenCode, "other") {
-		t.Error("expected false: server name not present")
+	if got := mcpConfigStatus(dir, configurator.ProviderOpenCode, "other", nil); got != mcpConfigMissing {
+		t.Errorf("state = %v, want mcpConfigMissing: server name not present", got)
+	}
+}
+
+// TestMCPConfigStatus_JSONProviders_MultiKB covers the three-state badge on
+// the JSON path across a multi-KB set: none, some, and all of the per-KB
+// entries present under "mcp".
+func TestMCPConfigStatus_JSONProviders_MultiKB(t *testing.T) {
+	dir := t.TempDir()
+	r, err := configurator.Emit(&configurator.ServerConfig{Name: "cartographer", URL: "http://x"}, configurator.ProviderOpenCode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	full := filepath.Join(dir, r.FilePath)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	kbs := []string{"alpha", "beta"}
+
+	if err := os.WriteFile(full, []byte(`{"mcp":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := mcpConfigStatus(dir, configurator.ProviderOpenCode, "cartographer", kbs); got != mcpConfigMissing {
+		t.Errorf("none present: state = %v, want mcpConfigMissing", got)
+	}
+
+	if err := os.WriteFile(full, []byte(`{"mcp":{"cartographer-alpha":{"type":"remote"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := mcpConfigStatus(dir, configurator.ProviderOpenCode, "cartographer", kbs); got != mcpConfigPartial {
+		t.Errorf("one of two present: state = %v, want mcpConfigPartial", got)
+	}
+
+	body := `{"mcp":{"cartographer-alpha":{"type":"remote"},"cartographer-beta":{"type":"remote"}}}`
+	if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := mcpConfigStatus(dir, configurator.ProviderOpenCode, "cartographer", kbs); got != mcpConfigInSync {
+		t.Errorf("both present: state = %v, want mcpConfigInSync", got)
 	}
 }
 

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -67,9 +67,18 @@ entries and `kbs` list untouched and warns; run `sync` again once it is up.
 Claude Code/Codex/OpenCode which namespace per server: writing 2+ MCP entries for `kiro` (i.e.
 connecting to a 2+-KB server) leaves only one KB's tools reachable in a Kiro session unless the
 *server* mounts the others with a `tool_prefix` (`docs/deployment.md` §MCP tool-name prefix, D102).
-`connect`/`sync` print an unconditional warning on stderr in that case — they cannot tell from
-`/health` whether the server already has prefixes configured, so the warning fires on the
-precondition alone; the operator is expected to add `tool_prefix`/`tool_prefix_mode` server-side.
+`connect`/`sync` warn on stderr in that case; the operator is expected to add
+`tool_prefix`/`tool_prefix_mode` server-side. Since D120 `/health` advertises each KB's effective
+`tool_prefix`, so the client can see which KBs are already namespaced instead of reasoning from the
+precondition alone.
+
+**Prefix discovery (D120).** Every client-owned direct tool call — manifest pull during `sync`,
+remote `reindex`, the TUI's status probes — qualifies the tool name with the prefix the server
+advertises for that KB in `/health`, never with one re-derived locally from the KB name. A locally
+derived prefix is a guess: `tool_prefix` is an arbitrary operator string, so a client that guessed it
+called tools that did not exist and reported the resulting failure as an unreachable server. The
+discovered value is used live and never persisted, so changing a prefix server-side needs no
+client-side reconnect.
 
 ```bash
 cartographer connect                                   # all agents detected on the machine

--- a/docs/decisions/transport-auth.md
+++ b/docs/decisions/transport-auth.md
@@ -176,3 +176,34 @@ exported (`audit.FailAppendsForTest`) because the MCP layer lives in another pac
 contract is about what happens when appends fail; it is test-only and never reached in production
 code. `audit.mode` and the rotation keys are YAML-only — the existing `CARTOGRAPHER_AUDIT_LOG`
 environment variable still enables the log with default best-effort behaviour.
+
+## D120 — Tool-prefix discovery for client-owned multi-KB operations
+
+**Decision.** `GET /health` now advertises each mounted KB's effective tool-name prefix
+(`mcpserver.KBInfo.ToolPrefix`, populated at mount time), and every client-owned direct tool call is
+qualified from that snapshot rather than from a locally recomputed prefix
+(`resolveKBTargets`/`qualifyTool`/`callTool` in `cmd/cartographer/multikb.go`, used by `sync`,
+`reindex` and the TUI). The discovered value is used live and never persisted. The TUI's MCP-config
+badge becomes three-state — `in-sync`, `partial`, `missing` — computed against **all** expected
+multi-KB entries instead of collapsing an incomplete configuration to `missing`. Remote failures
+carry a typed taxonomy that separates a server that never answered from a server that answered with
+a protocol or tool error, so the latter is no longer displayed as `unreachable`. This is a corrective
+extension of D102: the prefix remains opt-in and default-off.
+
+**Rationale.** D102 let an operator choose an arbitrary `tool_prefix`, but the client kept deriving
+the namespace from the KB name. On any installation whose prefix was not exactly the sanitised KB
+name, every client-owned call named a tool that did not exist. The symptom reached the operator as
+two false diagnostics — `mcp-config missing` and `artifacts: server unreachable` — that pointed at
+the network and the provider config while the server was healthy and correctly configured. Discovery
+is the only sound fix: the prefix is server state, so the server must report it. Not persisting it
+keeps client and server from drifting when a prefix changes. The badge and the error taxonomy are
+part of the same defect: a diagnostic that misattributes a failure costs more than the failure.
+
+**Consequences.** `/health` grows a field; the key is omitted when empty, so an older client parsing
+the response is unaffected and an unprefixed deployment sees a byte-identical body. Every direct
+tool call now depends on a successful `/health` first — a client that cannot reach health cannot
+qualify a call, which is why an unreachable server is reported as exactly that and not as a tool
+failure. The three-state badge means an operator who previously read `missing` on a partially
+provisioned multi-KB setup now reads `partial`: same underlying state, but it no longer suggests
+nothing was written. `server_url` in the client config is still expected to include the `/mcp` path
+segment; `/health` is derived from it by stripping that segment, unchanged from before.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -215,6 +215,14 @@ configured is `kiro` and 2+ MCP entries (i.e. 2+ KBs) are about to be written, r
 whether the server actually has prefixes configured (the client has no way to probe that): the
 operator adds `tool_prefix`/`tool_prefix_mode` to the server config as the fix.
 
+`GET /health`'s `kbs[]` items carry the KB's *effective* prefix as `tool_prefix` (omitted when
+unprefixed) — the exact sanitised value the server registered its tools under, whether it came
+from an explicit `kbs[].tool_prefix` or a derived `kb-name` mode (D120). Client-owned direct
+administrative tool calls (`cartographer sync`'s `sync_pull`, `cartographer reindex`) discover
+this value from a live `/health` snapshot before qualifying the tool name; they never re-derive
+it from the server's own YAML. A stale client selection (a configured KB no longer among the
+KBs the server currently advertises) is reported as an explicit error rather than guessed.
+
 ### Environment variables
 
 Every startup option has a corresponding environment variable (the CLI flag takes precedence):

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -74,6 +74,12 @@ When client and server don't share a filesystem (`internal/client`, `internal/cl
 3. `Apply` materializes/prunes and writes the v2 lockfile;
 4. pruning remains managed-only.
 
+Each `sync_pull` call (and the equivalent `cartographer reindex` remote call) is qualified with
+that KB's tool-name prefix (D102), discovered from a live `/health` snapshot rather than
+re-derived client-side (D120: `resolveKBTargets`/`qualifyTool` in `cmd/cartographer/multikb.go`).
+This keeps the client plumbing correct whether the server prefixes tools or not — an unprefixed
+KB is called unchanged, exactly as before D120.
+
 ## Security
 
 - **Cryptographic signature gate.** A configured KB signer creates a canonical Ed25519 envelope over domain, format version, source KB, kind, name, version and content hash. The remote client recomputes the content hash and verifies against out-of-band `signing_keys` pins before writing any provider file or lockfile. `signed:true` is verification output only; malformed, invalid, source-mismatched, unknown-key or tampered content fails the whole sync. Bundled artifacts use the separate `built_in:true` origin.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -90,6 +90,13 @@ since a log missing an operation that actually happened is worse than no log.
 `15_operational_audit` closes the loop end-to-end by tampering with a recorded
 entry and requiring `audit verify` and `audit export` to fail on it.
 
+**Prefixed multi-KB is exercised with an arbitrary prefix.** `16_prefixed_multikb`
+sets `tool_prefix` to a string unrelated to the KB name, precisely so a client
+that re-derived the prefix from the KB name instead of discovering it from
+`/health` fails the scenario. It also asserts the negative — the bare tool name
+must *not* resolve on the prefixed KB — because the D102 promise is that
+prefixing is exact, not additive.
+
 ## What is deliberately not in CI
 
 - Whether a particular model interprets an instruction well.

--- a/docs/transport-auth.md
+++ b/docs/transport-auth.md
@@ -186,3 +186,21 @@ the two situations stay distinguishable.
 Authorization and optimistic content hashes do not depend on an MCP session.
 Per-KB conflict and provisioning state is stored outside versioned concept
 content where required.
+
+## Tool namespace discovery
+
+`GET /health` reports, per mounted KB, the **effective** tool-name prefix under
+which that KB's tools are registered (`tool_prefix`, empty when unprefixed —
+the default). This is the authoritative source for any client that needs to
+call a tool by name (D120).
+
+Clients must not re-derive the prefix from the KB name: `tool_prefix` is an
+arbitrary operator-chosen string, so a derived value is a guess that produces
+calls to tools that do not exist. The value is read live per operation and
+never persisted, so an operator changing a prefix server-side does not require
+any client-side reconnection.
+
+Prefixing is exact, not additive: on a prefixed KB the bare tool name does not
+resolve. It applies uniformly to every tool the KB registers, including the
+ones hidden by the `agent` tools profile, so the advanced/operator tools stay
+reachable by name under the same namespace.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -21,6 +22,68 @@ import (
 // probing a server before committing to a connect (Ping, D64) can tell "wrong
 // token/env" apart from "server unreachable" and word their error accordingly.
 var ErrUnauthorized = errors.New("unauthorized (401): check the bearer token/env var")
+
+// RemoteState classifies a RemoteError as either the server being completely
+// unreachable/unusable (RemoteUnavailable: DNS/connection failure, HTTP
+// non-2xx, 401) or reached-but-this-call-failed (RemoteFailed: a malformed
+// JSON-RPC response, a JSON-RPC error object, or a tool result with
+// isError:true — e.g. an unqualified tool name after a healthy discovery,
+// the D120 regression this taxonomy exists to distinguish). Callers
+// (cmd/cartographer's status/TUI panels) render on this distinction instead
+// of a single hardcoded "server unreachable".
+type RemoteState string
+
+const (
+	RemoteUnavailable RemoteState = "unavailable"
+	RemoteFailed      RemoteState = "error"
+)
+
+// Remote error codes (D120): stable, machine-readable strings surfaced in
+// `cartographer status --output json` and matched by cmd/cartographer's
+// unified classifier.
+const (
+	CodeDNSFailed    = "dns_failed"
+	CodeUnreachable  = "unreachable"
+	CodeUnauthorized = "unauthorized"
+	CodeHTTPFailed   = "http_failed"
+	CodeMCPFailed    = "mcp_failed"
+)
+
+// RemoteError is returned by MCPClient's do/Call/Health/Ping for every
+// failure that involves the network or the remote server's response.
+// Local-only errors that never reach the network (an invalid server URL, a
+// JSON marshal failure) are not wrapped — only genuinely remote-shaped
+// failures are, so errors.As(err, &client.RemoteError{}) reliably means "we
+// talked to (or tried to talk to) the network for this call".
+type RemoteError struct {
+	State   RemoteState
+	Code    string
+	Message string
+	Cause   error
+}
+
+func (e *RemoteError) Error() string {
+	if e.Cause != nil {
+		return fmt.Sprintf("%s: %v", e.Message, e.Cause)
+	}
+	return e.Message
+}
+
+// Unwrap exposes Cause so errors.Is/As (including the pre-D120
+// errors.Is(err, ErrUnauthorized) check callers already rely on) keeps
+// working through a RemoteError.
+func (e *RemoteError) Unwrap() error { return e.Cause }
+
+// classifyDialErr distinguishes a DNS failure from any other dial-time
+// network error (connection refused, timeout, ...), mirroring the
+// pre-existing cmd/cartographer/status_snapshot.go classification.
+func classifyDialErr(err error) string {
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return CodeDNSFailed
+	}
+	return CodeUnreachable
+}
 
 // MCPClient is a minimal JSON-RPC 2.0 client for the MCP `tools/call` method.
 type MCPClient struct {
@@ -45,8 +108,14 @@ type Health struct {
 // HealthKB is the additive per-KB item returned by a MultiKB server's
 // /health endpoint. A single-KB (and older) server omits the kbs field
 // altogether, which callers distinguish through Health.KBs being nil.
+// ToolPrefix (D120) is the effective, already-sanitised tool-name prefix
+// (mcpserver.KBInfo.ToolPrefix) this KB's tools are registered under; empty
+// means unprefixed, which is also what an older server (that never sent the
+// field at all) decodes to — additive, byte-compatible with pre-D120
+// servers/clients.
 type HealthKB struct {
-	Name string `json:"name"`
+	Name       string `json:"name"`
+	ToolPrefix string `json:"tool_prefix,omitempty"`
 }
 
 // UnmarshalJSON accepts the current {"name":"..."} health shape and the
@@ -151,27 +220,34 @@ func (c *MCPClient) do(method string, params any) (json.RawMessage, error) {
 
 	resp, err := c.HTTP.Do(httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("client: request to %s: %w", reqURL, err)
+		return nil, &RemoteError{State: RemoteUnavailable, Code: classifyDialErr(err),
+			Message: fmt.Sprintf("could not reach %s", reqURL), Cause: err}
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 8*1024*1024))
 	if err != nil {
-		return nil, fmt.Errorf("client: read response: %w", err)
+		return nil, &RemoteError{State: RemoteUnavailable, Code: CodeHTTPFailed,
+			Message: fmt.Sprintf("could not read response from %s", reqURL), Cause: err}
 	}
 	if resp.StatusCode != http.StatusOK {
 		if resp.StatusCode == http.StatusUnauthorized {
-			return nil, fmt.Errorf("client: %s: %w", reqURL, ErrUnauthorized)
+			return nil, &RemoteError{State: RemoteUnavailable, Code: CodeUnauthorized,
+				Message: fmt.Sprintf("%s rejected the request", reqURL), Cause: ErrUnauthorized}
 		}
-		return nil, fmt.Errorf("client: %s returned HTTP %d: %s", reqURL, resp.StatusCode, respBody)
+		return nil, &RemoteError{State: RemoteUnavailable, Code: CodeHTTPFailed,
+			Message: fmt.Sprintf("%s returned HTTP %d", reqURL, resp.StatusCode),
+			Cause:   fmt.Errorf("%s", respBody)}
 	}
 
 	var rpcResp rpcResponse
 	if err := json.Unmarshal(respBody, &rpcResp); err != nil {
-		return nil, fmt.Errorf("client: decode JSON-RPC response: %w", err)
+		return nil, &RemoteError{State: RemoteFailed, Code: CodeMCPFailed,
+			Message: fmt.Sprintf("invalid JSON-RPC response from %s", reqURL), Cause: err}
 	}
 	if rpcResp.Error != nil {
-		return nil, fmt.Errorf("client: JSON-RPC error %d: %s", rpcResp.Error.Code, rpcResp.Error.Message)
+		return nil, &RemoteError{State: RemoteFailed, Code: CodeMCPFailed,
+			Message: fmt.Sprintf("JSON-RPC error %d: %s", rpcResp.Error.Code, rpcResp.Error.Message)}
 	}
 	return rpcResp.Result, nil
 }
@@ -220,23 +296,28 @@ func (c *MCPClient) Health(timeout time.Duration) (*Health, error) {
 
 	resp, err := hc.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("client: health request to %s: %w", u, err)
+		return nil, &RemoteError{State: RemoteUnavailable, Code: classifyDialErr(err),
+			Message: fmt.Sprintf("could not reach %s", u), Cause: err}
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		if resp.StatusCode == http.StatusUnauthorized {
-			return nil, fmt.Errorf("client: %s: %w", u, ErrUnauthorized)
+			return nil, &RemoteError{State: RemoteUnavailable, Code: CodeUnauthorized,
+				Message: fmt.Sprintf("%s rejected the request", u), Cause: ErrUnauthorized}
 		}
 		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 8*1024*1024))
 		if readErr != nil {
-			return nil, fmt.Errorf("client: read health response: %w", readErr)
+			return nil, &RemoteError{State: RemoteUnavailable, Code: CodeHTTPFailed,
+				Message: fmt.Sprintf("could not read response from %s", u), Cause: readErr}
 		}
-		return nil, fmt.Errorf("client: %s returned HTTP %d: %s", u, resp.StatusCode, body)
+		return nil, &RemoteError{State: RemoteUnavailable, Code: CodeHTTPFailed,
+			Message: fmt.Sprintf("%s returned HTTP %d", u, resp.StatusCode), Cause: fmt.Errorf("%s", body)}
 	}
 
 	var health Health
 	if err := json.NewDecoder(io.LimitReader(resp.Body, 8*1024*1024)).Decode(&health); err != nil {
-		return nil, fmt.Errorf("client: decode health response: %w", err)
+		return nil, &RemoteError{State: RemoteFailed, Code: CodeMCPFailed,
+			Message: fmt.Sprintf("invalid health response from %s", u), Cause: err}
 	}
 	return &health, nil
 }
@@ -250,13 +331,16 @@ func (c *MCPClient) Call(tool string, args any) (json.RawMessage, error) {
 
 	var tr toolResult
 	if err := json.Unmarshal(raw, &tr); err != nil {
-		return nil, fmt.Errorf("client: decode tool result for %q: %w", tool, err)
+		return nil, &RemoteError{State: RemoteFailed, Code: CodeMCPFailed,
+			Message: fmt.Sprintf("invalid tool result for %q", tool), Cause: err}
 	}
 	if len(tr.Content) == 0 {
-		return nil, fmt.Errorf("client: tool %q returned no content", tool)
+		return nil, &RemoteError{State: RemoteFailed, Code: CodeMCPFailed,
+			Message: fmt.Sprintf("tool %q returned no content", tool)}
 	}
 	if tr.IsError {
-		return nil, fmt.Errorf("client: tool %q returned an error: %s", tool, tr.Content[0].Text)
+		return nil, &RemoteError{State: RemoteFailed, Code: CodeMCPFailed,
+			Message: fmt.Sprintf("tool %q returned an error: %s", tool, tr.Content[0].Text)}
 	}
 	texts := make([]string, 0, len(tr.Content))
 	for _, block := range tr.Content {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -127,6 +128,32 @@ func TestCall_ToolError(t *testing.T) {
 	}
 }
 
+// TestCall_ToolError_ClassifiesAsRemoteFailed is the exact D120 regression
+// scenario: the server is reachable (it returns a valid JSON-RPC response)
+// but the requested tool doesn't exist there (e.g. a stale/unqualified tool
+// name) — this must classify as RemoteFailed/mcp_failed, never as
+// RemoteUnavailable (which would render as "server unreachable").
+func TestCall_ToolError_ClassifiesAsRemoteFailed(t *testing.T) {
+	srv := fakeMCPServer(t, "")
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	_, err := c.Call("err_tool", map[string]any{})
+	var re *client.RemoteError
+	if !errors.As(err, &re) {
+		t.Fatalf("err = %v, want a *client.RemoteError", err)
+	}
+	if re.State != client.RemoteFailed {
+		t.Errorf("State = %q, want %q", re.State, client.RemoteFailed)
+	}
+	if re.Code != client.CodeMCPFailed {
+		t.Errorf("Code = %q, want %q", re.Code, client.CodeMCPFailed)
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("error = %v, want it to preserve the tool's error text", err)
+	}
+}
+
 func TestCall_WithKB(t *testing.T) {
 	srv := fakeMCPServer(t, "")
 	defer srv.Close()
@@ -149,6 +176,87 @@ func TestCall_Unreachable(t *testing.T) {
 	c := client.New("http://127.0.0.1:1", "")
 	if _, err := c.Call("ok_tool", map[string]any{}); err == nil {
 		t.Fatal("expected error for unreachable server, got nil")
+	}
+}
+
+// TestCall_Unreachable_ClassifiesAsRemoteUnavailable is the dial-time
+// counterpart of TestCall_ToolError_ClassifiesAsRemoteFailed: a connection
+// that never reaches an HTTP server classifies as RemoteUnavailable, code
+// unreachable (not dns_failed: 127.0.0.1 resolves fine, the connection is
+// refused).
+func TestCall_Unreachable_ClassifiesAsRemoteUnavailable(t *testing.T) {
+	c := client.New("http://127.0.0.1:1", "")
+	_, err := c.Call("ok_tool", map[string]any{})
+	var re *client.RemoteError
+	if !errors.As(err, &re) {
+		t.Fatalf("err = %v, want a *client.RemoteError", err)
+	}
+	if re.State != client.RemoteUnavailable {
+		t.Errorf("State = %q, want %q", re.State, client.RemoteUnavailable)
+	}
+	if re.Code != client.CodeUnreachable {
+		t.Errorf("Code = %q, want %q", re.Code, client.CodeUnreachable)
+	}
+}
+
+// TestCall_Unauthorized_ClassifiesAsRemoteUnavailable confirms 401 responses
+// keep classifying as RemoteUnavailable/unauthorized, and that
+// errors.Is(err, client.ErrUnauthorized) still works through the
+// RemoteError wrapper (pre-D120 callers rely on this).
+func TestCall_Unauthorized_ClassifiesAsRemoteUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	_, err := client.New(srv.URL, "wrong-token").Call("ok_tool", map[string]any{})
+	var re *client.RemoteError
+	if !errors.As(err, &re) {
+		t.Fatalf("err = %v, want a *client.RemoteError", err)
+	}
+	if re.State != client.RemoteUnavailable || re.Code != client.CodeUnauthorized {
+		t.Errorf("State/Code = %q/%q, want %q/%q", re.State, re.Code, client.RemoteUnavailable, client.CodeUnauthorized)
+	}
+	if !errors.Is(err, client.ErrUnauthorized) {
+		t.Fatalf("expected errors.Is(err, client.ErrUnauthorized) through the RemoteError wrapper, got %v", err)
+	}
+}
+
+// TestCall_MalformedJSONRPCResponse_ClassifiesAsRemoteFailed: a reachable
+// server (HTTP 200) that returns a body that isn't valid JSON-RPC classifies
+// as RemoteFailed/mcp_failed, alongside the tool-level isError:true case.
+func TestCall_MalformedJSONRPCResponse_ClassifiesAsRemoteFailed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	_, err := client.New(srv.URL, "").Call("ok_tool", map[string]any{})
+	var re *client.RemoteError
+	if !errors.As(err, &re) {
+		t.Fatalf("err = %v, want a *client.RemoteError", err)
+	}
+	if re.State != client.RemoteFailed || re.Code != client.CodeMCPFailed {
+		t.Errorf("State/Code = %q/%q, want %q/%q", re.State, re.Code, client.RemoteFailed, client.CodeMCPFailed)
+	}
+}
+
+// TestCall_HTTPStatusFailure_ClassifiesAsRemoteUnavailable: a non-401 HTTP
+// failure status (e.g. 500) classifies as RemoteUnavailable/http_failed.
+func TestCall_HTTPStatusFailure_ClassifiesAsRemoteUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := client.New(srv.URL, "").Call("ok_tool", map[string]any{})
+	var re *client.RemoteError
+	if !errors.As(err, &re) {
+		t.Fatalf("err = %v, want a *client.RemoteError", err)
+	}
+	if re.State != client.RemoteUnavailable || re.Code != client.CodeHTTPFailed {
+		t.Errorf("State/Code = %q/%q, want %q/%q", re.State, re.Code, client.RemoteUnavailable, client.CodeHTTPFailed)
 	}
 }
 
@@ -251,6 +359,57 @@ func TestHealth_StripsMCPPathAndParsesVersion(t *testing.T) {
 	}
 	if health.Status != "ok" || health.Version != "v1.2.3" || health.Ready != nil || health.KBs == nil || len(*health.KBs) != 0 {
 		t.Errorf("Health = %+v, want status=ok version=v1.2.3 ready=nil kbs=empty-present", health)
+	}
+}
+
+// TestHealth_DecodesToolPrefix is D120: the client must decode each KB's
+// advertised tool_prefix, and keep tolerating the older shapes (string-only
+// KB list, or no tool_prefix field at all) as an empty (unprefixed) value.
+func TestHealth_DecodesToolPrefix(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"ok","kbs":[{"name":"alpha"},{"name":"beta","tool_prefix":"custom_name"}]}`))
+	}))
+	defer srv.Close()
+
+	health, err := client.New(srv.URL, "").Health(time.Second)
+	if err != nil {
+		t.Fatalf("Health: %v", err)
+	}
+	if health.KBs == nil || len(*health.KBs) != 2 {
+		t.Fatalf("KBs = %+v, want 2 entries", health.KBs)
+	}
+	kbs := *health.KBs
+	if kbs[0].Name != "alpha" || kbs[0].ToolPrefix != "" {
+		t.Errorf("kbs[0] = %+v, want Name=alpha ToolPrefix=\"\"", kbs[0])
+	}
+	if kbs[1].Name != "beta" || kbs[1].ToolPrefix != "custom_name" {
+		t.Errorf("kbs[1] = %+v, want Name=beta ToolPrefix=custom_name", kbs[1])
+	}
+}
+
+// TestHealth_ToolPrefixAbsentOnLegacyShapes confirms both older shapes an
+// existing client already tolerates — the bare string-array KB list, and an
+// object KB entry that predates tool_prefix entirely — decode to an empty
+// (unprefixed) ToolPrefix rather than failing.
+func TestHealth_ToolPrefixAbsentOnLegacyShapes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"ok","kbs":["alpha","beta"]}`))
+	}))
+	defer srv.Close()
+
+	health, err := client.New(srv.URL, "").Health(time.Second)
+	if err != nil {
+		t.Fatalf("Health: %v", err)
+	}
+	if health.KBs == nil || len(*health.KBs) != 2 {
+		t.Fatalf("KBs = %+v, want 2 entries", health.KBs)
+	}
+	for _, kb := range *health.KBs {
+		if kb.ToolPrefix != "" {
+			t.Errorf("kb %+v: ToolPrefix = %q, want empty for the legacy string-array shape", kb, kb.ToolPrefix)
+		}
 	}
 }
 

--- a/internal/mcpserver/httpserver.go
+++ b/internal/mcpserver/httpserver.go
@@ -292,6 +292,14 @@ type KBInfo struct {
 	Name   string `json:"name"`
 	Root   string `json:"root"`
 	Status string `json:"status"` // "normal", "syncing", "needs-resolution"
+	// ToolPrefix is the effective tool-name prefix (D102) this KB's tools were
+	// registered under, e.g. "ai_team" for tools named "ai_team__concept_read".
+	// Empty (omitted) for an unprefixed KB — the same shape a pre-D120 client
+	// already tolerates (see client.HealthKB). Set once, at mount time, from
+	// the exact sanitised value MountKBWithPrefix passed to
+	// Server.SetToolNamePrefix (D120): clients discover it here rather than
+	// re-deriving config.ResolveToolPrefix themselves.
+	ToolPrefix string `json:"tool_prefix,omitempty"`
 }
 
 // MultiKBServer wraps multiple KB instances served by a single HTTP server.
@@ -352,7 +360,7 @@ func (m *MultiKBServer) MountKBWithPrefix(name, prefix string, setupFn func(s *S
 		}
 	}
 	m.servers[name] = srv
-	m.kbs = append(m.kbs, KBInfo{Name: name, Status: "normal"})
+	m.kbs = append(m.kbs, KBInfo{Name: name, Status: "normal", ToolPrefix: prefix})
 	return nil
 }
 

--- a/internal/mcpserver/httpserver_test.go
+++ b/internal/mcpserver/httpserver_test.go
@@ -159,6 +159,55 @@ func TestMultiKB_Health_IncludesReady(t *testing.T) {
 	}
 }
 
+// TestMultiKB_Health_AdvertisesToolPrefix is D120: /health must expose each
+// mounted KB's effective tool-name prefix so clients discover it instead of
+// re-deriving config.ResolveToolPrefix themselves.
+func TestMultiKB_Health_AdvertisesToolPrefix(t *testing.T) {
+	multi := NewMultiKBServer("test")
+	k1 := setupTestKB(t)
+	if err := multi.MountKBWithPrefix("alpha", "", func(s *Server) { RegisterKBTools(s, k1, Deps{}) }); err != nil {
+		t.Fatalf("MountKBWithPrefix(alpha): %v", err)
+	}
+	k2 := setupTestKB(t)
+	if err := multi.MountKBWithPrefix("beta", "custom_name", func(s *Server) { RegisterKBTools(s, k2, Deps{}) }); err != nil {
+		t.Fatalf("MountKBWithPrefix(beta): %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rr := httptest.NewRecorder()
+	multi.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("/health: status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+
+	var body struct {
+		KBs []struct {
+			Name       string `json:"name"`
+			ToolPrefix string `json:"tool_prefix"`
+		} `json:"kbs"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON body: %v; body=%s", err, rr.Body.String())
+	}
+	byName := make(map[string]string, len(body.KBs))
+	for _, kb := range body.KBs {
+		byName[kb.Name] = kb.ToolPrefix
+	}
+	if got := byName["alpha"]; got != "" {
+		t.Fatalf("alpha tool_prefix = %q, want empty (unprefixed)", got)
+	}
+	if got := byName["beta"]; got != "custom_name" {
+		t.Fatalf("beta tool_prefix = %q, want \"custom_name\"", got)
+	}
+
+	// The raw body must carry exactly one "tool_prefix" occurrence (beta's):
+	// the unprefixed KB (alpha) omits the field entirely (json:",omitempty"),
+	// preserving the exact shape a pre-D120 client already tolerates.
+	if n := strings.Count(rr.Body.String(), `"tool_prefix"`); n != 1 {
+		t.Fatalf(`"tool_prefix" occurrences = %d, want 1 (only beta's); body=%s`, n, rr.Body.String())
+	}
+}
+
 func TestServer_Health_IncludesReady(t *testing.T) {
 	s := New("test")
 	handler := s.HTTPHandler()

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -32,6 +32,7 @@ overrides the default base port.
 | `13_stdio_mcp` | D116 trusted stdio MCP lifecycle across all provider configurations |
 | `14_rbac_visibility` | D118 fine-grained RBAC: per-KB collection visibility, exact-resource non-disclosure, out-of-perimeter write denial, admin/legacy retrocompatibility |
 | `15_operational_audit` | D119 compliance audit: attempt/completion event pairs, chain verification, export, tamper detection |
+| `16_prefixed_multikb` | D120 prefixed multi-KB: prefix discovery via /health, prefixed vs bare tool resolution, client connect/status/sync/reindex without false diagnostics |
 
 The numbering is retained to preserve historical references. Removed gaps were
 LLM-driven scenarios; model behavior is evaluated during real usage, not in the
@@ -60,6 +61,7 @@ test/e2e/
     13_stdio_mcp.sh
     14_rbac_visibility.sh
     15_operational_audit.sh
+    16_prefixed_multikb.sh
 ```
 
 Each scenario creates its own directory under `E2E_TMP_DIR`, owns the server

--- a/test/e2e/scenarios/16_prefixed_multikb.sh
+++ b/test/e2e/scenarios/16_prefixed_multikb.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# scenarios/16_prefixed_multikb.sh — OPERATOR scenario: prefixed multi-KB installation (D120).
+#
+# A two-KB server where ONE KB carries an arbitrary explicit tool_prefix (D102)
+# and the other does not. Before D120 the client re-derived the prefix locally,
+# so every client-owned direct tool call against the prefixed KB failed and was
+# reported as "server unreachable" / "mcp-config missing".
+#
+# Verifies (operator channel only, curl + CLI — no agent/model):
+#   1. /health advertises the effective per-KB tool prefix, so the namespace is
+#      discoverable without re-deriving it client-side.
+#   2. The prefixed KB answers on its prefixed tool names and NOT on the bare
+#      ones; the unprefixed KB is unchanged (the D102 default-off promise).
+#   3. `cartographer connect` writes one MCP entry per KB.
+#   4. `status`, `sync` and remote `reindex` succeed against both KBs and emit
+#      no false unreachable/missing diagnostic.
+#
+# Expected environment variables: E2E_TMP_DIR, E2E_HTTP_PORT, REPO_ROOT.
+
+set -uo pipefail
+
+SCENARIO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_DIR="$(cd "${SCENARIO_DIR}/.." && pwd)"
+
+# shellcheck source=../lib/assert.sh
+source "${E2E_DIR}/lib/assert.sh"
+# shellcheck source=../lib/kb.sh
+source "${E2E_DIR}/lib/kb.sh"
+# shellcheck source=../lib/server.sh
+source "${E2E_DIR}/lib/server.sh"
+
+SCENARIO_NAME="16_prefixed_multikb"
+
+echo "=== Scenario ${SCENARIO_NAME} ==="
+
+DIR="${E2E_TMP_DIR}/${SCENARIO_NAME}"
+KB_PLAIN="plainkb"
+KB_PREFIXED="prefixedkb"
+# Deliberately unrelated to the KB name: the client must not be able to guess it.
+PREFIX="zzarb"
+KB_PLAIN_DIR="${DIR}/${KB_PLAIN}"
+KB_PREFIXED_DIR="${DIR}/${KB_PREFIXED}"
+CONFIG="${DIR}/config.yaml"
+SANDBOX="${DIR}/home"
+BIN="${REPO_ROOT}/bin/cartographer"
+SERVER_URL="http://127.0.0.1:${E2E_HTTP_PORT}/mcp"
+
+mkdir -p "$DIR" "$SANDBOX"
+kb_make "$KB_PLAIN_DIR"
+kb_make "$KB_PREFIXED_DIR"
+
+cat > "$CONFIG" <<YAML
+http: ":${E2E_HTTP_PORT}"
+init: true
+kbs:
+  - path: ${KB_PLAIN_DIR}
+    name: ${KB_PLAIN}
+  - path: ${KB_PREFIXED_DIR}
+    name: ${KB_PREFIXED}
+    tool_prefix: "${PREFIX}"
+YAML
+
+E2E_CONFIG="$CONFIG" server_start "${KB_PLAIN_DIR},${KB_PREFIXED_DIR}"
+server_wait_health 20
+trap 'server_stop' EXIT
+
+BASE="$SERVER_URL"
+
+echo ""
+echo "--- Phase 1: the prefix is discoverable from /health ---"
+
+HEALTH="${DIR}/health.json"
+curl -s "http://127.0.0.1:${E2E_HTTP_PORT}/health" -o "$HEALTH"
+assert_file_contains "$HEALTH" '"tool_prefix":"'"${PREFIX}"'"'
+assert_file_contains "$HEALTH" "$KB_PREFIXED"
+assert_file_contains "$HEALTH" "$KB_PLAIN"
+
+echo ""
+echo "--- Phase 2: tools answer on the advertised namespace ---"
+
+call_body() { printf '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"%s","arguments":{}}}' "$1"; }
+
+assert_mcp_ok "unprefixed KB: bare tool name works" \
+    "$(mcp_call "$BASE" "$KB_PLAIN" "" "$(call_body atlas_overview)")"
+assert_mcp_ok "prefixed KB: prefixed tool name works" \
+    "$(mcp_call "$BASE" "$KB_PREFIXED" "" "$(call_body "${PREFIX}__atlas_overview")")"
+
+# The bare name must NOT resolve on the prefixed KB: that is the failure D120
+# was reported for, and the reason the client must discover the prefix.
+BARE_ON_PREFIXED="$(mcp_call "$BASE" "$KB_PREFIXED" "" "$(call_body atlas_overview)")"
+if echo "$BARE_ON_PREFIXED" | grep -q '"isError":true'; then
+    _assert_pass "prefixed KB: bare tool name does not resolve"
+else
+    _assert_fail "prefixed KB: bare tool name unexpectedly resolved: ${BARE_ON_PREFIXED}"
+fi
+
+echo ""
+echo "--- Phase 3: client connect writes one entry per KB ---"
+
+(cd "$SANDBOX" && HOME="$SANDBOX" "$BIN" connect opencode --server-url "$SERVER_URL" --auto-trust) >"${DIR}/connect.log" 2>&1 || true
+
+OPENCODE_CFG="${SANDBOX}/.config/opencode/opencode.json"
+if [[ ! -f "$OPENCODE_CFG" ]]; then
+    OPENCODE_CFG="$(find "$SANDBOX" -name 'opencode.json' -print -quit 2>/dev/null)"
+fi
+assert_file_exists "$OPENCODE_CFG"
+assert_file_contains "$OPENCODE_CFG" "$KB_PLAIN"
+assert_file_contains "$OPENCODE_CFG" "$KB_PREFIXED"
+
+echo ""
+echo "--- Phase 4: status/sync/reindex report no false diagnostic ---"
+
+run_client() {
+    local out="$1"; shift
+    (cd "$SANDBOX" && HOME="$SANDBOX" "$BIN" "$@") >"$out" 2>&1
+    return $?
+}
+
+STATUS_OUT="${DIR}/status.log"
+run_client "$STATUS_OUT" status || true
+assert_file_not_contains "$STATUS_OUT" "server unreachable"
+assert_file_not_contains "$STATUS_OUT" "mcp-config  missing"
+
+SYNC_OUT="${DIR}/sync.log"
+if run_client "$SYNC_OUT" sync; then
+    _assert_pass "cartographer sync exits 0 against a prefixed multi-KB server"
+else
+    _assert_fail "cartographer sync failed: $(cat "$SYNC_OUT")"
+fi
+assert_file_not_contains "$SYNC_OUT" "unreachable"
+
+REINDEX_OUT="${DIR}/reindex.log"
+if run_client "$REINDEX_OUT" reindex; then
+    _assert_pass "remote reindex exits 0 on both KBs"
+else
+    _assert_fail "remote reindex failed: $(cat "$REINDEX_OUT")"
+fi
+assert_file_not_contains "$REINDEX_OUT" "unreachable"
+assert_file_not_contains "$REINDEX_OUT" "tool not found"
+
+echo ""
+if [[ "${E2E_FAILURES}" -eq 0 ]]; then
+    echo "[SCENARIO ${SCENARIO_NAME}] PASS"
+    exit 0
+else
+    echo "[SCENARIO ${SCENARIO_NAME}] FAIL (${E2E_FAILURES} assertion(s) failed)"
+    exit 1
+fi


### PR DESCRIPTION
D102 lets an operator pick an arbitrary per-KB `tool_prefix`, but the client kept deriving the namespace from the KB name. On any installation whose prefix was not exactly the sanitised KB name, every client-owned call named a tool that did not exist — and the failure surfaced as two *false* diagnostics, `mcp-config missing` and `artifacts: server unreachable`, pointing at the network and the provider config while the server was healthy.

- `GET /health` now advertises each KB's effective `tool_prefix` (omitted when empty, so an unprefixed deployment sends a byte-identical body).
- `sync`, `reindex` and the TUI qualify every direct tool call from that live snapshot via `resolveKBTargets`/`qualifyTool`, never from a locally recomputed prefix. The value is not persisted, so changing a prefix server-side needs no client reconnect.
- The TUI MCP-config badge is now three-state (`in-sync` / `partial` / `missing`) computed against all expected multi-KB entries, instead of collapsing a partially provisioned setup to `missing`.
- Remote failures carry a typed taxonomy separating "never answered" from "answered with a protocol or tool error", so the latter is no longer shown as `unreachable`.

Corrective extension of D102 — the prefix stays opt-in and default-off.

Tests: 10 unit tests across `internal/client`, `internal/mcpserver` and `cmd/cartographer` (prefix decoding, absence on legacy shapes, health advertisement, the four remote-error classes, multi-KB badge for both JSON and Codex TOML providers), plus 5 in `cmd/cartographer/toolprefix_client_test.go`.

`test/e2e/scenarios/16_prefixed_multikb.sh` (16 assertions) starts a two-KB server where one KB carries a prefix deliberately unrelated to its name — so a client that guessed the prefix fails the scenario — and asserts the negative too: the bare tool name must *not* resolve on the prefixed KB.

Docs: `transport-auth.md` (new §Tool namespace discovery), `configurator.md`, `deployment.md`, `sync.md`, `testing.md`, `test/e2e/README.md`, decision entry D120. `configurator.md` claimed the client could not tell from `/health` whether prefixes were configured — no longer true, rewritten.

Verified locally: `gofmt`, `go vet`, `go test ./...` clean, `make e2e` 12/12, `make smoke-http` clean.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)