### PR TITLE
test: cover filtered-search paging and the server Git profile YAML

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -343,3 +343,24 @@ func TestNormalizeAuthMode(t *testing.T) {
 		}
 	}
 }
+
+// TestLoadServerGitProfile pins the YAML surface of the server Git profile
+// (D117): the keys are operator-facing, so a silent rename or a missing
+// mapping would leave a configured profile inert rather than failing.
+func TestLoadServerGitProfile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	data := []byte("git:\n  profile: server\n  base_branch: main\n  working_branch: cartographer/wiki\n  forge: github\n  github_owner: acme\n  github_repository: wiki\n  github_api_url: https://api.github.test\n  github_token_env: CARTOGRAPHER_GITHUB_TOKEN\n")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Git.Profile != "server" || cfg.Git.BaseBranch != "main" || cfg.Git.WorkingBranch != "cartographer/wiki" || cfg.Git.Forge != "github" || cfg.Git.GitHubOwner != "acme" || cfg.Git.GitHubRepository != "wiki" {
+		t.Fatalf("server git config = %#v", cfg.Git)
+	}
+	if cfg.Git.GitHubAPIURL != "https://api.github.test" || cfg.Git.GitHubTokenEnv != "CARTOGRAPHER_GITHUB_TOKEN" {
+		t.Fatalf("server git endpoint/token config = %#v", cfg.Git)
+	}
+}

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -117,6 +117,16 @@ func TestStoreEmpty(t *testing.T) {
 	}
 }
 
+func TestStoreSearchFilteredFillsLimitAfterHiddenHits(t *testing.T) {
+	s := NewStore()
+	s.Add("hidden", Vector{1, 0})
+	s.Add("visible", Vector{0.8, 0.2})
+	hits := s.SearchFiltered(Vector{1, 0}, 1, func(id string) bool { return id != "hidden" })
+	if len(hits) != 1 || hits[0].ID != "visible" {
+		t.Fatalf("filtered hits = %+v, want visible", hits)
+	}
+}
+
 // -- OllamaEmbedder --
 
 func TestOllamaEmbed(t *testing.T) {

--- a/internal/search/index_test.go
+++ b/internal/search/index_test.go
@@ -140,3 +140,13 @@ func TestIndex_SearchLimit(t *testing.T) {
 		t.Fatalf("Search with limit 5: got %d hits, want 5", len(hits))
 	}
 }
+
+func TestIndex_SearchFilteredFillsLimitAfterHiddenHits(t *testing.T) {
+	idx := New()
+	idx.Add("hidden", "needle needle needle")
+	idx.Add("visible", "needle")
+	hits := idx.SearchFiltered("needle", "", 1, func(id string) bool { return id != "hidden" })
+	if len(hits) != 1 || hits[0].ID != "visible" {
+		t.Fatalf("filtered hits = %+v, want visible", hits)
+	}
+}

--- a/internal/sqlindex/sqlindex_test.go
+++ b/internal/sqlindex/sqlindex_test.go
@@ -1,6 +1,7 @@
 package sqlindex
 
 import (
+	"fmt"
 	"math"
 	"path/filepath"
 	"strings"
@@ -109,6 +110,29 @@ func TestSearchFTS_MultiTermFallback(t *testing.T) {
 	}
 	if len(hits) != 2 {
 		t.Fatalf("OR fallback got %+v, want 2 hits", hits)
+	}
+}
+
+func TestSearchFTSFilteredFillsLimitAcrossHiddenPages(t *testing.T) {
+	ix, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ix.Close()
+	for i := 0; i < ftsSearchBatch+1; i++ {
+		if err := ix.Upsert(fmt.Sprintf("hidden/%03d", i), fmt.Sprintf("h%d", i), "needle needle"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := ix.Upsert("visible", "visible", "needle"); err != nil {
+		t.Fatal(err)
+	}
+	hits, err := ix.SearchFTSFiltered("needle", "", 1, func(id string) bool { return !strings.HasPrefix(id, "hidden/") })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 1 || hits[0].ID != "visible" {
+		t.Fatalf("filtered FTS hits = %+v, want visible", hits)
 	}
 }
 


### PR DESCRIPTION
Four regression tests recovered from an abandoned working copy that predated the D114–D121 merges. Each one covers a gap the suite currently leaves open; the two that turned out to be redundant or to target code that never landed on `main` were discarded rather than adapted.

## Filtered search must fill the limit past hidden hits

`Store.SearchFiltered`, `Index.SearchFiltered` and `Index.SearchFTSFiltered` rank first and apply the permission predicate afterwards. If the top-ranked documents are hidden from the caller, a naive implementation returns a short page — the exact failure mode `docs/testing.md` calls out ("a filtered collection must not reveal hidden elements through a short page").

`TestSearchFTSFilteredFillsLimitAcrossHiddenPages` seeds `ftsSearchBatch + 1` hidden documents on purpose, so it only passes if the paging loop keeps reading. Verified by mutation: forcing the loop to stop after the first batch makes it fail with an empty result, so the assertion is a real guard rather than an incidental pass.

## The server Git profile YAML surface

`TestLoadServerGitProfile` pins the mapping of the D117 `git.*` keys, including `github_api_url` and `github_token_env`. Nothing currently loads them from YAML in a test: these are operator-facing keys, so a silent rename would leave a configured profile inert instead of failing at startup.

## Verification

`make vet` and `make test` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
