### PR TITLE
fix(configurator): preserve Codex-owned tables written inside a managed block

### DIFF
--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -356,6 +356,14 @@ file, which would otherwise be duplicate keys and stop Codex from starting, and 
 each removal as a `warning:` line. Everything else in the file — comments, ordering,
 unrelated tables, Codex's own `[hooks.state."…"]` bookkeeping — is left as it is (D99).
 
+Codex also places that same `[hooks.state."…"]` bookkeeping positionally after the last
+table it finds in the file — which, once a block has been written, is the one Cartographer
+owns. Before rewriting a block, `connect`/`sync` first relocate any table the block does
+not itself declare out of the span, verbatim, to just before the block's begin marker, so
+the next `blocktext.Write` cannot destroy it; each relocation is reported as its own
+`warning:` line (D126). Purely textual, like every other step of this reconciliation:
+`config.toml` is never parsed/re-serialized (D58).
+
 **Kiro**:
 ```json
 {

--- a/docs/decisions/client-configurator.md
+++ b/docs/decisions/client-configurator.md
@@ -262,3 +262,42 @@ its presentation and visible actions to terminal width and selection.
 and contradictory repeated errors. A small stable schema gives scripts a safe
 contract while keeping the terminal interface concise, and makes the dashboard
 an alternate view of the same facts rather than a second status implementation.
+
+---
+
+<a id="d126"></a>
+## D126 — Codex's `config.toml`: foreign tables written inside a managed block are relocated, not lost
+
+**Status: implemented (2026-08-04).**
+
+**Decision.** Before either Codex `config.toml` block rewrite, Cartographer moves out of the
+span every top-level table group that the block's next contents do not themselves declare
+(`configurator.EvictForeignTablesFromBlock`, `internal/configurator/codextoml.go`, sibling of
+D99's `AdoptCodexOrphanTables`). Foreign groups are cut from the span, verbatim, and re-inserted,
+in file order, immediately before the begin marker line, separated from their neighbours by at
+most one blank line (`joinSeam`); a key declared both inside the span and in the block's next
+contents is left alone — it is ours, `blocktext.Write` will overwrite it. Both call sites
+(`registerHookConfigTOML` in `internal/provisioning/hooksettings.go`, and the `.toml` branch of
+`configurator.Apply`) run the new eviction *before* D99's adoption and before `blocktext.Write`,
+so a table that is both foreign-in-span and adoption-owned collapses to one copy instead of a
+duplicate key. Purely textual, as D58 requires: no parse/re-serialize, every byte outside the
+moved spans preserved.
+
+**Rationale.** D99 made the write path idempotent against Codex's own rewrites by adopting the
+marker-less copies of tables Cartographer owns. It did not cover the mirror case: Codex records
+its per-hook trusted-hash bookkeeping (`[hooks.state."<config path>:<event>:<i>:<j>"]`) positionally
+after the last `[[hooks.*]]` table in the file — which, in a Cartographer-managed `config.toml`, is
+the one inside our own span. `blocktext.Write` replaces everything between its markers, so those
+tables were silently destroyed on the next `connect`/`sync`, even though `codexHookTableOwner`
+(D99) deliberately excludes `[hooks.state]` from adoption specifically to leave Codex's own
+bookkeeping alone — the write path was destroying what the adoption predicate was written to
+protect. Rewriting the relocated tables in canonical form would mean parsing/re-serializing
+`config.toml`, which D58 forbids; relocating them verbatim keeps the invariant that Cartographer
+owns only the text it wrote.
+
+**Consequences.** Codex no longer loses the trust record for hooks it had already approved when
+the state table happens to fall inside a managed block. `EvictForeignTablesFromBlock` reports each
+relocation as its own warning, mirroring D99's phrasing. The fix lives in `internal/configurator`
+next to the existing `codextoml.go` line/header/span primitives it reuses, not in `internal/blocktext`
+— that package stays provider-agnostic (it also serves the `AGENTS.md`/`CLAUDE.md` instruction
+block).

--- a/internal/configurator/codextoml.go
+++ b/internal/configurator/codextoml.go
@@ -296,8 +296,17 @@ func isSubKey(key, root []string) bool {
 	return true
 }
 
-// span is a byte range [start, end) of a config.toml.
-type span struct{ start, end int }
+// span is a byte range [start, end) of a config.toml, covered by the
+// Cartographer-managed block identified by id — the block id parsed from its
+// marker ("# cartographer:<id>:begin" / ":end"). bodyStart/bodyEnd are the
+// range strictly between the two marker lines (the marker lines themselves
+// excluded): table-group discovery must stay inside it, or the last group in
+// the block would absorb the end marker's own comment line.
+type span struct {
+	start, end         int
+	bodyStart, bodyEnd int
+	id                 string
+}
 
 // codexManagedSpans returns the byte ranges covered by the Cartographer-managed
 // blocks of content, marker lines included — every block, not just the one
@@ -306,6 +315,7 @@ type span struct{ start, end int }
 // be adopted.
 func codexManagedSpans(content string) []span {
 	open := map[string]int{}
+	openBody := map[string]int{}
 	var spans []span
 	for _, l := range codexLines(content) {
 		if !l.comment {
@@ -317,14 +327,43 @@ func codexManagedSpans(content string) []span {
 		}
 		if m[2] == "begin" {
 			open[m[1]] = l.start
+			openBody[m[1]] = l.end
 			continue
 		}
 		if start, ok := open[m[1]]; ok {
-			spans = append(spans, span{start: start, end: l.end})
+			spans = append(spans, span{start: start, end: l.end, bodyStart: openBody[m[1]], bodyEnd: l.start, id: m[1]})
 			delete(open, m[1])
+			delete(openBody, m[1])
 		}
 	}
 	return spans
+}
+
+// codexManagedSpanByID returns content's Cartographer-managed span whose
+// block id matches id, and whether one was found — false if the block is
+// absent, or its begin marker has no matching end (codexManagedSpans only
+// ever emits closed spans).
+func codexManagedSpanByID(content, id string) (span, bool) {
+	for _, s := range codexManagedSpans(content) {
+		if s.id == id {
+			return s, true
+		}
+	}
+	return span{}, false
+}
+
+// codexMarkerBlockID extracts the block id a Cartographer marker line
+// encodes ("# cartographer:<id>:begin" / ":end" — the display text after the
+// begin marker's " — " is not part of it, same as ReplaceBetween's "stable"
+// prefix), and whether marker is a well-formed one. Lets a caller holding
+// just a begin/end marker string, not the whole file, find its own span among
+// codexManagedSpans's.
+func codexMarkerBlockID(marker string) (string, bool) {
+	m := codexManagedMarker.FindStringSubmatch(strings.TrimSpace(marker))
+	if m == nil {
+		return "", false
+	}
+	return m[1], true
 }
 
 // overlapsAny reports whether g overlaps any of the spans.
@@ -335,4 +374,149 @@ func overlapsAny(g codexTableGroup, spans []span) bool {
 		}
 	}
 	return false
+}
+
+// codexTableGroupsInRange is codexTableGroups restricted to r: groups are
+// computed against r's own text, so a group can never spill past r.end into
+// content outside it (the same rule codexTableGroups applies at end-of-file
+// applies here at end-of-span instead) — offsets are then translated back
+// into content's coordinates.
+func codexTableGroupsInRange(content string, r span) []codexTableGroup {
+	groups := codexTableGroups(content[r.start:r.end])
+	for i := range groups {
+		groups[i].start += r.start
+		groups[i].end += r.start
+	}
+	return groups
+}
+
+// codexBodyHeaderKeys returns the key of every table header declared in
+// body, in the order they appear — the tables a managed block's next
+// contents (about to replace the span) declares.
+func codexBodyHeaderKeys(body string) [][]string {
+	var keys [][]string
+	for _, line := range strings.Split(body, "\n") {
+		if key, ok := codexTableHeaderKey(line); ok {
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}
+
+// keyDeclaredIn reports whether key exactly matches one of keys, segment by
+// segment — segments are already unquoted by splitTOMLKey, so a bare and a
+// quoted spelling of the same key compare equal.
+func keyDeclaredIn(key []string, keys [][]string) bool {
+	for _, k := range keys {
+		if keysEqual(key, k) {
+			return true
+		}
+	}
+	return false
+}
+
+func keysEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// EvictForeignTablesFromBlock moves out of the Cartographer-managed block
+// delimited by begin/end, in the config.toml at path, every top-level table
+// group that newBody — the block's next contents, about to replace the span
+// via blocktext.Write — does not declare. Codex records its own bookkeeping
+// (e.g. [hooks.state."…"] trusted-hash tables) positionally after the last
+// table it finds in the file, which in a Cartographer-managed config.toml can
+// land inside our span; blocktext.Write would otherwise destroy it along with
+// the rest of the block on the next rewrite, silently losing state that is
+// entirely Codex's own (D99's codexHookTableOwner deliberately leaves it
+// alone for the same reason).
+//
+// Foreign groups are cut from the span, verbatim, and re-inserted, in file
+// order, immediately before the begin marker line, separated from their
+// neighbours by at most one blank line — never merged or reformatted (D58:
+// config.toml is never parsed/re-serialized). A key declared both inside the
+// span and in newBody is ours: it is left in the block for blocktext.Write to
+// overwrite, never relocated.
+//
+// Returns the relocated keys (dotted, as segments joined) in file order, so
+// the caller can warn; no-op with no error if the file or the block is
+// absent, or nothing in the span is foreign.
+func EvictForeignTablesFromBlock(path, begin, end, newBody string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	content := string(data)
+
+	beginID, ok := codexMarkerBlockID(begin)
+	if !ok {
+		return nil, nil
+	}
+	if endID, ok := codexMarkerBlockID(end); !ok || endID != beginID {
+		return nil, nil
+	}
+	target, ok := codexManagedSpanByID(content, beginID)
+	if !ok {
+		return nil, nil
+	}
+
+	ownKeys := codexBodyHeaderKeys(newBody)
+	var foreign []codexTableGroup
+	for _, g := range codexTableGroupsInRange(content, span{start: target.bodyStart, end: target.bodyEnd}) {
+		if !keyDeclaredIn(g.key, ownKeys) {
+			foreign = append(foreign, g)
+		}
+	}
+	if len(foreign) == 0 {
+		return nil, nil
+	}
+
+	if err := os.WriteFile(path, []byte(evictGroupsFromSpan(content, target, foreign)), 0o644); err != nil {
+		return nil, err
+	}
+
+	relocated := make([]string, len(foreign))
+	for i, g := range foreign {
+		relocated[i] = strings.Join(g.key, ".")
+	}
+	return relocated, nil
+}
+
+// evictGroupsFromSpan cuts foreign (in file order, all within target) out of
+// content and re-inserts their verbatim text, stitched together and onto
+// their neighbours via joinSeam's blank-line accounting, immediately before
+// target's start (the begin marker line).
+func evictGroupsFromSpan(content string, target span, foreign []codexTableGroup) string {
+	spanPieces := make([]string, 0, len(foreign)+1)
+	removed := make([]string, 0, len(foreign))
+	last := target.start
+	for _, g := range foreign {
+		spanPieces = append(spanPieces, content[last:g.start])
+		removed = append(removed, content[g.start:g.end])
+		last = g.end
+	}
+	spanPieces = append(spanPieces, content[last:target.end])
+
+	strippedSpan := spanPieces[0]
+	for _, p := range spanPieces[1:] {
+		strippedSpan = joinSeam(strippedSpan, p)
+	}
+
+	relocated := removed[0]
+	for _, r := range removed[1:] {
+		relocated = joinSeam(relocated, r)
+	}
+
+	before := joinSeam(joinSeam(content[:target.start], relocated), strippedSpan)
+	return before + content[target.end:]
 }

--- a/internal/configurator/configurator.go
+++ b/internal/configurator/configurator.go
@@ -197,6 +197,19 @@ func Apply(results []*EmitResult, baseDir string, dryRun bool) ([]string, error)
 		// instead of parsing/re-serializing the user's hand-curated config.toml
 		// (D58) — see EmitResult.Content's doc comment.
 		if filepath.Ext(fullPath) == ".toml" {
+			// Codex may have written its own tables (e.g. [hooks.state.*]
+			// trusted-hash bookkeeping) inside the managed block, positionally
+			// after the last table it found in the file: relocate them out of
+			// the block before rewriting it, or they would be destroyed (D126).
+			evicted, err := EvictForeignTablesFromBlock(fullPath, codexMCPBlockBegin, codexMCPBlockEnd, string(r.Content))
+			if err != nil {
+				return written, fmt.Errorf("reconcile %s: %w", fullPath, err)
+			}
+			for _, key := range evicted {
+				r.Warnings = append(r.Warnings, fmt.Sprintf(
+					"codex: moved a Codex-owned [%s] table out of the managed block so it would not be lost on rewrite", key))
+			}
+
 			// Codex rewrites config.toml behind our back and drops the markers
 			// with every other comment: adopt the tables it left orphaned
 			// before writing the block, or they would become duplicate keys

--- a/internal/configurator/configurator_codex_test.go
+++ b/internal/configurator/configurator_codex_test.go
@@ -444,3 +444,204 @@ bearer_token_env_var = "CARTOGRAPHER_TOKENS"
 		t.Errorf("nothing left to adopt on re-apply, got warnings %v", warnings)
 	}
 }
+
+// --- EvictForeignTablesFromBlock (D126) ---
+
+const (
+	evictTestBegin = "# cartographer:hook:sops-warn:begin"
+	evictTestEnd   = "# cartographer:hook:sops-warn:end"
+	evictTestBody  = "[[hooks.PreToolUse]]\nmatcher = \"Bash\"\n[[hooks.PreToolUse.hooks]]\ntype = \"command\"\ncommand = \"/Users/me/.codex/hooks/sops-warn/hook.sh\"\n"
+)
+
+func TestEvictForeignTablesFromBlock_RelocatesStateWrittenInsideBlock(t *testing.T) {
+	dir := t.TempDir()
+	path := writeCodexConfig(t, dir, `model = "gpt-5.6"
+
+`+evictTestBegin+`
+[[hooks.PreToolUse]]
+matcher = "Bash"
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "/Users/me/.codex/hooks/sops-warn/hook.sh"
+
+[hooks.state."/Users/me/.codex/config.toml:pre_tool_use:0:0"]
+trusted_hash = "sha256:abc123"
+`+evictTestEnd+`
+
+[mcp_servers.other]
+url = "https://example.com/mcp"
+`)
+
+	relocated, err := configurator.EvictForeignTablesFromBlock(path, evictTestBegin, evictTestEnd, evictTestBody)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The relocated key is dotted, as segments joined (unquoted), same
+	// convention AdoptCodexOrphanTables already uses for its own removed keys.
+	want := `hooks.state./Users/me/.codex/config.toml:pre_tool_use:0:0`
+	if len(relocated) != 1 || relocated[0] != want {
+		t.Fatalf("relocated = %v, want [%s]", relocated, want)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+
+	stateIdx := strings.Index(got, `[hooks.state."`)
+	beginIdx := strings.Index(got, evictTestBegin)
+	endIdx := strings.Index(got, evictTestEnd)
+	if stateIdx < 0 || beginIdx < 0 || endIdx < 0 {
+		t.Fatalf("missing markers in:\n%s", got)
+	}
+	if !(stateIdx < beginIdx) {
+		t.Errorf("the state table must now sit before the begin marker, got:\n%s", got)
+	}
+	if strings.Contains(got[beginIdx:endIdx], "hooks.state") {
+		t.Errorf("the state table must not remain inside the block, got:\n%s", got)
+	}
+	if !strings.Contains(got, `trusted_hash = "sha256:abc123"`) {
+		t.Errorf("trusted_hash value lost: %s", got)
+	}
+	if !strings.Contains(got, `[mcp_servers.other]`) {
+		t.Errorf("unrelated content lost: %s", got)
+	}
+	if strings.Count(got, `[hooks.state."/Users/me/.codex/config.toml:pre_tool_use:0:0"]`) != 1 {
+		t.Errorf("state table duplicated: %s", got)
+	}
+}
+
+func TestEvictForeignTablesFromBlock_NoForeign_NoOp(t *testing.T) {
+	dir := t.TempDir()
+	content := evictTestBegin + "\n" + evictTestBody + evictTestEnd + "\n"
+	path := writeCodexConfig(t, dir, content)
+
+	relocated, err := configurator.EvictForeignTablesFromBlock(path, evictTestBegin, evictTestEnd, evictTestBody)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if relocated != nil {
+		t.Errorf("relocated = %v, want nil", relocated)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != content {
+		t.Errorf("file must be byte-identical when nothing is foreign, got:\n%s", data)
+	}
+}
+
+func TestEvictForeignTablesFromBlock_MultipleForeign_OrderPreserved_NoBlankLineAccumulation(t *testing.T) {
+	dir := t.TempDir()
+	path := writeCodexConfig(t, dir, evictTestBegin+`
+[[hooks.PreToolUse]]
+matcher = "Bash"
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "/Users/me/.codex/hooks/sops-warn/hook.sh"
+
+[hooks.state."a"]
+trusted_hash = "sha256:aaa"
+
+[hooks.state."b"]
+trusted_hash = "sha256:bbb"
+`+evictTestEnd+`
+`)
+
+	relocated, err := configurator.EvictForeignTablesFromBlock(path, evictTestBegin, evictTestEnd, evictTestBody)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantA, wantB := `hooks.state.a`, `hooks.state.b`
+	if len(relocated) != 2 || relocated[0] != wantA || relocated[1] != wantB {
+		t.Fatalf("relocated = %v, want [%s %s] in order", relocated, wantA, wantB)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+
+	aIdx := strings.Index(got, `[hooks.state."a"]`)
+	bIdx := strings.Index(got, `[hooks.state."b"]`)
+	beginIdx := strings.Index(got, evictTestBegin)
+	if aIdx < 0 || bIdx < 0 || beginIdx < 0 || !(aIdx < bIdx && bIdx < beginIdx) {
+		t.Fatalf("expected [a], then [b], then the begin marker, got:\n%s", got)
+	}
+	if strings.Contains(got, "\n\n\n") {
+		t.Errorf("blank lines accumulated:\n%s", got)
+	}
+}
+
+func TestEvictForeignTablesFromBlock_KeyDeclaredInBody_NotRelocated(t *testing.T) {
+	dir := t.TempDir()
+	path := writeCodexConfig(t, dir, evictTestBegin+`
+[[hooks.PreToolUse]]
+matcher = "Bash"
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "/Users/me/.codex/hooks/sops-warn/hook.sh"
+
+[[hooks.PreToolUse]]
+matcher = "Write"
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "/Users/me/.codex/hooks/sops-warn/other.sh"
+`+evictTestEnd+`
+`)
+
+	relocated, err := configurator.EvictForeignTablesFromBlock(path, evictTestBegin, evictTestEnd, evictTestBody)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if relocated != nil {
+		t.Errorf("relocated = %v, want nil: a key declared in newBody must never be relocated, even a second copy of it", relocated)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if strings.Index(got, `command = "/Users/me/.codex/hooks/sops-warn/other.sh"`) < strings.Index(got, evictTestBegin) {
+		t.Errorf("the second copy must stay inside the block, not before it:\n%s", got)
+	}
+	if n := strings.Count(got, `command = "/Users/me/.codex/hooks/sops-warn/other.sh"`); n != 1 {
+		t.Errorf("second copy must survive untouched, found %d occurrences:\n%s", n, got)
+	}
+}
+
+func TestEvictForeignTablesFromBlock_BlockAbsent_NoOp(t *testing.T) {
+	dir := t.TempDir()
+	content := "model = \"gpt-5.6\"\n"
+	path := writeCodexConfig(t, dir, content)
+
+	relocated, err := configurator.EvictForeignTablesFromBlock(path, evictTestBegin, evictTestEnd, evictTestBody)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if relocated != nil {
+		t.Errorf("relocated = %v, want nil when the block is absent", relocated)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != content {
+		t.Errorf("file must be untouched when the block is absent, got:\n%s", data)
+	}
+}
+
+func TestEvictForeignTablesFromBlock_MissingFile_NoOp(t *testing.T) {
+	relocated, err := configurator.EvictForeignTablesFromBlock(filepath.Join(t.TempDir(), ".codex", "config.toml"), evictTestBegin, evictTestEnd, evictTestBody)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if relocated != nil {
+		t.Errorf("relocated = %v, want nil when the file does not exist", relocated)
+	}
+}

--- a/internal/provisioning/hooksettings.go
+++ b/internal/provisioning/hooksettings.go
@@ -335,20 +335,38 @@ func registerHookConfigTOML(baseDir, hookName, fullDestDir string) (string, erro
 	fmt.Fprintf(&sb, "command = %s\n", configurator.QuoteTOMLString(command))
 
 	path := codexConfigTOMLPath(baseDir)
+	begin, end := codexHookMarkers(hookName)
+
+	// Codex may have written its own tables (e.g. [hooks.state.*] trusted-hash
+	// bookkeeping) inside this hook's managed block, positionally after the
+	// last [[hooks.*]] table it found in the file: relocate them out of the
+	// block before rewriting it, or they would be destroyed (D126).
+	evicted, err := configurator.EvictForeignTablesFromBlock(path, begin, end, sb.String())
+	if err != nil {
+		return "", fmt.Errorf("provisioning: reconcile %s: %w", path, err)
+	}
+
 	adopted, err := configurator.AdoptCodexOrphanTables(path, codexHookTableOwner(hookName))
 	if err != nil {
 		return "", fmt.Errorf("provisioning: reconcile %s: %w", path, err)
 	}
 
-	begin, end := codexHookMarkers(hookName)
 	if err := blocktext.Write(path, begin, end, sb.String()); err != nil {
 		return "", err
 	}
-	if len(adopted) == 0 {
-		return "", nil
+
+	var warnings []string
+	for _, key := range evicted {
+		warnings = append(warnings, fmt.Sprintf(
+			"codex: hook %q — moved a Codex-owned table (%s) out of the managed block so it would not be lost on rewrite",
+			hookName, key))
 	}
-	return fmt.Sprintf("codex: hook %q — removed %d stale registration(s) left outside the managed block by Codex's own config.toml rewrite (the hook would have fired twice)",
-		hookName, len(adopted)), nil
+	if len(adopted) > 0 {
+		warnings = append(warnings, fmt.Sprintf(
+			"codex: hook %q — removed %d stale registration(s) left outside the managed block by Codex's own config.toml rewrite (the hook would have fired twice)",
+			hookName, len(adopted)))
+	}
+	return strings.Join(warnings, "\n"), nil
 }
 
 // removeHookConfigTOML strips hookName's marker-delimited block (if present)

--- a/internal/provisioning/provisioning_codex_test.go
+++ b/internal/provisioning/provisioning_codex_test.go
@@ -500,3 +500,111 @@ command = "/Users/me/scripts/mine.sh"
 		}
 	}
 }
+
+// injectBeforeEndMarker inserts text into the config.toml at path immediately
+// before endMarker's line — simulating Codex persisting its own bookkeeping
+// (e.g. [hooks.state."…"]) positionally after the last table it finds in the
+// file, which lands inside a Cartographer-managed block once one has been
+// written (D126).
+func injectBeforeEndMarker(t *testing.T, path, endMarker, text string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	idx := strings.Index(content, endMarker)
+	if idx < 0 {
+		t.Fatalf("end marker %q not found in:\n%s", endMarker, content)
+	}
+	if err := os.WriteFile(path, []byte(content[:idx]+text+content[idx:]), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestApply_Codex_Hook_Eviction_PreservesStateWrittenInsideBlock(t *testing.T) {
+	// D126: Codex records its per-hook trusted-hash bookkeeping
+	// ([hooks.state."…"]) positionally after the last [[hooks.*]] table it
+	// finds in the file — which, once the hook is registered, is the one
+	// inside our own managed block. Re-registering the hook must relocate
+	// that table out of the block instead of destroying it with the rewrite.
+	kbRoot := t.TempDir()
+	writeCodexHookKB(t, kbRoot, "notify", "PostToolUse", "concept_write", "./notify.sh")
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
+	if err != nil {
+		t.Fatalf("BuildManifest: %v", err)
+	}
+
+	baseDir := t.TempDir()
+	opts := provisioning.ApplyOptions{
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderCodex,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
+	}
+	if _, err := provisioning.Apply(m, opts); err != nil {
+		t.Fatalf("Apply (1): %v", err)
+	}
+
+	configPath := filepath.Join(baseDir, ".codex", "config.toml")
+	stateTable := "\n[hooks.state.\"/Users/me/.codex/config.toml:post_tool_use:0:0\"]\ntrusted_hash = \"sha256:6a78\"\n"
+	injectBeforeEndMarker(t, configPath, "# cartographer:hook:notify:end", stateTable)
+
+	res, err := provisioning.Apply(m, opts)
+	if err != nil {
+		t.Fatalf("Apply (2): %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if !strings.Contains(got, `[hooks.state."/Users/me/.codex/config.toml:post_tool_use:0:0"]`) {
+		t.Fatalf("Codex's trusted-hash state table was lost:\n%s", got)
+	}
+	if !strings.Contains(got, `trusted_hash = "sha256:6a78"`) {
+		t.Errorf("state table's own content lost:\n%s", got)
+	}
+
+	stateIdx := strings.Index(got, `[hooks.state."`)
+	beginIdx := strings.Index(got, "# cartographer:hook:notify:begin")
+	endIdx := strings.Index(got, "# cartographer:hook:notify:end")
+	if stateIdx < 0 || beginIdx < 0 || endIdx < 0 {
+		t.Fatalf("missing markers in:\n%s", got)
+	}
+	if !(stateIdx < beginIdx) {
+		t.Errorf("the state table must now sit outside (before) the managed block, got:\n%s", got)
+	}
+	if strings.Contains(got[beginIdx:endIdx], "hooks.state") {
+		t.Errorf("the state table must not remain inside the managed block:\n%s", got)
+	}
+
+	var relocationWarned bool
+	for _, w := range res.Warnings {
+		if strings.Contains(w, "moved") && strings.Contains(w, "notify") {
+			relocationWarned = true
+		}
+	}
+	if !relocationWarned {
+		t.Errorf("expected a warning about the relocated table, got %v", res.Warnings)
+	}
+
+	// A second apply over the repaired file must be a no-op: the state table
+	// is already outside every managed span.
+	res2, err := provisioning.Apply(m, opts)
+	if err != nil {
+		t.Fatalf("Apply (3): %v", err)
+	}
+	data2, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data2) != got {
+		t.Errorf("re-apply over the repaired file must be a no-op:\nbefore:\n%s\nafter:\n%s", got, data2)
+	}
+	if len(res2.Warnings) != 0 {
+		t.Errorf("nothing left to relocate on re-apply, got warnings %v", res2.Warnings)
+	}
+}


### PR DESCRIPTION
Implements the plan issue #106 (D126).

Codex records its per-hook trusted-hash bookkeeping as `[hooks.state."…"]` tables, placed positionally after the last table it finds in `config.toml` — which, in a Cartographer-managed file, sits *inside* one of our marker-delimited blocks. `blocktext.Write` then replaced everything between `begin` and `end`, destroying state that is entirely Codex's own.

`EvictForeignTablesFromBlock` relocates, verbatim and just before the block's begin marker, every table group the block's next contents do not declare. Call-site order at both write sites is now evict → adopt → write, so a relocated table is visible to D99's adoption as a normal out-of-block table instead of becoming a duplicate key. Purely textual, as D58 requires.

Verified against a real `~/.codex/config.toml` that previously lost 11 lines per sync: the three `trusted_hash` tables now survive, outside every managed span, and the file stays valid TOML.

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)