### PR TITLE
fix(provisioning): adopt Codex hook registrations with inline commands

### DIFF
--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -356,6 +356,18 @@ file, which would otherwise be duplicate keys and stop Codex from starting, and 
 each removal as a `warning:` line. Everything else in the file — comments, ordering,
 unrelated tables, Codex's own `[hooks.state."…"]` bookkeeping — is left as it is (D99).
 
+Recognizing a hook's own orphaned registration among those copies cannot rely only on a
+path fragment into the hook's materialized directory (D99's original identity): a hook
+whose command is a self-contained inline one-liner (e.g. a `jq ...` command, not a script
+file) never contains one. `connect`/`sync` also match on the registration's `command`
+*value*, decoded regardless of which of the four TOML string forms it is spelled in —
+Codex re-serializes a command Cartographer wrote as a basic string (`"…"`) into a
+multi-line literal string (`'''…'''`) — and compared byte-exact against the command the
+hook currently registers. Both identities are accepted, so an older client's
+path-fragment-only registrations are still adopted (D127). A hook whose command changed
+in the narrow window between a Codex rewrite and the next sync matches neither identity
+and is left duplicated — accepted as a residual, two-fault edge case; see D127.
+
 Codex also places that same `[hooks.state."…"]` bookkeeping positionally after the last
 table it finds in the file — which, once a block has been written, is the one Cartographer
 owns. Before rewriting a block, `connect`/`sync` first relocate any table the block does

--- a/docs/decisions/client-configurator.md
+++ b/docs/decisions/client-configurator.md
@@ -301,3 +301,49 @@ relocation as its own warning, mirroring D99's phrasing. The fix lives in `inter
 next to the existing `codextoml.go` line/header/span primitives it reuses, not in `internal/blocktext`
 — that package stays provider-agnostic (it also serves the `AGENTS.md`/`CLAUDE.md` instruction
 block).
+
+---
+
+<a id="d127"></a>
+## D127 — Codex hook adoption also matches on the decoded command value
+
+**Status: implemented (2026-08-04).**
+
+**Decision.** `codexHookTableOwner` (`internal/provisioning/hooksettings.go`) accepts a
+marker-less `[[hooks.<event>]]` registration as hookName's own by **either** identity: D99's
+original path-fragment marker (`codexHookOwnershipMarker`), **or** a `command` that decodes to
+exactly the command `registerHookConfigTOML` is about to write for that hook. The decode is
+`configurator.CodexTableStringValue(body, "command")`, a new exported helper next to
+`codextoml.go`'s existing line/key parsing that reads the value of a `key = <string>` assignment
+regardless of which of the four TOML string forms it is spelled in — basic `"…"`, literal `'…'`,
+multi-line literal `'''…'''`, multi-line basic `"""…"""` — decoding each one's own escaping rules
+(or none, for literal forms) rather than comparing raw TOML text. The comparison is byte-exact on
+the decoded value, no trimming or normalization.
+
+**Rationale.** D99's path-fragment identity only holds for a hook whose command invokes a script
+inside its own materialized directory (`resolveHookCommand` only ever prefixes such a command with
+the hook's directory). A hook whose `hook.json` command is a self-contained one-liner — the `jq`
+one-liners shipped as `env-block`/`sops-warn` in a real KB — is passed through verbatim and
+contains no path fragment at all, so it never matched. After a Codex rewrite dropped the block's
+comment markers, `AdoptCodexOrphanTables` could not recognize that class of hook's orphaned
+registration; `blocktext.Write` appended the block again, registering — and firing — the hook
+twice, the exact failure D99 set out to prevent. The command Cartographer writes for a hook is
+otherwise deterministic (`resolveHookCommand` computed once per registration), so its decoded value
+is a sound second identity; a new emitted key (e.g. `cartographer_hook = "<name>"`) was rejected —
+Codex's config schema is not ours to extend, and an unknown key risks a hard parse failure on the
+user's only Codex config file. The decode is necessary, not optional: Codex re-serializes a command
+Cartographer wrote as a basic string into a multi-line literal string, and the two spellings share
+no useful substring to match on directly.
+
+**Consequences.** `env-block`/`sops-warn`-style hooks stop being duplicated (and firing twice)
+after a Codex `config.toml` rewrite. The legacy path-fragment identity is kept, so a registration
+written by an older client version is still adopted. A user-authored hook on the same event with a
+genuinely different command matches neither identity and is left untouched, as before. **Residual
+limit, accepted rather than engineered around:** a hook whose command changes in the narrow window
+between a Codex rewrite and the next `connect`/`sync` matches neither identity — the orphan and the
+freshly-written registration disagree — and survives as a duplicate; this requires two faults
+inside the same window, and the legacy path-fragment match still covers the script-based hooks
+where a command change is the most likely of the two. `internal/provisioning/hooksettings.go` (D57,
+Claude Code's `settings.json`) has the same shape and the same blind spot, but no duplication was
+reproducible there — its JSON path never goes through orphan adoption — so it is left unchanged
+pending an actual reproduction.

--- a/internal/configurator/codextoml.go
+++ b/internal/configurator/codextoml.go
@@ -245,6 +245,99 @@ func unquoteTOMLSegment(s string, quote byte) string {
 	return r.Replace(s)
 }
 
+// CodexTableStringValue returns the decoded value of the first top-level
+// `key = <string>` assignment in body — a table's text as produced by
+// codexTableGroups (or any string containing one) — and whether one was
+// found. Handles the four TOML string forms: basic `"…"` (with the escapes
+// QuoteTOMLString produces), literal `'…'`, multi-line literal (opened and
+// closed with three single quotes — what Codex emits when it re-serializes
+// a value we wrote as a basic string) and multi-line basic `"""…"""`
+// (QuoteTOMLMultiline's own form). A
+// multi-line form whose opening delimiter is immediately followed by a
+// newline drops that first newline, per the TOML spec. Returns false — never
+// a guess — for a missing key or a non-string value (bool, number, array,
+// ...); the caller decides what a non-match means (D127).
+func CodexTableStringValue(body, key string) (string, bool) {
+	lines := strings.Split(body, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, key) {
+			continue
+		}
+		rest := strings.TrimSpace(trimmed[len(key):])
+		if !strings.HasPrefix(rest, "=") {
+			continue
+		}
+		return decodeTOMLStringValue(strings.TrimSpace(rest[1:]), lines, i)
+	}
+	return "", false
+}
+
+// decodeTOMLStringValue decodes rest — the text of an assignment's value,
+// starting at the opening delimiter — dispatching on which of the four TOML
+// string forms it opens. lines/lineIdx let a multi-line form keep consuming
+// lines of body past the assignment's own line until its closing delimiter.
+func decodeTOMLStringValue(rest string, lines []string, lineIdx int) (string, bool) {
+	switch {
+	case strings.HasPrefix(rest, `"""`):
+		return decodeMultilineTOMLString(rest[3:], lines, lineIdx, `"""`, true)
+	case strings.HasPrefix(rest, `'''`):
+		return decodeMultilineTOMLString(rest[3:], lines, lineIdx, `'''`, false)
+	case strings.HasPrefix(rest, `"`):
+		return decodeQuotedTOMLValue(rest, '"')
+	case strings.HasPrefix(rest, `'`):
+		return decodeQuotedTOMLValue(rest, '\'')
+	default:
+		return "", false
+	}
+}
+
+// decodeQuotedTOMLValue decodes a single-line basic (`"…"`, quote is `"`) or
+// literal (`'…'`, quote is `'`) string value starting at rest[0]. Basic
+// strings have their backslash escapes undone (unquoteTOMLSegment); literal
+// strings have none.
+func decodeQuotedTOMLValue(rest string, quote byte) (string, bool) {
+	end := -1
+	for i := 1; i < len(rest); i++ {
+		if rest[i] == '\\' && quote == '"' {
+			i++
+			continue
+		}
+		if rest[i] == quote {
+			end = i
+			break
+		}
+	}
+	if end < 0 {
+		return "", false
+	}
+	return unquoteTOMLSegment(rest[1:end], quote), true
+}
+
+// decodeMultilineTOMLString decodes a multi-line string value whose opening
+// delimiter (delim, already stripped from rest) sits on lines[lineIdx];
+// consumes further lines of lines until delim closes it. basic strings get
+// their backslash escapes undone (unquoteTOMLSegment), literal strings none —
+// same distinction as decodeQuotedTOMLValue, just spanning lines. The first
+// newline right after the opening delimiter, if any, is not part of the
+// value (TOML spec).
+func decodeMultilineTOMLString(rest string, lines []string, lineIdx int, delim string, basic bool) (string, bool) {
+	text := rest
+	for i := lineIdx + 1; ; i++ {
+		if idx := strings.Index(text, delim); idx >= 0 {
+			content := strings.TrimPrefix(text[:idx], "\n")
+			if basic {
+				content = unquoteTOMLSegment(content, '"')
+			}
+			return content, true
+		}
+		if i >= len(lines) {
+			return "", false
+		}
+		text += "\n" + lines[i]
+	}
+}
+
 func isBareKeyRune(r rune) bool {
 	return r == '-' || r == '_' ||
 		(r >= '0' && r <= '9') ||

--- a/internal/configurator/configurator_codex_test.go
+++ b/internal/configurator/configurator_codex_test.go
@@ -645,3 +645,104 @@ func TestEvictForeignTablesFromBlock_MissingFile_NoOp(t *testing.T) {
 		t.Errorf("relocated = %v, want nil when the file does not exist", relocated)
 	}
 }
+
+// --- CodexTableStringValue (D127): decoding a command's value regardless of
+// the TOML string form Codex re-serializes it as ---
+
+func TestCodexTableStringValue_BasicString_RoundTripsQuoteTOMLString(t *testing.T) {
+	value := "jq -e '.tool_input.file_path | test(\"\\.env$\")' >/dev/null 2>&1 && exit 2 || true"
+	body := "[[hooks.PreToolUse.hooks]]\ntype = \"command\"\ncommand = " + configurator.QuoteTOMLString(value) + "\n"
+
+	got, ok := configurator.CodexTableStringValue(body, "command")
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got != value {
+		t.Errorf("got %q, want %q", got, value)
+	}
+}
+
+func TestCodexTableStringValue_LiteralString(t *testing.T) {
+	body := "[[hooks.PreToolUse.hooks]]\ncommand = 'jq -e \"literal, no escapes\\here\"'\n"
+
+	got, ok := configurator.CodexTableStringValue(body, "command")
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	want := `jq -e "literal, no escapes\here"`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestCodexTableStringValue_MultilineLiteralString_MatchesBasicFormOfSameValue(t *testing.T) {
+	// The shape observed from Codex CLI: it re-serializes a command we wrote as
+	// a basic string ("…") into a multi-line literal string ('''…''') on the
+	// same physical line — the two spellings must decode to the same value.
+	value := `jq -e '.tool_input.file_path | test("\\.env$")' >/dev/null 2>&1 && echo blocked`
+	basicBody := "command = " + configurator.QuoteTOMLString(value) + "\n"
+	multilineBody := "command = '''" + value + "'''\n"
+
+	basicGot, ok := configurator.CodexTableStringValue(basicBody, "command")
+	if !ok {
+		t.Fatalf("basic form: expected ok=true")
+	}
+	multilineGot, ok := configurator.CodexTableStringValue(multilineBody, "command")
+	if !ok {
+		t.Fatalf("multi-line literal form: expected ok=true")
+	}
+	if basicGot != multilineGot {
+		t.Errorf("the two TOML spellings decoded to different values: %q vs %q", basicGot, multilineGot)
+	}
+	if multilineGot != value {
+		t.Errorf("multi-line literal decoded to %q, want %q", multilineGot, value)
+	}
+}
+
+func TestCodexTableStringValue_MultilineLiteralString_OwnLine_DropsLeadingNewline(t *testing.T) {
+	body := "command = '''\njq -e 'x'\n'''\n"
+
+	got, ok := configurator.CodexTableStringValue(body, "command")
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	want := "jq -e 'x'\n"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestCodexTableStringValue_MultilineBasicString(t *testing.T) {
+	// Manually escaped, TOML multi-line basic form of value: a lone quote
+	// needs no escaping in this form (unlike single-line basic), only the
+	// backslash does.
+	value := "line one\nline two \"quoted\" and \\backslash"
+	body := "developer_instructions = \"\"\"" + strings.ReplaceAll(value, `\`, `\\`) + "\"\"\"\n"
+
+	got, ok := configurator.CodexTableStringValue(body, "developer_instructions")
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got != value {
+		t.Errorf("got %q, want %q", got, value)
+	}
+}
+
+func TestCodexTableStringValue_NonStringValue_ReturnsFalse(t *testing.T) {
+	if _, ok := configurator.CodexTableStringValue("trust_level = true\n", "trust_level"); ok {
+		t.Errorf("expected ok=false for a bool value")
+	}
+	if _, ok := configurator.CodexTableStringValue("count = 42\n", "count"); ok {
+		t.Errorf("expected ok=false for a number value")
+	}
+	if _, ok := configurator.CodexTableStringValue("names = [\"a\", \"b\"]\n", "names"); ok {
+		t.Errorf("expected ok=false for an array value")
+	}
+}
+
+func TestCodexTableStringValue_MissingKey_ReturnsFalse(t *testing.T) {
+	body := "[[hooks.PreToolUse.hooks]]\ntype = \"command\"\n"
+	if _, ok := configurator.CodexTableStringValue(body, "command"); ok {
+		t.Errorf("expected ok=false when the key is absent")
+	}
+}

--- a/internal/provisioning/hooksettings.go
+++ b/internal/provisioning/hooksettings.go
@@ -289,23 +289,43 @@ func codexHookMarkers(hookName string) (begin, end string) {
 // registration as owned by hookName: the command of a registration Cartographer
 // wrote for this hook always points inside the hook's own materialized
 // directory (D58). Same role as hookOwnershipMarker for Claude's settings.json,
-// and the identity used to recognize the marker-less copies Codex leaves behind
-// when it rewrites config.toml (D99) — the table name cannot serve as identity
-// here, since [[hooks.<event>]] is shared by every hook on that event.
+// and one of the two identities codexHookTableOwner accepts to recognize the
+// marker-less copies Codex leaves behind when it rewrites config.toml (D99) —
+// the table name cannot serve as identity here, since [[hooks.<event>]] is
+// shared by every hook on that event. Only holds for a hook whose command
+// invokes a script inside its own materialized directory; a self-contained
+// inline command (e.g. a "jq ..." one-liner) never contains this fragment and
+// is matched on its decoded value instead (D127).
 func codexHookOwnershipMarker(hookName string) string {
 	return ".codex/hooks/" + hookName + "/"
 }
 
 // codexHookTableOwner returns an owned-predicate (see
 // configurator.AdoptCodexOrphanTables) matching the [[hooks.<event>]]
-// registrations of hookName. The [hooks.state."…"] tables are deliberately left
-// alone: they are Codex's own bookkeeping (per-hook trusted hashes), not a
-// registration — a stale one is inert, since Codex gates it on a hash we do not
-// compute (D99).
-func codexHookTableOwner(hookName string) func(key []string, body string) bool {
+// registrations of hookName: either the legacy path-fragment marker
+// (codexHookOwnershipMarker, kept so a registration written by an older
+// client version is still adopted) or a command that decodes
+// (configurator.CodexTableStringValue) to exactly command — the same string
+// registerHookConfigTOML is about to write for this hook. The second identity
+// covers hooks whose command is a self-contained inline one-liner, which
+// contains no path fragment at all and would otherwise never be recognized
+// once Codex re-serializes it (D127; Codex may spell the same value as a
+// different TOML string form than QuoteTOMLString does — see
+// configurator.CodexTableStringValue). The [hooks.state."…"] tables are
+// deliberately left alone: they are Codex's own bookkeeping (per-hook trusted
+// hashes), not a registration — a stale one is inert, since Codex gates it on
+// a hash we do not compute (D99).
+func codexHookTableOwner(hookName, command string) func(key []string, body string) bool {
 	marker := codexHookOwnershipMarker(hookName)
 	return func(key []string, body string) bool {
-		return len(key) >= 2 && key[0] == "hooks" && key[1] != "state" && strings.Contains(body, marker)
+		if len(key) < 2 || key[0] != "hooks" || key[1] == "state" {
+			return false
+		}
+		if strings.Contains(body, marker) {
+			return true
+		}
+		got, ok := configurator.CodexTableStringValue(body, "command")
+		return ok && got == command
 	}
 }
 
@@ -346,7 +366,7 @@ func registerHookConfigTOML(baseDir, hookName, fullDestDir string) (string, erro
 		return "", fmt.Errorf("provisioning: reconcile %s: %w", path, err)
 	}
 
-	adopted, err := configurator.AdoptCodexOrphanTables(path, codexHookTableOwner(hookName))
+	adopted, err := configurator.AdoptCodexOrphanTables(path, codexHookTableOwner(hookName, command))
 	if err != nil {
 		return "", fmt.Errorf("provisioning: reconcile %s: %w", path, err)
 	}

--- a/internal/provisioning/provisioning_codex_test.go
+++ b/internal/provisioning/provisioning_codex_test.go
@@ -608,3 +608,141 @@ func TestApply_Codex_Hook_Eviction_PreservesStateWrittenInsideBlock(t *testing.T
 		t.Errorf("nothing left to relocate on re-apply, got warnings %v", res2.Warnings)
 	}
 }
+
+// --- Adoption of hooks whose command is a self-contained inline one-liner (D127) ---
+
+// rewriteCodexInlineCommandsAsMultilineLiteral simulates the shape a real
+// Codex CLI rewrite leaves behind (D127): comments — our markers included —
+// are dropped, like any Codex rewrite (see stripCodexComments), and every
+// `command = "…"` line we wrote as a basic string is re-serialized as a
+// multi-line literal string (opened and closed with three single quotes) on
+// the same physical line — the quoting subtlety the adoption match must see
+// through.
+func rewriteCodexInlineCommandsAsMultilineLiteral(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var kept []string
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, `command = "`) {
+			value, ok := configurator.CodexTableStringValue(trimmed+"\n", "command")
+			if !ok {
+				t.Fatalf("could not decode command line: %q", line)
+			}
+			line = "command = '''" + value + "'''"
+		}
+		kept = append(kept, line)
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(kept, "\n")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestApply_Codex_Hook_ReApplyAfterCodexRewrite_InlineCommand_NoDuplicate(t *testing.T) {
+	// The class of hook D99's marker alone could not recognize: env-block and
+	// sops-warn-style hooks whose command is a self-contained "jq ..."
+	// one-liner, with no path fragment into the hook's own materialized
+	// directory. session-init (a script command, same shape as the real
+	// cartographer-bootstrap hook) is registered alongside them to confirm
+	// the legacy path-fragment match still adopts it too, in the same
+	// rewritten file.
+	kbRoot := t.TempDir()
+	writeCodexHookKB(t, kbRoot, "env-block", "PreToolUse", "Edit|Write",
+		`jq -e '.tool_input.file_path | test("\.env$")' >/dev/null 2>&1 && exit 2 || true`)
+	writeCodexHookKB(t, kbRoot, "sops-warn", "PreToolUse", "Bash",
+		`jq -e '.tool_input.command | test("sops ")' >/dev/null 2>&1 && echo warn`)
+	writeCodexHookKB(t, kbRoot, "session-init", "SessionStart", "", "./notify.sh")
+
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
+	if err != nil {
+		t.Fatalf("BuildManifest: %v", err)
+	}
+
+	baseDir := t.TempDir()
+	opts := provisioning.ApplyOptions{
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderCodex,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
+	}
+	if _, err := provisioning.Apply(m, opts); err != nil {
+		t.Fatalf("Apply (1): %v", err)
+	}
+
+	configPath := filepath.Join(baseDir, ".codex", "config.toml")
+	rewriteCodexInlineCommandsAsMultilineLiteral(t, configPath)
+
+	res, err := provisioning.Apply(m, opts)
+	if err != nil {
+		t.Fatalf("Apply (2): %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if n := strings.Count(got, "[[hooks.PreToolUse]]"); n != 2 {
+		t.Errorf("expected exactly 2 [[hooks.PreToolUse]] (env-block + sops-warn, no duplicate), found %d:\n%s", n, got)
+	}
+	if n := strings.Count(got, "[[hooks.SessionStart]]"); n != 1 {
+		t.Errorf("expected exactly 1 [[hooks.SessionStart]], found %d:\n%s", n, got)
+	}
+	if len(res.Warnings) != 3 {
+		t.Errorf("expected one adoption warning per hook (3), got %v", res.Warnings)
+	}
+}
+
+func TestApply_Codex_Hook_Adoption_UserAuthoredInlineCommand_NotAdopted(t *testing.T) {
+	// A user-authored [[hooks.PreToolUse]] registration with a different
+	// inline command must survive: neither the legacy path-fragment marker
+	// nor the decoded-command match applies to it (D127).
+	kbRoot := t.TempDir()
+	writeCodexHookKB(t, kbRoot, "env-block", "PreToolUse", "Edit|Write",
+		`jq -e '.tool_input.file_path | test("\.env$")' >/dev/null 2>&1 && exit 2 || true`)
+
+	m, err := provisioning.BuildManifest(nil, map[string]string{"kb": kbRoot}, provisioning.BuildOptions{})
+	if err != nil {
+		t.Fatalf("BuildManifest: %v", err)
+	}
+
+	baseDir := t.TempDir()
+	configPath := filepath.Join(baseDir, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	preexisting := "[[hooks.PreToolUse]]\nmatcher = \"Bash\"\n[[hooks.PreToolUse.hooks]]\ntype = \"command\"\ncommand = \"echo not ours\"\n"
+	if err := os.WriteFile(configPath, []byte(preexisting), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := provisioning.ApplyOptions{
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderCodex,
+		BaseDir:   baseDir,
+		Lock:      provisioning.Lock{},
+	}
+	if _, err := provisioning.Apply(m, opts); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if !strings.Contains(got, `command = "echo not ours"`) {
+		t.Errorf("user-authored registration with a different command must not be adopted:\n%s", got)
+	}
+	if n := strings.Count(got, "[[hooks.PreToolUse]]"); n != 2 {
+		t.Errorf("expected 2 [[hooks.PreToolUse]] (user's + ours), found %d:\n%s", n, got)
+	}
+}


### PR DESCRIPTION
## Summary

- D99's orphan-adoption identity for Codex `config.toml` hooks matched only a command that points inside the hook's own materialized directory — a self-contained inline one-liner (e.g. `env-block`, `sops-warn`, both `jq` commands) never matches, so after Codex rewrites `config.toml` the registration is duplicated and the hook fires twice.
- `codexHookTableOwner` now also accepts a registration whose `command`, decoded regardless of which of the four TOML string forms it is spelled in (basic, literal, multi-line literal, multi-line basic — new `configurator.CodexTableStringValue`), equals the command Cartographer is about to write. The legacy path-fragment identity is kept as a second accepted match, so older-client registrations still adopt.
- Residual, accepted limit: a hook whose command changes in the narrow window between a Codex rewrite and the next sync matches neither identity and survives as a duplicate (documented in D127).

Depends on #108 (D126) — merge that first.

Closes #107

## Test plan
- [x] `make vet` → exit 0
- [x] `make test` → exit 0 (includes new unquoter tests in `internal/configurator/configurator_codex_test.go` and fixture-based hook-adoption tests in `internal/provisioning/provisioning_codex_test.go`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)