### PR TITLE
feat(control-plane): expose read-only governance tools to descriptor-bound agents

### DIFF
--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -32,7 +32,9 @@ Tools marked **[R]** have `Tool.ReadOnly=true` (`internal/mcpserver`): they neve
 
 Beyond that read/write split, every tool is also classified by the **resource** it addresses — exact concept, collection, source/destination, or whole KB — which is what a fine-grained role is evaluated against (D118). Collection tools filter their results per element before applying any limit; exact-resource tools collapse "forbidden" and "missing" into the same generic `not found`. A tool missing from that classification is denied outright, so adding a tool without choosing its resource semantics fails closed rather than granting access. The table and the guarantees are in [`transport-auth.md`](transport-auth.md) §Roles and fine-grained permissions. The same `[R]` tools expose `annotations: {"readOnlyHint": true}` in `tools/list` per the MCP spec (D76): a client can use this to auto-approve reads without a manual allowlist, without having to derive the list by hand.
 
-Tools marked **[A]** (advanced, `advancedToolNames` in `internal/mcpserver/visibility.go`) are **hidden from `tools/list` in the default `agent` tool profile** (D65): governance/maintenance and provisioning plumbing that would bloat the LLM agent's context without being useful in a normal session. They all remain **callable via `tools/call`** by name (CLI client, hooks, operator) in both profiles. Profile: `tools.profile` in YAML / `CARTOGRAPHER_TOOLS_PROFILE` / `--tools-profile`, values `agent` (default) \| `full` → [`deployment.md`](deployment.md).
+Tools marked **[A]** (advanced, `advancedToolNames` in `internal/mcpserver/visibility.go`) are **hidden from `tools/list` in the default `agent` tool profile** (D65): operator maintenance/mutation and provisioning plumbing that would bloat the LLM agent's context without being useful in a normal session. They all remain **callable via `tools/call`** by name (CLI client, hooks, operator) in both profiles. Profile: `tools.profile` in YAML / `CARTOGRAPHER_TOOLS_PROFILE` / `--tools-profile`, values `agent` (default) \| `full` → [`deployment.md`](deployment.md).
+
+**Agent governance vs. operator maintenance (D123).** `validate`, `lint`, `gate_check`, and `kb_status` are read-only governance diagnostics, not operator maintenance: the documented agent loop (`loop.md`, `use-cases.md`) runs them every session, and a descriptor-bound MCP host (one that can only invoke tools `tools/list` advertises, e.g. Codex) cannot call them by name the way a stdio/TUI agent can. They are therefore part of the default `agent` profile's core set, unlike `commit_gate`, `conflict_resolve`, `contradiction_report`, and the rest of `advancedToolNames`, which stay operator-only and advanced.
 
 ### Reading and navigation
 
@@ -80,13 +82,13 @@ Tools marked **[A]** (advanced, `advancedToolNames` in `internal/mcpserver/visib
 
 | Tool | Purpose |
 |---|---|
-| `validate(scope)` **[R]** **[A]** | OKF compliance (frontmatter, `type`, reserved files). |
-| `lint([scope], [scope_neighbors])` **[R]** **[A]** | Runs deterministic broken-link, stale-claim, orphan, contract and structural checks. `scope_neighbors=true` adds one-hop graph neighbors. There is no model-backed/deep mode. |
+| `validate(scope)` **[R]** | OKF compliance (frontmatter, `type`, reserved files). |
+| `lint([scope], [scope_neighbors])` **[R]** | Runs deterministic broken-link, stale-claim, orphan, contract and structural checks. `scope_neighbors=true` adds one-hop graph neighbors. There is no model-backed/deep mode. |
 | `commit_gate()` **[A]** | Blocks when open `Contradiction`s are involved in the diff. |
-| `gate_check()` **[R]** **[A]** | Combines validate + lint + commit_gate in a single tool (lightweight local gate). |
+| `gate_check()` **[R]** | Combines validate + lint + commit_gate in a single tool (lightweight local gate). |
 | `conflict_resolve(contradiction_id, resolution, [reason])` **[A]** | Closes an open `Contradiction`. |
 | `contradiction_report([scope], [status])` **[A]** | Lists contradictions, filterable by scope and status. |
-| `kb_status()` **[R]** **[A]** | Aggregate metrics: total concepts, per type, stale ones, open contradictions. |
+| `kb_status()` **[R]** | Aggregate metrics: total concepts, per type, stale ones, open contradictions. |
 | `conflicts_list()` **[R]** | Lists open git rebase conflicts (read-only). For each entry: `concept_id`, local/remote SHAs, `branch`, files involved, `detected_at`, resolution guidance. See also the `kb-conflict-resolve` skill. |
 | `git_conflict_resolve(concept_id, strategy, [body])` | Resolves a registered conflict (Step 4). `strategy`: `ours` (local version), `theirs` (remote version), `edit` (full content in `body`). Records the per-concept decision; once every open conflict is resolved, it performs a single merge+commit+push and clears the `degraded` markers. See `concurrency.md` §Step 4. |
 

--- a/docs/decisions/control-plane.md
+++ b/docs/decisions/control-plane.md
@@ -124,6 +124,14 @@ through `tools/list`.
 Measured result: fixed cost per session from ~4.8k to ~1.9k tokens (17 tools ≈ 1.86k of schemas
 + reduced block), with the daily flow unchanged (search → read → write → log).
 
+**Amended by D123.** `validate`, `lint`, `gate_check`, and `kb_status` moved
+from the advanced set into the `agent` profile's core set: they are
+read-only governance the documented agent loop depends on, and a
+descriptor-bound MCP host cannot call a tool `tools/list` never advertised.
+The counts above are the state as decided here, not current; see D123 for
+the measured cost of the change and `control-plane.md` for the current
+core/advanced split.
+
 **Discarded alternatives.** Consolidating governance into a single `kb_admin(action=...)` (fewer
 tools but a more opaque umbrella schema, and it does not solve the plumbing); filtering `tools/list` by token
 scope (entangles visibility and authorization: an rw agent token would still see everything);
@@ -427,3 +435,48 @@ indexes. A new resource class (rather than folding `index_patch` into
 Map's index without a whole-KB grant, while keeping the root index — which
 has no bounded collection of its own — behind the same unscoped grant every
 other whole-KB tool already requires.
+
+---
+
+<a id="d123"></a>
+## D123 — Expose read-only governance tools to descriptor-bound agents
+
+**Status: implemented (2026-08-04).**
+
+**Context.** The default `agent` tools profile (D65) hid `validate`, `lint`,
+`gate_check`, and `kb_status` from `tools/list`. They stayed registered and
+directly callable by name (`ToolAdvanced` filters `tools/list`, not
+dispatch), which is enough for a stdio/TUI agent that can invoke any known
+tool name. It is not enough for a descriptor-bound MCP host such as Codex,
+which can only invoke tools `tools/list` advertises: the documented agent
+loop (`docs/loop.md` §Validate and lint, `docs/use-cases.md`) requires all
+four, but a descriptor-bound agent had no way to call them.
+
+**Decision.** Remove `validate`, `lint`, `gate_check`, and `kb_status` from
+`advancedToolNames` (`internal/mcpserver/visibility.go`): they join the
+`agent` profile's core set, unchanged in every other respect — same
+`ReadOnly: true` classification (`readonly.go`), same `resourceWhole`
+resource class and whole-KB RBAC (`policy.go`), same handlers. Everything
+else stays advanced: `commit_gate`, contradiction/conflict mutation, index
+maintenance, provisioning, secrets, artifact enumeration/removal, and PR
+finalization remain operator-only, because they are either mutating or
+genuinely niche — unlike these four, no documented agent-loop step depends
+on a descriptor-bound host being able to invoke them without an operator
+switching the server to `profile: full`.
+
+**Measured cost.** Serialized `tools/list` under the `agent` profile against
+the demo KB: 28 tools / 21814 bytes (~5453 tokens, bytes/4 estimate per D65)
+before, 32 tools / 23324 bytes (~5831 tokens) after — a ~378-token, ~7%
+increase for the four added descriptors, well short of erasing D65's
+~2.9k-token reduction from the pre-D65 baseline.
+
+**Rationale.** No third profile and no umbrella governance tool: a third
+profile duplicates the two-value contract admin/operators already reason
+about (`agent`/`full`) without resolving the descriptor-bound gap for the
+existing default, and an umbrella tool (`kb_admin(action=...)`, already
+discarded once by D65) trades four typed, independently discoverable
+schemas for one opaque one. Reclassification also does not touch RBAC:
+`ToolAdvanced` gates `tools/list` visibility only, `authorizeTool` and the
+resource-class tables are untouched, so a caller who could not call these
+four before still cannot call them after — only what a compliant
+descriptor-bound client is told exists has changed.

--- a/docs/loop.md
+++ b/docs/loop.md
@@ -35,6 +35,11 @@ Remote synchronization is handled around writes when configured. See
 
 ## Validate and lint
 
+`validate`, `lint`, and `gate_check` are agent governance, not operator
+maintenance: they are part of the default `agent` tool profile precisely so a
+descriptor-bound MCP host advertises them and this loop stays runnable
+end-to-end (D123, → `control-plane.md` §MCP API).
+
 - `validate` checks KB and frontmatter invariants.
 - `lint(scope, scope_neighbors)` runs deterministic checks over a scope and,
   optionally, its graph neighbors, including any declarative map contract for

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -43,7 +43,11 @@ the KB's managed skills, agents, hooks and instructions. `cartographer status`
 shows drift; `cartographer sync` reconciles it.
 
 Providers differ in what they can represent. See [configurator](configurator.md)
-and [synchronization](sync.md) for the exact mappings and limitations.
+and [synchronization](sync.md) for the exact mappings and limitations. A
+descriptor-bound host such as Codex can only call tools `tools/list`
+advertises; the default `agent` profile's core set (→ `control-plane.md` §MCP
+API) includes `validate`, `lint`, `gate_check`, and `kb_status` for exactly
+this reason (D123).
 
 ## Separate domains into multiple KBs
 

--- a/internal/mcpserver/httpserver_auth_test.go
+++ b/internal/mcpserver/httpserver_auth_test.go
@@ -240,6 +240,44 @@ func TestHTTPGuard_ServiceGet_ResolveSecrets_RequiresRW(t *testing.T) {
 	}
 }
 
+// TestHTTPGuard_GovernanceTools_WholeKBAuthorization exercises the resource
+// class shared by the four D123 descriptor-bound governance tools
+// (validate, lint, gate_check, kb_status): all four are resourceWhole, so a
+// whole-KB read grant (a legacy KBScope, Write:false) must allow them, and a
+// fine-grained selector-scoped permission — even one that grants read on the
+// exact map these tools would inspect — must not, since resourceWhole has no
+// safe partial semantics (policy.go). D123 WP1 only changes tools/list
+// visibility; it must not weaken this existing RBAC boundary.
+func TestHTTPGuard_GovernanceTools_WholeKBAuthorization(t *testing.T) {
+	governanceTools := []string{"validate", "lint", "gate_check", "kb_status"}
+
+	ts := auth.NewScopedTokenStore([]auth.ScopedToken{
+		{Token: "r-tok", Scopes: []auth.KBScope{{KB: "kbx", Write: false}}},
+		{Token: "scoped-tok", Policy: auth.Policy{Permissions: []auth.Permission{
+			{KB: "kbx", Maps: []string{"manutenzione"}},
+		}}},
+	})
+	handler := newScopedTestHandler(t, ts)
+
+	for _, name := range governanceTools {
+		// Whole-KB read scope: dispatch guard passes (the handler itself may
+		// still report an application-level result, e.g. gate_check without
+		// changed_ids, which is not what this guard test is checking).
+		rr := doMCP(handler, "kbx", "r-tok", writeToolCallBody(name))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("%s with whole-kb read scope: status = %d, want 200; body=%s", name, rr.Code, rr.Body.String())
+		}
+		if tr := decodeToolResult(t, unmarshalMCPResponse(t, rr)); tr.IsError && strings.Contains(tr.Content[0].Text, "forbidden") {
+			t.Fatalf("%s with whole-kb read scope: unexpected forbidden: %v", name, tr.Content)
+		}
+
+		// Map-scoped (not whole-KB) permission: forbidden, even though it
+		// grants read access to a real map in the KB.
+		rr = doMCP(handler, "kbx", "scoped-tok", writeToolCallBody(name))
+		assertMCPForbidden(t, rr)
+	}
+}
+
 // TestReadOnlyToolsGolden verifies that the set of tools marked ReadOnly:true
 // in the real registry (built via RegisterKBTools, including the BundleFS-gated
 // sync tools) matches exactly the readOnlyToolNames source of truth consulted

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -2945,6 +2945,7 @@ func TestServer_ToolsProfile(t *testing.T) {
 		"conflicts_list", "git_conflict_resolve",
 		"artifact_read", "template_list",
 		"asset_read", "asset_list", "asset_write",
+		"validate", "lint", "gate_check", "kb_status",
 	}
 	got := listToolNames(t, s)
 	for _, name := range agentVisible {
@@ -2979,11 +2980,44 @@ func TestServer_ToolsProfile(t *testing.T) {
 	// Hidden tools stay callable via tools/call under the agent profile.
 	callResps := runMCPSequence(t, s, []string{
 		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}`,
-		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"kb_status","arguments":{}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"index_rebuild","arguments":{}}}`,
 	})
 	tr := decodeToolResult(t, callResps[1])
 	if tr.IsError {
-		t.Errorf("agent profile: hidden tool kb_status must stay callable, got error: %v", tr.Content)
+		t.Errorf("agent profile: hidden tool index_rebuild must stay callable, got error: %v", tr.Content)
+	}
+
+	// D123: the descriptor-bound governance loop must be advertised with the
+	// read-only hint, matching their ReadOnly:true classification.
+	listResp := runMCPSequence(t, s, []string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`,
+	})
+	resultBytes, _ := json.Marshal(listResp[1].Result)
+	var listResult struct {
+		Tools []struct {
+			Name        string `json:"name"`
+			Annotations struct {
+				ReadOnlyHint bool `json:"readOnlyHint"`
+			} `json:"annotations"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(resultBytes, &listResult); err != nil {
+		t.Fatalf("tools/list: decode: %v", err)
+	}
+	toolsByName := map[string]bool{}
+	for _, tl := range listResult.Tools {
+		toolsByName[tl.Name] = tl.Annotations.ReadOnlyHint
+	}
+	for _, name := range []string{"validate", "lint", "gate_check", "kb_status"} {
+		readOnlyHint, ok := toolsByName[name]
+		if !ok {
+			t.Errorf("agent profile: governance tool %q not advertised", name)
+			continue
+		}
+		if !readOnlyHint {
+			t.Errorf("agent profile: governance tool %q must advertise readOnlyHint:true", name)
+		}
 	}
 
 	// Full profile: everything advertised again.

--- a/internal/mcpserver/toolprefix_test.go
+++ b/internal/mcpserver/toolprefix_test.go
@@ -56,7 +56,9 @@ func TestServer_ToolRequiresWrite_Prefixed(t *testing.T) {
 }
 
 // TestServer_ToolsProfile_Prefixed verifies the "agent" tools-profile filter
-// (ToolAdvanced) still hides advanced tools under their prefixed name.
+// (ToolAdvanced) still hides advanced tools under their prefixed name, and
+// (D123) still exposes the four canonical governance descriptors — with
+// readOnlyHint:true — under their configured prefix.
 func TestServer_ToolsProfile_Prefixed(t *testing.T) {
 	k := setupTestKB(t)
 	s := New("test")
@@ -70,11 +72,23 @@ func TestServer_ToolsProfile_Prefixed(t *testing.T) {
 	}
 	names := toolNamesFromToolsList(t, resps[0])
 
-	if _, ok := names["aiteam__validate"]; ok {
-		t.Error("aiteam__validate is an advanced tool and must be hidden under the agent profile, even prefixed")
+	if _, ok := names["aiteam__index_rebuild"]; ok {
+		t.Error("aiteam__index_rebuild is an advanced tool and must be hidden under the agent profile, even prefixed")
 	}
 	if _, ok := names["aiteam__atlas_overview"]; !ok {
 		t.Error("aiteam__atlas_overview must be visible under the agent profile")
+	}
+
+	readOnlyHints := toolReadOnlyHintsFromToolsList(t, resps[0])
+	for _, name := range []string{"aiteam__validate", "aiteam__lint", "aiteam__gate_check", "aiteam__kb_status"} {
+		hint, ok := readOnlyHints[name]
+		if !ok {
+			t.Errorf("%s must be visible under the agent profile, even prefixed", name)
+			continue
+		}
+		if !hint {
+			t.Errorf("%s must advertise readOnlyHint:true under the agent profile", name)
+		}
 	}
 }
 
@@ -96,6 +110,32 @@ func toolNamesFromToolsList(t *testing.T, resp Response) map[string]bool {
 	out := make(map[string]bool, len(result.Tools))
 	for _, tl := range result.Tools {
 		out[tl.Name] = true
+	}
+	return out
+}
+
+// toolReadOnlyHintsFromToolsList decodes a tools/list Response into a
+// name -> annotations.readOnlyHint map.
+func toolReadOnlyHintsFromToolsList(t *testing.T, resp Response) map[string]bool {
+	t.Helper()
+	resultBytes, err := json.Marshal(resp.Result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	var result struct {
+		Tools []struct {
+			Name        string `json:"name"`
+			Annotations struct {
+				ReadOnlyHint bool `json:"readOnlyHint"`
+			} `json:"annotations"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(resultBytes, &result); err != nil {
+		t.Fatalf("unmarshal tools/list result: %v", err)
+	}
+	out := make(map[string]bool, len(result.Tools))
+	for _, tl := range result.Tools {
+		out[tl.Name] = tl.Annotations.ReadOnlyHint
 	}
 	return out
 }

--- a/internal/mcpserver/visibility.go
+++ b/internal/mcpserver/visibility.go
@@ -5,14 +5,13 @@ package mcpserver
 // registered and callable via tools/call — the CLI client (sync_pull, D57) and
 // the SessionStart hook (sync_check, D48) invoke them by name without going
 // through tools/list — but they are not advertised to the LLM agent, whose
-// working set stays small (search/read/write/log plus content structure and
-// git-conflict self-recovery).
+// working set stays small (search/read/write/log plus content structure,
+// git-conflict self-recovery, and the read-only governance loop below).
 //
 // Classification rationale:
-//   - governance/diagnostics (validate, lint, gate_check, commit_gate,
-//     kb_status, contradiction_report, conflict_resolve, index_rebuild,
-//     reindex):
-//     operator-level maintenance, not part of a normal agent session;
+//   - operator-level mutation/maintenance (commit_gate, contradiction_report,
+//     conflict_resolve, index_rebuild, reindex): not part of a normal agent
+//     session;
 //   - provisioning plumbing (sync_*, skill_*, service_*): consumed by the
 //     client CLI / hooks, or operator-level (skill_install, service_get).
 //
@@ -25,17 +24,18 @@ package mcpserver
 // NOT advanced: concept_expand (D77 WP2) — growing a concept into an
 // expanded concept is a normal, frequent agent action, same tier as
 // concept_move/concept_delete. Also NOT advanced: map_delete (D88 WP2) —
-// same tier as its counterpart map_create, normal Atlas upkeep.
+// same tier as its counterpart map_create, normal Atlas upkeep. Also NOT
+// advanced: validate, lint, gate_check, kb_status (D123) — read-only
+// governance diagnostics that the documented agent loop (docs/loop.md,
+// docs/use-cases.md) requires, and that descriptor-bound MCP hosts (e.g.
+// Codex) can only ever invoke if tools/list advertises them: unlike a
+// stdio/TUI agent, they cannot call a tool by name that tools/list omits.
 //
-// TestToolsProfile (server_test.go) is the golden test: it builds a real
-// registry and asserts the exact agent-visible set, so adding a tool without
-// classifying it here fails the build.
+// TestServer_ToolsProfile (server_test.go) is the golden test: it builds a
+// real registry and asserts the exact agent-visible set, so adding a tool
+// without classifying it here fails the build.
 var advancedToolNames = map[string]bool{
-	"validate":             true,
-	"lint":                 true,
-	"gate_check":           true,
 	"commit_gate":          true,
-	"kb_status":            true,
 	"contradiction_report": true,
 	"conflict_resolve":     true,
 	"index_rebuild":        true,


### PR DESCRIPTION
## Summary
- Implements plan issue #101 (D123): reclassifies `validate`, `lint`, `gate_check`, and `kb_status` from the advanced set into the default `agent` tools/list core set, so descriptor-bound MCP hosts (e.g. Codex, which can only invoke tools `tools/list` advertises) can run the documented agent governance loop (`docs/loop.md`, `docs/use-cases.md`).
- RBAC, read-only classification, and resource-class authorization are unchanged: all four stay `ReadOnly: true` / `resourceWhole`, `authorizeTool` is untouched — only `tools/list` visibility moves.
- Measured cost (agent profile, demo KB): 28 → 32 tools, 21814 → 23324 bytes (~5453 → ~5831 tokens, bytes/4 estimate per D65) — about +378 tokens for the four descriptors.

## Test plan
- [x] `internal/mcpserver/server_test.go`: `TestServer_ToolsProfile` golden updated for the new core set, plus a `readOnlyHint:true` assertion for the four tools and a still-hidden control (`index_rebuild`).
- [x] `internal/mcpserver/toolprefix_test.go`: `TestServer_ToolsProfile_Prefixed` updated to assert the four governance tools are visible and read-only-hinted under a configured prefix.
- [x] `internal/mcpserver/httpserver_auth_test.go`: new `TestHTTPGuard_GovernanceTools_WholeKBAuthorization` exercises the shared `resourceWhole` HTTP authorization path for all four — whole-KB read scope allowed, map-scoped (non-whole-KB) permission denied — proving RBAC was not weakened.
- [x] `make vet` → exit 0
- [x] `make test` → exit 0 (`internal/mcpserver` 27.7s, all packages `ok`)

## Docs
- `docs/control-plane.md`: drop `[A]` from the four tools, add an "agent governance vs. operator maintenance" note.
- `docs/loop.md`, `docs/use-cases.md`: cross-reference D123 where the governance loop / descriptor-bound clients are discussed.
- `docs/decisions/control-plane.md`: new `## D123` entry (context, decision, measured cost, rationale) plus an "Amended by D123" cross-reference in D65.
- `docs/transport-auth.md` was intentionally left untouched: this plan does not change the authorization model, only `tools/list` visibility (confirmed against `policy.go`/`authorizeTool`, unmodified).

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)