### PR TITLE
feat(kb_status): roll up concepts by status

### DIFF
--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -89,7 +89,7 @@ Tools marked **[A]** (advanced, `advancedToolNames` in `internal/mcpserver/visib
 | `gate_check()` **[R]** | Combines validate + lint + commit_gate in a single tool (lightweight local gate). |
 | `conflict_resolve(contradiction_id, resolution, [reason])` **[A]** | Closes an open `Contradiction`. |
 | `contradiction_report([scope], [status])` **[A]** | Lists contradictions, filterable by scope and status. |
-| `kb_status()` **[R]** | Aggregate metrics: total concepts, per type, stale ones, open contradictions. |
+| `kb_status()` **[R]** | Aggregate metrics: total concepts, per type, per `status` (concepts with no `status` field are excluded, D131), stale ones, open contradictions. |
 | `conflicts_list()` **[R]** | Lists open git rebase conflicts (read-only). For each entry: `concept_id`, local/remote SHAs, `branch`, files involved, `detected_at`, resolution guidance. See also the `kb-conflict-resolve` skill. |
 | `git_conflict_resolve(concept_id, strategy, [body])` | Resolves a registered conflict (Step 4). `strategy`: `ours` (local version), `theirs` (remote version), `edit` (full content in `body`). Records the per-concept decision; once every open conflict is resolved, it performs a single merge+commit+push and clears the `degraded` markers. See `concurrency.md` §Step 4. |
 

--- a/docs/decisions/control-plane.md
+++ b/docs/decisions/control-plane.md
@@ -480,3 +480,26 @@ schemas for one opaque one. Reclassification also does not touch RBAC:
 resource-class tables are untouched, so a caller who could not call these
 four before still cannot call them after — only what a compliant
 descriptor-bound client is told exists has changed.
+
+---
+
+<a id="d131"></a>
+## D131 — `kb_status`: `by_status` roll-up excludes unset status
+
+**Decision.** `kb_status` gains a `by_status` map (status value → count),
+built in the same `WalkConcepts` pass that already produces `by_type`.
+Concepts whose frontmatter does not declare `status` are left out of the
+map entirely, not bucketed under an empty-string key — mirroring how
+`concept_list`'s `where` predicates already treat a missing key (D108).
+`by_status` is initialized as an empty map like `by_type`, so a KB with no
+`status` values in use serializes it as `{}` rather than omitting the key.
+
+**Rationale.** `status` is already a free-form optional OKF field that
+`concept_list` filters on exactly (D108); without an aggregate, an agent
+can only discover which values are in use by guessing and calling
+`concept_list` once per guess. Excluding unset status avoids a giant `""`
+bucket dominating the map in the common case where only a minority of
+concepts track status — the aggregate should answer "how much of this KB
+is in each declared state", not restate `total`. No new predicate grammar,
+task/workflow semantics, or status-value validation is introduced: values
+stay owned by each KB, exactly as scoped by issue #119.

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -1703,6 +1703,78 @@ func TestServer_CommitGate_Blocked(t *testing.T) {
 	}
 }
 
+func TestServer_KBStatus_ByStatus(t *testing.T) {
+	k := setupTestKB(t)
+	// setupTestKB already creates one Runbook concept with no status.
+	os.WriteFile(filepath.Join(k.DataRoot(), "manutenzione", "open-1.md"),
+		[]byte("---\ntype: Note\nstatus: open\n---\n# Open 1\n"), 0o644)
+	os.WriteFile(filepath.Join(k.DataRoot(), "manutenzione", "open-2.md"),
+		[]byte("---\ntype: Note\nstatus: open\n---\n# Open 2\n"), 0o644)
+	os.WriteFile(filepath.Join(k.DataRoot(), "manutenzione", "done-1.md"),
+		[]byte("---\ntype: Note\nstatus: done\n---\n# Done 1\n"), 0o644)
+	os.WriteFile(filepath.Join(k.DataRoot(), "manutenzione", "no-status.md"),
+		[]byte("---\ntype: Note\n---\n# No Status\n"), 0o644)
+
+	s := New("0.4.0-m4")
+	RegisterKBTools(s, k, Deps{})
+
+	msgs := []string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"kb_status","arguments":{}}}`,
+	}
+	resps := runMCPSequence(t, s, msgs)
+
+	tr := decodeToolResult(t, resps[1])
+	if tr.IsError {
+		t.Fatalf("kb_status: isError=true: %v", tr.Content)
+	}
+
+	var result struct {
+		ByStatus map[string]int `json:"by_status"`
+	}
+	if err := json.Unmarshal([]byte(tr.Content[0].Text), &result); err != nil {
+		t.Fatalf("decode kb_status result: %v", err)
+	}
+	want := map[string]int{"open": 2, "done": 1}
+	if len(result.ByStatus) != len(want) {
+		t.Fatalf("by_status = %v, want %v", result.ByStatus, want)
+	}
+	for status, count := range want {
+		if result.ByStatus[status] != count {
+			t.Errorf("by_status[%q] = %d, want %d", status, result.ByStatus[status], count)
+		}
+	}
+}
+
+func TestServer_KBStatus_ByStatus_Empty(t *testing.T) {
+	k := setupTestKB(t)
+	// setupTestKB creates only a concept with no status: by_status must have no entries.
+
+	s := New("0.4.0-m4")
+	RegisterKBTools(s, k, Deps{})
+
+	msgs := []string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"kb_status","arguments":{}}}`,
+	}
+	resps := runMCPSequence(t, s, msgs)
+
+	tr := decodeToolResult(t, resps[1])
+	if tr.IsError {
+		t.Fatalf("kb_status: isError=true: %v", tr.Content)
+	}
+
+	var result struct {
+		ByStatus map[string]int `json:"by_status"`
+	}
+	if err := json.Unmarshal([]byte(tr.Content[0].Text), &result); err != nil {
+		t.Fatalf("decode kb_status result: %v", err)
+	}
+	if len(result.ByStatus) != 0 {
+		t.Errorf("by_status = %v, want empty", result.ByStatus)
+	}
+}
+
 func TestServer_GateCheck_Pass(t *testing.T) {
 	k := setupTestKB(t)
 	s := New("0.5.0-m5")

--- a/internal/mcpserver/tools_governance.go
+++ b/internal/mcpserver/tools_governance.go
@@ -398,12 +398,13 @@ func toolConflictResolve(k *kb.KB) Tool {
 func toolKBStatus(k *kb.KB) Tool {
 	return Tool{
 		Name:        "kb_status",
-		Description: "Returns aggregate metrics about the KB: total concepts, per-type counts, stale concepts (review_after in the past), open contradictions.",
+		Description: "Returns aggregate metrics about the KB: total concepts, per-type counts, per-status counts (concepts with no status field are excluded), stale concepts (review_after in the past), open contradictions.",
 		ReadOnly:    true,
 		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
 		Handler: func(ctx requestContext, args json.RawMessage) (ToolResult, error) {
 			today := time.Now().UTC().Format("2006-01-02")
 			typeCounts := map[string]int{}
+			statusCounts := map[string]int{}
 			total := 0
 			staleCount := 0
 			openContradictions := 0
@@ -418,6 +419,12 @@ func toolKBStatus(k *kb.KB) Tool {
 
 				t := fm.Type()
 				typeCounts[t]++
+
+				if s, ok := fm.Get("status"); ok {
+					if sStr, ok := s.(string); ok && sStr != "" {
+						statusCounts[sStr]++
+					}
+				}
 
 				if ra, ok := fm.Get("review_after"); ok {
 					if raStr, ok := ra.(string); ok && raStr != "" && raStr < today {
@@ -443,6 +450,7 @@ func toolKBStatus(k *kb.KB) Tool {
 			result := map[string]interface{}{
 				"total":               total,
 				"by_type":             typeCounts,
+				"by_status":           statusCounts,
 				"stale_count":         staleCount,
 				"open_contradictions": openContradictions,
 				"git_profile":         server.Profile,


### PR DESCRIPTION
Closes #119.

Adds a `by_status` map to `kb_status`: status value → count, built in the same
`WalkConcepts` pass that already produces `by_type`.

- Concepts that declare no `status` are **excluded** rather than bucketed under
  an empty-string key, mirroring how `concept_list`'s `where` predicates treat a
  missing key (D108). A KB where only a minority of concepts track status does
  not get a giant `""` bucket restating `total`.
- Initialized as an empty map like `by_type`, so a KB with no status values in
  use serializes `"by_status": {}` rather than omitting the key.

Non-goals held: no new predicate grammar, no task/workflow semantics, no
validation of status values — they stay free-form strings owned by each KB.

Docs: `docs/control-plane.md` §MCP tools row updated; decision record **D131**
in `docs/decisions/control-plane.md` (D130 is reserved by the approved plan in
#118).

`make vet && make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)