### PR TITLE
fix(mcpserver): audit authorization denials and drop the unwired handler layer

### DIFF
--- a/docs/decisions/transport-auth.md
+++ b/docs/decisions/transport-auth.md
@@ -295,3 +295,53 @@ indistinguishable to the protocol. Recording is a side effect on the request pat
 path — hitting the cap is invisible to the caller. A hostile client can burn the 64 key slots, which
 degrades the roster to an overflow count but cannot grow memory; an operator who sees `overflow`
 climb should read it as noise, not as topology.
+
+<a id="d132"></a>
+## D132 — Audit authorization denials; serve RFC 9728 metadata; drop the unwired HTTP handler layer
+
+**Decision.** Three corrections, found while implementing D128 (issue #122, outside its scope).
+(1) `handleToolsCall` (`internal/mcpserver/server.go`) returned as soon as `s.authorize` failed,
+before `beginAuditCall` ever ran — a denial produced no audit event at all, even though D119 already
+documents the attempt+completion pair with `outcome=unauthorized` as part of the contract. The denial
+is now audited at the point the decision actually happens: on the `authorize` failure path,
+`handleToolsCall` calls `Server.auditDenied`, which now takes the principal directly (already resolved
+from the request context per D118) instead of an `*http.Request` — the dependency existed only to
+re-derive the principal, redundantly, from the bearer token. (2) `docs/transport-auth.md` already
+claimed the server publishes RFC 9728 Protected Resource Metadata, and `auth.go`'s `isPublicPath`
+already exempted `/.well-known/oauth-protected-resource` from authentication, but nothing served it —
+`auth.ProtectedResourceMetadata` had no caller outside its own test. The route is now registered in
+`MultiKBServer.Handler()`, the handler `cmd/cartographer/serve.go` actually wraps in
+`OriginGuard(store.Middleware(...))`; `resource` and `authorization_servers` both name this server's
+own base URL, reconstructed per-request from `Host` and `X-Forwarded-Proto`, since there is no
+separate OAuth authorization server to plumb through config (this server validates its own static
+tokens). (3) With both fixed, `mcpAccessGuard` and the exported `FullHTTPHandler`, `WellKnownHandler`,
+`ListenAndServeWithHandler` and `ListenAndServeHandler` (`internal/mcpserver/httpserver.go`) had no
+caller in production or in tests — `auditDenied` was `mcpAccessGuard`'s only caller, and
+`cmd/cartographer/serve.go` has always built its handler directly from `MultiKBServer.Handler()`,
+never through any of the five. All five are deleted; the handful of tests that only exercised
+`FullHTTPHandler` as a third member of a "same behavior across handler constructors" table lost that
+one entry, not the test.
+
+**Rationale.** An audit log exists precisely to show what was refused, and `mcpAccessGuard`'s
+per-KB r/rw body-peek (D45) and `service_get`/`resolve_secrets` override (D47) had already been
+re-implemented in the authorizer (`internal/mcpserver/policy.go`, D118) — nothing was unenforced, but
+three comments elsewhere still pointed at the guard as the place access is decided
+(`audit.go`, `tools_skill.go`), so a reader looking for the enforcement point found the wrong function
+first. Serving the RFC 9728 route was the smaller of the two options available (serve it, or retract
+the docs claim and the auth exemption): the docs and the exemption already existed and were correct in
+intent, only the handler was missing. Deriving `resource`/`authorization_servers` from the request
+rather than adding a config field keeps the change to the size the docs already promised, and is
+honest about what this deployment actually is — its own token validator, not a client of a separate
+authorization server.
+
+**Consequences.** A denied `tools/call` now appears in the audit log exactly like every other call,
+closing the gap between D119's documented contract and what the code did. The RFC 9728 endpoint is
+self-describing rather than operator-configured: an operator behind a reverse proxy that does not set
+`X-Forwarded-Proto` gets an `http://` `resource` even when the public entry point is HTTPS — no worse
+than the previous 404, but not authoritative either; a future need for a precise external issuer
+would need real config, not this inference. Deleting the dead handler layer removes the only place
+`FullHTTPHandler`'s CORS behavior was exercised at all outside its own tests — CORS for the production
+path continues to live in `OriginGuard`, unaffected by this change. `Server.HTTPHandler` (single-KB,
+no `.well-known` route) and the plain `Server.ListenAndServe` are unaffected: neither is on the
+production path (`serveHTTP` always mounts through `MultiKBServer`, even for one KB) but both remain
+for direct single-KB embedding and their own tests, which this issue did not ask to remove.

--- a/docs/transport-auth.md
+++ b/docs/transport-auth.md
@@ -10,11 +10,14 @@
 HTTP requests return complete JSON-RPC responses. Cartographer does not expose
 the legacy two-endpoint SSE transport or an HTTP streaming session.
 
-`GET /health` reports service readiness. The server also publishes RFC 9728
-Protected Resource Metadata so clients can discover the protected resource.
-Cartographer does **not** implement an OAuth authorization server, dynamic
-client registration or JWT validation; configured tokens are opaque static
-bearer values.
+`GET /health` reports service readiness. `GET /.well-known/oauth-protected-resource`
+publishes RFC 9728 Protected Resource Metadata, unauthenticated, so clients can
+discover the protected resource; `resource` and `authorization_servers` both
+name this server's own externally-visible base URL (scheme + `Host`, from the
+request itself), since it validates its own static bearer tokens rather than
+delegating to a separate authorization server. Cartographer does **not**
+implement an OAuth authorization server, dynamic client registration or JWT
+validation; configured tokens are opaque static bearer values.
 
 ### Protocol versions: two eras at once
 
@@ -198,15 +201,16 @@ described in [deployment](deployment.md).
 
 ## Operational audit
 
-When `audit.log` is configured, every `tools/call` dispatched over HTTP or
-stdio records **two** events (D119): an *attempt* before the tool runs and a
-*completion* after it, carrying the tool name, the KB, the transport, the
-principal and the outcome (`success`, `application_error`, `internal_error`,
-`unauthorized`, `unknown_tool`, …). An attempt with no matching completion is
-itself evidence: a crash mid-operation becomes visible rather than silent. The
-principal is read from the request context, so it is always the identity
-authorization actually used. Arguments of an unregistered tool are never
-recorded.
+When `audit.log` is configured, every `tools/call` received over HTTP or
+stdio records **two** events (D119), including one an authorization decision
+denies (D132): an *attempt* before the tool would run (or before the denial is
+returned) and a *completion* after it, carrying the tool name, the KB, the
+transport, the principal and the outcome (`success`, `application_error`,
+`internal_error`, `unauthorized`, `unknown_tool`, …). An attempt with no
+matching completion is itself evidence: a crash mid-operation becomes visible
+rather than silent. The principal is read from the request context, so it is
+always the identity authorization actually used. Arguments of an unregistered
+tool are never recorded.
 
 Entries form a JSONL hash chain with optional Ed25519 signatures: altering one
 recorded entry invalidates every entry after it.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -223,12 +223,18 @@ func (ts *TokenStore) Middleware(next http.Handler) http.Handler {
 	})
 }
 
+// WellKnownProtectedResourcePath is the RFC 9728 discovery path for OAuth
+// Protected Resource Metadata. It is exempted from authentication here (by
+// definition it must be public) and served by mcpserver.MultiKBServer.Handler
+// using ProtectedResourceMetadata.
+const WellKnownProtectedResourcePath = "/.well-known/oauth-protected-resource"
+
 // isPublicPath reports whether a request path must be reachable without auth:
 // the health endpoint (used by k8s liveness/readiness probes) and the OAuth
 // protected-resource metadata (RFC 9728, which by definition must be public).
 func isPublicPath(path string) bool {
 	return path == "/health" ||
-		path == "/.well-known/oauth-protected-resource"
+		path == WellKnownProtectedResourcePath
 }
 
 // ScopesFromToken extracts KB scopes from a bearer token.

--- a/internal/mcpserver/audit.go
+++ b/internal/mcpserver/audit.go
@@ -2,11 +2,8 @@ package mcpserver
 
 import (
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"net/http"
-	"strings"
 	"time"
 
 	"github.com/BeppeTemp/cartographer/internal/audit"
@@ -99,8 +96,9 @@ func extractResources(tool string, args json.RawMessage) map[string]string {
 
 // classifyOutcome maps a tool call's result onto the audit outcome taxonomy
 // (internal/audit.Outcome*). Unauthenticated/unauthorized/cancelled are
-// produced by other callers (mcpAccessGuard for unauthorized; the other two
-// are not reachable from this iteration's call sites — see docs/testing.md).
+// produced by other callers (auditDenied, called from handleToolsCall's
+// authorize-failure path, for unauthorized; the other two are not reachable
+// from this iteration's call sites — see docs/testing.md).
 func classifyOutcome(result ToolResult, err error) string {
 	switch {
 	case err != nil:
@@ -194,13 +192,17 @@ func (c auditCall) end(s *Server, outcome string, result ToolResult) {
 	})
 }
 
-// auditDenied records a scope-based access denial (403, mcpAccessGuard,
-// httpserver.go) as one attempt+completion pair with outcome=unauthorized.
-// The guard runs before dispatch ever sees the request, so this is the only
-// point that can audit that denial; it never blocks or changes the 403
-// response — if the sink itself is unavailable, the denial is simply not
-// recorded (best_effort) rather than failing the already-decided rejection.
-func (s *Server) auditDenied(r *http.Request, toolName string, rawArgs json.RawMessage) {
+// auditDenied records an authorization denial (handleToolsCall's
+// s.authorize failure path, server.go) as one attempt+completion pair with
+// outcome=unauthorized. This is the only point that can audit that denial:
+// dispatch never reaches the tool, so beginAuditCall/end never runs for it.
+// principal is read from the request context by the caller (D118) rather
+// than derived here, so this function has no *http.Request dependency and
+// audits identically over HTTP and stdio. It never blocks or changes the
+// caller's already-decided error response — if the sink itself is
+// unavailable, the denial is simply not recorded (best_effort) rather than
+// failing the already-decided rejection a second time.
+func (s *Server) auditDenied(principal, toolName string, rawArgs json.RawMessage) {
 	s.mu.Lock()
 	log, kbName, transport := s.auditLog, s.kbName, s.transport
 	s.mu.Unlock()
@@ -218,7 +220,6 @@ func (s *Server) auditDenied(r *http.Request, toolName string, rawArgs json.RawM
 		readOnly = t.ReadOnly
 	}
 	resources := extractResources(canonical, rawArgs)
-	principal := principalIDFromRequest(r)
 	requestID := newAuditRequestID()
 	start := time.Now()
 
@@ -230,8 +231,8 @@ func (s *Server) auditDenied(r *http.Request, toolName string, rawArgs json.RawM
 	if err != nil {
 		// Sink unhealthy: nothing safe to record for this denial (a
 		// completion here would pair with an attempt that never landed on
-		// disk). The 403 is unaffected either way — the call was already
-		// going to be denied.
+		// disk). The denial response is unaffected either way — the call was
+		// already going to be denied.
 		return
 	}
 	_, _ = log.AppendEvent(audit.Entry{
@@ -240,25 +241,6 @@ func (s *Server) auditDenied(r *http.Request, toolName string, rawArgs json.RawM
 		Phase: audit.PhaseCompletion, Outcome: audit.OutcomeUnauthorized,
 		DurationMs: time.Since(start).Milliseconds(),
 	})
-}
-
-// principalIDFromRequest derives a stable, opaque principal identifier from
-// the request's bearer token: the hex SHA-256 of the token, truncated to 16
-// characters — never the token itself, never reversible to it. Returns "" if
-// the request carries no bearer token (auth disabled, or an already-rejected
-// request that never reaches this point).
-func principalIDFromRequest(r *http.Request) string {
-	const prefix = "Bearer "
-	v := r.Header.Get("Authorization")
-	if !strings.HasPrefix(v, prefix) {
-		return ""
-	}
-	token := strings.TrimPrefix(v, prefix)
-	if token == "" {
-		return ""
-	}
-	sum := sha256.Sum256([]byte(token))
-	return hex.EncodeToString(sum[:])[:16]
 }
 
 // newAuditRequestID returns a random 32-hex-char correlation ID pairing one

--- a/internal/mcpserver/audit_test.go
+++ b/internal/mcpserver/audit_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/BeppeTemp/cartographer/internal/audit"
+	"github.com/BeppeTemp/cartographer/internal/auth"
 )
 
 func auditServer(t *testing.T, opts audit.Options) (*Server, *audit.Log, string) {
@@ -85,6 +86,57 @@ func TestAuditRecordsAttemptAndCompletionPair(t *testing.T) {
 	for i, e := range entries {
 		if e.Tool != "ok_tool" {
 			t.Errorf("entry %d tool = %q", i, e.Tool)
+		}
+	}
+}
+
+// TestAuditRecordsDenialAttemptAndCompletionPair is the audit-of-denial
+// contract (D132, issue #122): handleToolsCall returns as soon as s.authorize
+// fails, before beginAuditCall would otherwise run — so a scope/permission
+// denial must still leave an attempt+completion pair, with outcome
+// unauthorized, via auditDenied, or a denied call would be invisible in the
+// log.
+func TestAuditRecordsDenialAttemptAndCompletionPair(t *testing.T) {
+	s, _, path := auditServer(t, audit.Options{})
+	called := false
+	s.RegisterTool(Tool{
+		Name: "guarded_tool", ReadOnly: true,
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+		Handler: func(requestContext, json.RawMessage) (ToolResult, error) {
+			called = true
+			return textResult("should never run"), nil
+		},
+	})
+
+	// A non-admin principal with no authorizer installed is fail-closed
+	// (Server.authorize), the same shape a real scope denial takes.
+	ctx := restrictedContext(auth.Policy{})
+	resp := s.dispatch(ctx, &Request{
+		ID:     json.RawMessage(`1`),
+		Method: "tools/call",
+		Params: json.RawMessage(`{"name":"guarded_tool","arguments":{}}`),
+	})
+	tr := decodeToolResult(t, resp)
+	if !tr.IsError {
+		t.Fatalf("denied call did not return an error result: %+v", tr)
+	}
+	if called {
+		t.Fatal("denied call reached the tool handler")
+	}
+
+	entries := auditEntries(t, path)
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want a denial attempt+completion pair: %+v", len(entries), entries)
+	}
+	if entries[0].Phase != audit.PhaseAttempt {
+		t.Errorf("first entry phase = %q, want %q", entries[0].Phase, audit.PhaseAttempt)
+	}
+	if entries[1].Phase != audit.PhaseCompletion || entries[1].Outcome != audit.OutcomeUnauthorized {
+		t.Errorf("second entry = %q/%q, want completion/%q", entries[1].Phase, entries[1].Outcome, audit.OutcomeUnauthorized)
+	}
+	for i, e := range entries {
+		if e.Tool != "guarded_tool" {
+			t.Errorf("entry %d tool = %q, want %q", i, e.Tool, "guarded_tool")
 		}
 	}
 }

--- a/internal/mcpserver/httpserver.go
+++ b/internal/mcpserver/httpserver.go
@@ -1,7 +1,6 @@
 package mcpserver
 
 import (
-	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -135,8 +134,10 @@ func statusForResponse(era protocolEra, resp Response) int {
 // The point of the check is that the headers exist for intermediaries that
 // route or rate-limit without parsing a JSON-RPC body — which means a client
 // could describe itself one way to the proxy and another way to the server.
-// The body remains the only thing this server acts on (see mcpAccessGuard);
-// the headers are validated against it and then discarded.
+// The body remains the only thing this server acts on for authorization,
+// which happens later in dispatch (the authorizer installed by
+// installPolicy, internal/mcpserver/policy.go); the headers are validated
+// against it here and then discarded.
 //
 // Header names are matched case-insensitively (net/http canonicalises them);
 // values are compared exactly.
@@ -190,98 +191,6 @@ func decodeMcpName(v string) string {
 		return v
 	}
 	return string(decoded)
-}
-
-// mcpAccessGuard wraps next (an /mcp handler for a single KB) with per-KB,
-// per-tool r/rw scope enforcement. Scopes come from the request context
-// (auth.ScopesFromContext, populated by TokenStore.Middleware from the
-// token's configured scopes); a nil/empty scope list means full access
-// (admin token) and the guard passes through unconditionally.
-//
-// To decide whether the request needs write access it peeks the JSON-RPC
-// body: any method other than "tools/call" (initialize, tools/list, ping,
-// ...) is treated as read-only; "tools/call" needs write iff
-// ToolRequiresWrite(params.name) — fail-closed, so an unparsable body or an
-// unknown tool name requires write. The body is always restored on r.Body
-// (via io.NopCloser over the buffered bytes) so the wrapped handler, which
-// reads it again from scratch, sees the exact original bytes.
-//
-// Special case (M4, D47): service_get is classified ReadOnly (it only reads
-// frontmatter+body by default), but with arguments.resolve_secrets==true it
-// decrypts and returns the service's secrets — access to secrets requires at
-// least the same privilege as a write. The tool-name classification in
-// ToolRequiresWrite can't see arguments, so this per-argument override lives
-// here, at the one place that already parses the JSON-RPC body.
-//
-// D128: the 2026-07-28 mirror headers (Mcp-Method, Mcp-Name) name the same
-// method and tool this function parses out of the body, and must never become
-// its input. They are client-controlled and exist for intermediaries; reading
-// authorization off them would create exactly the two-sources-of-truth split
-// the spec mandates header validation to close. They are checked against the
-// body downstream, in validateMirrorHeaders.
-//
-// srv is the KB's own *Server: its ToolRequiresWrite method strips this
-// server's tool-name prefix (D102), if any, before classifying — so a
-// prefixed write tool is still correctly rejected for a read-only scope.
-//
-// D119: a denial of an actual "tools/call" request is recorded as one
-// attempt+completion audit event pair (outcome=unauthorized) via
-// srv.auditDenied, since this is the one place that decides the denial —
-// dispatch (and its own audit wrapping in handleToolsCall) never runs for a
-// request rejected here. Denials of any other JSON-RPC method (e.g. a
-// wrong-KB scoped token hitting tools/list) are not tool calls and are not
-// audited, matching handleToolsCall's own scope.
-func mcpAccessGuard(kbName string, srv *Server, next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		scopes := auth.ScopesFromContext(r.Context())
-		if len(scopes) == 0 {
-			next.ServeHTTP(w, r)
-			return
-		}
-
-		body, err := io.ReadAll(io.LimitReader(r.Body, 2<<20))
-		if err != nil {
-			http.Error(w, "read error", http.StatusBadRequest)
-			return
-		}
-		r.Body = io.NopCloser(bytes.NewReader(body))
-
-		needWrite := true // fail-closed: an unparsable request requires write access
-		isToolCall := false
-		var toolName string
-		var toolArgs json.RawMessage
-		var req Request
-		if err := json.Unmarshal(body, &req); err == nil {
-			if req.Method != "tools/call" {
-				needWrite = false
-			} else {
-				isToolCall = true
-				var params struct {
-					Name      string          `json:"name"`
-					Arguments json.RawMessage `json:"arguments"`
-				}
-				_ = json.Unmarshal(req.Params, &params) // ignore errors: ToolRequiresWrite("") is fail-closed too
-				toolName, toolArgs = params.Name, params.Arguments
-				var resolve struct {
-					ResolveSecrets bool `json:"resolve_secrets"`
-				}
-				_ = json.Unmarshal(params.Arguments, &resolve)
-				needWrite = srv.ToolRequiresWrite(toolName)
-				if srv.StripToolPrefix(toolName) == "service_get" && resolve.ResolveSecrets {
-					needWrite = true
-				}
-			}
-		}
-
-		if !auth.HasAccess(scopes, kbName, needWrite) {
-			if isToolCall {
-				srv.auditDenied(r, toolName, toolArgs)
-			}
-			auth.Forbidden(w)
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
 }
 
 // auditState returns this Server's attached audit sink health (D119), or nil
@@ -375,61 +284,6 @@ func (s *Server) ListenAndServe(addr string) error {
 	return http.ListenAndServe(addr, handler)
 }
 
-// ListenAndServeWithHandler starts the HTTP server with a custom handler wrapper
-// (e.g. for adding auth middleware).
-func (s *Server) ListenAndServeWithHandler(addr string, wrap func(http.Handler) http.Handler) error {
-	handler := wrap(s.HTTPHandler())
-	log.Printf("MCP HTTP server listening on %s", addr)
-	return http.ListenAndServe(addr, handler)
-}
-
-// ListenAndServeHandler starts an HTTP server with the given handler.
-func ListenAndServeHandler(addr string, handler http.Handler) error {
-	return http.ListenAndServe(addr, handler)
-}
-
-// WellKnownHandler returns a handler for /.well-known/oauth-protected-resource.
-func WellKnownHandler(metadataJSON []byte) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write(metadataJSON)
-	}
-}
-
-// FullHTTPHandler returns a combined handler with /mcp, /health, and
-// /.well-known endpoints. allowedOrigins is the OriginGuard allow-list applied
-// to the MCP endpoint (nil = same-origin only).
-func (s *Server) FullHTTPHandler(oauthMetadata []byte, allowedOrigins []string) http.Handler {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/mcp", s.handleMCP)
-	mux.HandleFunc("/health", s.handleHealth)
-	mux.HandleFunc("/ready", s.handleReady)
-	mux.HandleFunc("/clients", s.handleClients)
-	if oauthMetadata != nil {
-		mux.HandleFunc("/.well-known/oauth-protected-resource", WellKnownHandler(oauthMetadata))
-	}
-
-	// CORS headers for browser-based clients. The allow-origin header echoes
-	// the origin OriginGuard accepted rather than "*" (D128): a wildcard tells
-	// every browser its page may read the response, which is the other half of
-	// what makes a rebinding attack pay off.
-	cors := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, MCP-Protocol-Version, Mcp-Method, Mcp-Name")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(http.StatusNoContent)
-			return
-		}
-		mux.ServeHTTP(w, r)
-	})
-	return OriginGuard(allowedOrigins, cors)
-}
-
 // KBInfo holds metadata about a mounted KB for kb_list responses.
 type KBInfo struct {
 	Name   string `json:"name"`
@@ -507,8 +361,37 @@ func (m *MultiKBServer) MountKBWithPrefix(name, prefix string, setupFn func(s *S
 	return nil
 }
 
+// resourceBaseURL reconstructs this server's own externally-visible base URL
+// (scheme://host, no path) from one request, for RFC 9728's self-describing
+// "resource" and "authorization_servers" fields (D132): cartographer
+// validates its own static bearer tokens rather than delegating to a
+// separate OAuth authorization server (docs/transport-auth.md), so there is
+// no distinct issuer to plumb through config — the server names itself in
+// both fields. scheme is inferred from X-Forwarded-Proto (set by a
+// TLS-terminating reverse proxy) or, failing that, from whether the
+// connection itself is TLS; r.Host already carries the port, if any.
+// X-Forwarded-Proto is client-controlled when no proxy overwrites it, so only
+// the two schemes this server can actually be reached on are honoured, and
+// only the first hop of a proxy chain ("https, http") is read.
+func resourceBaseURL(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		first := strings.TrimSpace(strings.Split(proto, ",")[0])
+		if first == "http" || first == "https" {
+			scheme = first
+		}
+	}
+	return scheme + "://" + r.Host
+}
+
 // Handler returns the HTTP handler that routes MCP requests to the correct
-// KB server. Three ways to select a KB:
+// KB server, plus /health, /ready, /clients and the RFC 9728
+// well-known/oauth-protected-resource metadata endpoint (D132; auth.go's
+// isPublicPath exempts the same path from authentication). Three ways to
+// select a KB:
 //   - bare /mcp: auto-routes when exactly one KB is mounted;
 //   - /mcp?kb=<name>: explicit selection by query parameter;
 //   - /mcp/<name>: explicit selection by path.
@@ -529,6 +412,17 @@ func (m *MultiKBServer) Handler() http.Handler {
 				"ready":   len(m.servers) > 0,
 			}
 			json.NewEncoder(w).Encode(result)
+			return
+
+		case r.URL.Path == auth.WellKnownProtectedResourcePath:
+			if r.Method != http.MethodGet {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			base := resourceBaseURL(r)
+			w.Write(auth.ProtectedResourceMetadata(base, base))
 			return
 
 		case r.URL.Path == "/ready":

--- a/internal/mcpserver/httpserver_test.go
+++ b/internal/mcpserver/httpserver_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/BeppeTemp/cartographer/internal/auth"
 )
 
 // newMultiKBTestHandler mounts the given KB names on a fresh MultiKBServer
@@ -78,6 +80,43 @@ func TestMultiKB_PathRouting_AgreeingKBSelection(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("/mcp/kbx?kb=kbx: status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestMultiKB_WellKnownProtectedResource_ServedWithoutAuth is the RFC 9728
+// contract (D132, issue #122): docs/transport-auth.md promises the server
+// publishes Protected Resource Metadata, and auth.go's isPublicPath already
+// exempts this path from authentication — this asserts the production
+// handler (MultiKBServer.Handler, the one cmd/cartographer/serve.go wraps in
+// auth.TokenStore.Middleware) actually answers it, unauthenticated, with the
+// expected JSON, instead of falling through to the "not found" default.
+func TestMultiKB_WellKnownProtectedResource_ServedWithoutAuth(t *testing.T) {
+	multi := newMultiKBTestHandler(t, "kbx")
+	ts := auth.NewScopedTokenStore([]auth.ScopedToken{
+		{Token: "some-tok", Scopes: []auth.KBScope{{KB: "kbx", Write: false}}},
+	})
+	handler := ts.Middleware(multi.Handler())
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+	req.Host = "cartographer.example.com"
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req) // no Authorization header: must not be rejected
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON body: %v", err)
+	}
+	if body["resource"] != "http://cartographer.example.com" {
+		t.Errorf("resource = %v, want %q", body["resource"], "http://cartographer.example.com")
+	}
+	if _, ok := body["authorization_servers"]; !ok {
+		t.Error("missing authorization_servers")
+	}
+	if _, ok := body["bearer_methods_supported"]; !ok {
+		t.Error("missing bearer_methods_supported")
 	}
 }
 
@@ -283,13 +322,12 @@ func TestClients_EmptyRoster(t *testing.T) {
 // 405 on /clients for every handler constructor.
 func TestClients_MethodNotAllowed(t *testing.T) {
 	s := New("test")
-	// Single-KB handlers.
+	// Single-KB handler.
 	for _, v := range []struct {
 		h    http.Handler
 		desc string
 	}{
 		{s.HTTPHandler(), "HTTPHandler"},
-		{s.FullHTTPHandler(nil, nil), "FullHTTPHandler"},
 	} {
 		for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete} {
 			req := httptest.NewRequest(method, "/clients", nil)
@@ -312,9 +350,9 @@ func TestClients_MethodNotAllowed(t *testing.T) {
 	}
 }
 
-// TestClients_ThreeHandlers verifies /clients answers on all three handler
-// constructors (HTTPHandler, FullHTTPHandler, MultiKBServer.Handler).
-func TestClients_ThreeHandlers(t *testing.T) {
+// TestClients_HandlerConstructors verifies /clients answers on both handler
+// constructors (HTTPHandler, MultiKBServer.Handler).
+func TestClients_HandlerConstructors(t *testing.T) {
 	// Build a single-KB server and populate the roster by hitting /mcp.
 	k := setupTestKB(t)
 	s := New("test")
@@ -335,7 +373,6 @@ func TestClients_ThreeHandlers(t *testing.T) {
 		h    http.Handler
 	}{
 		{"HTTPHandler", s.HTTPHandler()},
-		{"FullHTTPHandler", s.FullHTTPHandler(nil, nil)},
 	} {
 		req := httptest.NewRequest(http.MethodGet, "/clients", nil)
 		rr := httptest.NewRecorder()

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -596,8 +596,9 @@ const toolsListTTLMillis = 60_000
 
 // handleToolsCall routes the call to the correct tool. Authorization runs
 // before the handler for every call — a denial never reaches tool logic — and
-// an attempt+completion audit event pair is recorded around the dispatch when
-// an audit sink is attached (SetAuditLog, D119; see audit.go).
+// an attempt+completion audit event pair is recorded around the dispatch (on
+// authorization failure, via auditDenied; on dispatch, via beginAuditCall/end)
+// when an audit sink is attached (SetAuditLog, D119/D132; see audit.go).
 func (s *Server) handleToolsCall(ctx context.Context, req *Request) Response {
 	var params struct {
 		Name      string          `json:"name"`
@@ -624,6 +625,10 @@ func (s *Server) handleToolsCall(ctx context.Context, req *Request) Response {
 	principal := auth.PrincipalFromContext(ctx).ID
 
 	if err := s.authorize(ctx, canonicalName, args); err != nil {
+		// D119/D132: a denial is audited here, at the point the decision
+		// actually happens — before this returned early and the call below
+		// (which records success/failure of the dispatched tool) never ran.
+		s.auditDenied(principal, params.Name, args)
 		return successResponse(req.ID, errorResult(err.Error()))
 	}
 

--- a/internal/mcpserver/tools_skill.go
+++ b/internal/mcpserver/tools_skill.go
@@ -59,10 +59,9 @@ func toolServiceGet(k *kb.KB) Tool {
 		// ReadOnly for the default path: it only reads frontmatter+body. With
 		// resolve_secrets=true it decrypts and returns the service's secrets,
 		// which requires write-equivalent privilege — that override is NOT
-		// expressed here (Tool.ReadOnly is a per-tool-name classification
-		// consulted by the HTTP guard before arguments are known) but as a
-		// special case in mcpAccessGuard (httpserver.go, D47) that inspects
-		// arguments.resolve_secrets directly.
+		// expressed here (Tool.ReadOnly is a per-tool-name classification) but
+		// as a special case in the authorizer (policy.go's authorizeTool, D47)
+		// that inspects arguments.resolve_secrets directly.
 		ReadOnly:    true,
 		Description: "Reads a concept of type Service. Returns frontmatter (YAML) and body. With resolve_secrets=true, also decrypts and returns the service's secrets_source (requires rw scope).",
 		InputSchema: json.RawMessage(`{


### PR DESCRIPTION
Closes #122.

All three steps of the issue's suggested shape.

### 1. An authorization denial is now audited

`handleToolsCall` returned as soon as `s.authorize` failed — before
`beginAuditCall` — so a denied call produced no audit events at all, even though
`audit.OutcomeUnauthorized` is part of the D119 contract. The denial is now
audited at the point the decision happens. `auditDenied` lost its `*http.Request`
parameter in favour of the principal the context already carries (D118), so it
audits identically over HTTP and stdio; `principalIDFromRequest` is gone.

Verified against a real `bin/cartographer`, one KB, `--tokens 'reader|kb:kb1:r'`,
`CARTOGRAPHER_AUDIT_LOG` set:

| Request | Response | Audit lines appended |
|---|---|---|
| `tools/call kb_status` (allowed) | `result` | 2 (attempt + `success`) |
| `tools/call map_create` (denied) | `isError: true`, `"forbidden"` | **2** (attempt + `unauthorized`, same `request_id`, principal set) — was 0 |

### 2. RFC 9728 metadata is served

`docs/transport-auth.md` promised it and `auth.go` exempted the path from
authentication, but nothing answered it (404). The route is now registered in
`MultiKBServer.Handler` — the handler `cmd/cartographer/serve.go` actually builds
— so it is reachable in production; `OriginGuard` already passes through
non-`/mcp` paths. Verified: `GET /.well-known/oauth-protected-resource` → 200
with the metadata JSON, no `Authorization` header needed.

Cartographer validates its own static bearer tokens rather than delegating to a
separate authorization server, so it names itself in both `resource` and
`authorization_servers`, derived from the request's own authority.
`X-Forwarded-Proto` is honoured only for `http`/`https` and only its first hop,
since it is client-controlled when no proxy overwrites it.

### 3. The dead code is gone

Removed `mcpAccessGuard`, `FullHTTPHandler`, `WellKnownHandler`,
`ListenAndServeWithHandler` and `ListenAndServeHandler` — none had a production
caller. The comments in `audit.go`, `httpserver.go` and `tools_skill.go` that
pointed at the guard as the place where access is decided now point at
`policy.go`'s `authorizeTool`, which is what is actually wired.

Docs: `docs/transport-auth.md` updated; decision record **D132** in
`docs/decisions/transport-auth.md` for the audit-coverage correction.

`make vet && make test && make smoke && make smoke-http` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)