### PR TITLE
fix(mcpserver): select the protocol era by header value, not presence

### DIFF
--- a/docs/decisions/transport-auth.md
+++ b/docs/decisions/transport-auth.md
@@ -345,3 +345,45 @@ path continues to live in `OriginGuard`, unaffected by this change. `Server.HTTP
 no `.well-known` route) and the plain `Server.ListenAndServe` are unaffected: neither is on the
 production path (`serveHTTP` always mounts through `MultiKBServer`, even for one KB) but both remain
 for direct single-KB embedding and their own tests, which this issue did not ask to remove.
+
+---
+
+<a id="d133"></a>
+## D133 — The version header selects the era by value, not by presence
+
+**Decision.** `Request.resolveEra` switches to the `2026-07-28` era from the
+`MCP-Protocol-Version` header only when that header's value is exactly
+`2026-07-28`. Any other value — an earlier revision, or one this server does not
+know — leaves the request in the handshake era. The
+`_meta.io.modelcontextprotocol/protocolVersion` path is unchanged: a client that
+sets that reserved key is declaring the new revision, so an unsupported value
+there still yields `-32022`.
+
+**Context.** D128 keyed the era off the header's *presence*
+(`if headerVersion != ""`). That silently assumed only a `2026-07-28` client
+would ever send it, which is wrong: `MCP-Protocol-Version` has been part of the
+HTTP transport since `2025-06-18`, so a conformant client on an earlier revision
+sends it while sending none of the mirrored headers `validateMirrorHeaders`
+demands. Such a client was classified into the new era and then rejected with
+`-32020 missing required header Mcp-Method` — and had it passed that check it
+would have hit `-32022`, since `SupportedProtocolVersions` does not list the
+intermediate revisions. Found on `v0.6.0` against a real client, reported as
+issue #126.
+
+**Rationale.** This restores D128's own stated invariant — a handshake-era
+client sees byte-identical responses to what it saw before `2026-07-28` was
+served — which the presence check violated for every client that sends the
+header. Before D128 the header was not read at all, so falling back to the
+handshake era on any other value *is* the pre-D128 behaviour, not a new policy.
+Keying on the exact value is also the narrowest fix available: it needs no list
+of known earlier revisions to maintain, and it leaves the new era's own
+requirements untouched — a client naming `2026-07-28` without the mirror headers
+is still correctly rejected.
+
+**Consequences.** A client sending an unknown or future version in the header is
+served the handshake era rather than told its version is unsupported. That is
+the right trade while both eras are served, but it stops being so once the
+handshake era is retired: D130 (#118) already specifies that afterwards any
+version other than `2026-07-28` gets `-32022` with a single-entry list, and this
+branch is one of the places that plan must delete. Noted here so the retirement
+does not have to rediscover it.

--- a/docs/transport-auth.md
+++ b/docs/transport-auth.md
@@ -27,8 +27,13 @@ negotiated and nothing is remembered:
 
 | Era | Identified by | Shape |
 |---|---|---|
-| handshake (`2024-11-05`) | neither marker below | `initialize`/`ping` available; results exactly as before |
-| `2026-07-28` | `params._meta.io.modelcontextprotocol/protocolVersion`, **or** the `MCP-Protocol-Version` header | `resultType` + `_meta` server info on every result |
+| handshake (`2024-11-05`) | neither marker below — including an `MCP-Protocol-Version` header naming an *earlier* revision | `initialize`/`ping` available; results exactly as before |
+| `2026-07-28` | `params._meta.io.modelcontextprotocol/protocolVersion`, **or** an `MCP-Protocol-Version` header whose value is exactly `2026-07-28` | `resultType` + `_meta` server info on every result |
+
+The header selects the new era by its **value**, not by being present (D133).
+Clients on earlier revisions send `MCP-Protocol-Version` too — the header
+predates this revision — and they must keep landing in the handshake era, since
+they send none of the mirrored headers that era requires.
 
 A handshake-era client sees byte-identical responses to the ones it saw before
 `2026-07-28` was served at all. `server/discover` answers in both eras and

--- a/internal/mcpserver/protocol.go
+++ b/internal/mcpserver/protocol.go
@@ -117,7 +117,14 @@ func (r *Request) resolveEra(headerVersion string) error {
 		}
 		r.era, r.protocolVersion = era20260728, v
 	}
-	if headerVersion != "" {
+	// Only the new revision's own version selects the new era. Any other value
+	// leaves the request in the handshake era, which is exactly what happened
+	// before D128, when this header was not read at all: sending
+	// MCP-Protocol-Version is conformant for a client on an earlier revision
+	// (the header predates 2026-07-28), and such a client sends none of the
+	// mirror headers validateMirrorHeaders would then demand. Keying off the
+	// header's presence instead of its value rejected those clients (D133).
+	if headerVersion == ProtocolVersion20260728 {
 		r.era = era20260728
 		if r.protocolVersion == "" {
 			r.protocolVersion = headerVersion

--- a/internal/mcpserver/protocol_era_test.go
+++ b/internal/mcpserver/protocol_era_test.go
@@ -311,6 +311,27 @@ func TestHTTP_HandshakeEraNeedsNoHeaders(t *testing.T) {
 	}
 }
 
+// A version header naming anything other than 2026-07-28 leaves the request in
+// the handshake era (D133). Sending MCP-Protocol-Version is conformant for a
+// client on an earlier revision — the header predates this one — and such a
+// client sends none of the mirror headers. Keying the era off the header's
+// presence rather than its value rejected those clients with -32020.
+func TestHTTP_OldVersionHeaderStaysHandshakeEra(t *testing.T) {
+	for _, version := range []string{SupportedProtocolVersion, "2025-06-18", "2025-11-25"} {
+		t.Run(version, func(t *testing.T) {
+			rr := serveHTTPReq(t, newEraPost(toolsListBody, map[string]string{
+				"MCP-Protocol-Version": version,
+			}))
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+			}
+			if result := resultMap(t, decodeRPC(t, rr)); result["resultType"] != nil {
+				t.Errorf("resultType = %v, want the handshake envelope (absent)", result["resultType"])
+			}
+		})
+	}
+}
+
 func TestHTTP_McpNameBase64Sentinel(t *testing.T) {
 	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"kb_status","arguments":{},` + metaNewEra + `}}`
 	encoded := "=?base64?" + base64.StdEncoding.EncodeToString([]byte("kb_status")) + "?="


### PR DESCRIPTION
Closes #126.

`resolveEra` switched to the `2026-07-28` era whenever `MCP-Protocol-Version`
was present, without reading it. That header has been part of the HTTP transport
since `2025-06-18`, so a conformant client on an earlier revision sends it while
sending none of the mirrored headers the new era requires — and got
`-32020 missing required header Mcp-Method`. Had it passed that check it would
have hit `-32022`, since `SupportedProtocolVersions` does not list the
intermediate revisions.

This violated the invariant D128 itself states: a handshake-era client sees
byte-identical responses to what it saw before `2026-07-28` was served. Before
D128 the header was not read at all, so falling back to the handshake era on any
other value restores the previous behaviour rather than inventing a new policy.

Verified on `bin/cartographer`, one KB, body
`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`:

| Request headers | Before | After |
|---|---|---|
| *(none)* | `result` | `result` |
| `MCP-Protocol-Version: 2025-06-18` | **`-32020`** | **`result`** (handshake era) |
| `MCP-Protocol-Version: 2026-07-28` | `-32020` | `-32020` — unchanged, correct |
| `2026-07-28` + `Mcp-Method: tools/list` | `result` | `result` |

Row 3 stays an error on purpose: a client naming the new revision without its
mirror headers should be rejected.

The `_meta.io.modelcontextprotocol/protocolVersion` path is untouched — setting
that reserved key still declares the new revision, and an unsupported value
there still yields `-32022`.

Tests: `TestHTTP_OldVersionHeaderStaysHandshakeEra` covers `2024-11-05`,
`2025-06-18` and `2025-11-25`, asserting 200 and the handshake envelope.
`TestHTTP_HeaderAloneSelectsNewEra` already pinned the `2026-07-28` case and
still passes unchanged.

Docs: `docs/transport-auth.md` §Protocol versions now says the header selects by
value; decision record **D133**, which also flags this branch as one D130 (#118)
must delete when the handshake era is retired.

`make vet && make test && make smoke && make smoke-http && make e2e` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)