### PR TITLE
feat(cli)!: require a git remote for `kb create`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,16 @@ first KB, and connect an agent client to it.
 ```bash
 brew install beppetemp/tap/cartographer   # or curl install.sh, or `go install` (see Install above)
 cartographer service install              # generates config, installs and starts the service
-cartographer kb create <name>             # scaffolds a KB in the service's data dir
+cartographer kb create <name> --remote <url>  # scaffolds a KB in the data dir, pushes it to <url>
 cartographer connect                      # connects an agent client (Claude Code, OpenCode, Codex, Kiro)
 ```
 
-`cartographer kb create <name>` prints how to get the server to pick up the new KB
-(`cartographer service restart`, or `--restart` to do it and wait for it automatically); `service
-install` itself hints at `kb create` if it starts with no KB mounted yet.
+`--remote <url>` is an **empty** git repository that becomes the KB's `origin`: a KB is a git
+repository, and that remote is what makes it durable and syncable (`--no-remote` creates a
+local-only KB that is neither, D134). A repository that already holds a KB is mounted with
+`cartographer kb clone <remote>` instead. `kb create` prints how to get the server to pick up the
+new KB (`cartographer service restart`, or `--restart` to do it and wait for it automatically);
+`service install` itself hints at `kb create` if it starts with no KB mounted yet.
 
 Upgrades of a native local install (`brew upgrade` or `install.sh update`) repair themselves:
 the new binary restarts the running service and re-synchronizes the configured providers in

--- a/cmd/cartographer/connect.go
+++ b/cmd/cartographer/connect.go
@@ -65,7 +65,7 @@ func probeServer(opts connectOptions) (probeState, error) {
 // first-KB onboarding case from auth and network failures.
 func probeErrorMessage(state probeState, err error) string {
 	if state == probeNoKB {
-		return "server is up but no KB is mounted — create one with: cartographer kb create <name>, then: cartographer service restart"
+		return "server is up but no KB is mounted — create one with: cartographer kb create <name> --remote <url>, then: cartographer service restart"
 	}
 	if errors.Is(err, client.ErrUnauthorized) {
 		return fmt.Sprintf("server reached but the token was rejected (check Token env var / Auth): %v", err)

--- a/cmd/cartographer/kbcmd.go
+++ b/cmd/cartographer/kbcmd.go
@@ -50,7 +50,7 @@ func cmdKB(args []string) int {
 	case "clone":
 		return cmdKBClone(rest)
 	default:
-		fmt.Fprintln(os.Stderr, "Error: usage: cartographer kb create <name> [--data <dir>] [--restart]\n       cartographer kb clone <remote> [name] [--data <dir>] [--restart]")
+		fmt.Fprintln(os.Stderr, "Error: usage: cartographer kb create <name> (--remote <url> | --no-remote) [--data <dir>] [--restart]\n       cartographer kb clone <remote> [name] [--data <dir>] [--restart]")
 		return 2
 	}
 }
@@ -75,32 +75,42 @@ func validateKBName(name string) error {
 	return nil
 }
 
-// cmdKBCreate implements `cartographer kb create <name> [--data <dir>]
-// [--restart]`: scaffolds a new KB at <data>/<name> via the same kb.Init
-// bootstrap used by `serve --kb <path> --init` (git init + OKF layout), then
-// prints guidance on how to get the server to pick it up (WP2, D85). The
-// data dir resolution mirrors `service install`'s: the running service's
-// config YAML `data:` field, falling back to defaultDataDir()
-// (~/cartographer-data); --data overrides both.
+// cmdKBCreate implements `cartographer kb create <name> (--remote <url> |
+// --no-remote) [--data <dir>] [--restart]`: scaffolds a new KB at
+// <data>/<name> via the same kb.Init bootstrap used by `serve --kb <path>
+// --init` (git init + OKF layout), attaches its git remote, then prints
+// guidance on how to get the server to pick it up (WP2, D85). The remote is
+// not optional (D134): a KB without an origin is neither durable nor
+// syncable, and nothing downstream surfaces that state — `--no-remote` is the
+// explicit opt-out for a throwaway local KB. The data dir resolution mirrors
+// `service install`'s: the running service's config YAML `data:` field,
+// falling back to defaultDataDir() (~/cartographer-data); --data overrides
+// both.
 func cmdKBCreate(args []string) int {
 	// <name> is a leading positional argument, before the flags (see usage:
-	// "kb create <name> [--data <dir>] [--restart]") — flag.Parse stops at
+	// "kb create <name> (--remote <url> | --no-remote) …") — flag.Parse stops at
 	// the first non-flag token, so it must be pulled out first (same
 	// splitPositional dance as `service <target>` and `sync <provider>`).
 	name, rest := splitPositional(args, "")
 
 	fs := flag.NewFlagSet("kb create", flag.ExitOnError)
 	dataFlag := fs.String("data", "", "KB data directory (default: the server config's data:, or "+defaultDataDir()+")")
+	remoteFlag := fs.String("remote", "", "Git remote URL of an empty repository: attached as origin and pushed to")
+	noRemoteFlag := fs.Bool("no-remote", false, "Create a local-only KB with no origin (not durable, never synced)")
 	restartFlag := fs.Bool("restart", false, "Restart the local service and wait until healthy after creating the KB")
 	fs.Parse(rest)
 
 	if name == "" || fs.NArg() != 0 {
-		fmt.Fprintln(os.Stderr, "Usage: cartographer kb create <name> [--data <dir>] [--restart]")
+		fmt.Fprintln(os.Stderr, "Usage: cartographer kb create <name> (--remote <url> | --no-remote) [--data <dir>] [--restart]")
 		return 2
 	}
 	if err := validateKBName(name); err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)
 		return 2
+	}
+	remote := strings.TrimSpace(*remoteFlag)
+	if code := checkRemoteChoice(remote, *noRemoteFlag); code != 0 {
+		return code
 	}
 
 	dataDir := *dataFlag
@@ -123,10 +133,73 @@ func cmdKBCreate(args []string) int {
 		fmt.Fprintln(os.Stderr, "Error:", err)
 		return 1
 	}
+	if remote != "" {
+		if code := attachOrigin(path, remote); code != 0 {
+			// Same guarantee as kb clone's cleanup: never leave a
+			// half-provisioned KB where auto-discovery can mount it.
+			_ = os.RemoveAll(path)
+			return code
+		}
+	}
 	fmt.Printf("KB %q created at %s\n", name, path)
+	if remote != "" {
+		fmt.Printf("origin: %s\n", remote)
+	} else {
+		printNoRemoteWarning(path)
+	}
 
 	printPostCreateGuidanceFn(*restartFlag)
 	return 0
+}
+
+// checkRemoteChoice validates the --remote/--no-remote pair, which is a
+// deliberate choice the caller has to make (D134): it returns 0 when exactly
+// one of them is set, and the usage exit code (2) otherwise, after printing
+// the three ways to get a KB.
+func checkRemoteChoice(remote string, noRemote bool) int {
+	if remote != "" && noRemote {
+		fmt.Fprintln(os.Stderr, "Error: --remote and --no-remote are mutually exclusive")
+		return 2
+	}
+	if remote == "" && !noRemote {
+		fmt.Fprintln(os.Stderr, "Error: a KB needs a git remote — that is what makes it durable and syncable.")
+		fmt.Fprintln(os.Stderr, "  cartographer kb create <name> --remote <url>   empty repository, becomes this KB's origin")
+		fmt.Fprintln(os.Stderr, "  cartographer kb clone <remote>                 repository that already holds a KB")
+		fmt.Fprintln(os.Stderr, "  cartographer kb create <name> --no-remote      local-only KB (not durable, never synced)")
+		return 2
+	}
+	return 0
+}
+
+// attachOrigin wires the freshly scaffolded KB at path to remote as "origin"
+// and pushes its initial commit with upstream tracking, so the KB is
+// reconstructible from its repository the moment it exists. Returns the exit
+// code to use (0 on success); on failure the caller removes the scaffold.
+func attachOrigin(path, remote string) int {
+	if err := gitx.AddRemote(path, "origin", remote); err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		return 1
+	}
+	branch, err := gitx.Branch(path)
+	if err != nil || branch == "" {
+		branch = gitx.DefaultBranch
+	}
+	if err := gitx.PushSetUpstream(path, "origin", branch); err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		fmt.Fprintln(os.Stderr, "Hint: authenticate git with your SSH agent or credential helper, then retry.")
+		fmt.Fprintf(os.Stderr, "Hint: if the remote already holds a KB, mount it instead: cartographer kb clone %s\n", remote)
+		return 1
+	}
+	return 0
+}
+
+// printNoRemoteWarning states what --no-remote costs, on stderr: the KB is a
+// purely local git repository, so it has no backup and every sync path is
+// inert for it (kb.hasRemote, CARTOGRAPHER_GIT_SYNC).
+func printNoRemoteWarning(path string) {
+	fmt.Fprintln(os.Stderr, "Warning: this KB has no origin — it is not backed up and will never sync.")
+	fmt.Fprintf(os.Stderr, "  Attach one later with: git -C %s remote add origin <url> && git -C %s push -u origin %s\n",
+		path, path, gitx.DefaultBranch)
 }
 
 // cmdKBClone implements `cartographer kb clone <remote> [name] [--data <dir>]

--- a/cmd/cartographer/kbcmd_test.go
+++ b/cmd/cartographer/kbcmd_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/BeppeTemp/cartographer/internal/gitx"
 	"github.com/BeppeTemp/cartographer/internal/kb"
 )
 
@@ -52,7 +53,7 @@ func TestCmdKBCreateScaffold(t *testing.T) {
 	var code int
 	out := withStdout(t, func() {
 		withNoGuidance(t, func() {
-			code = cmdKBCreate([]string{"alpha", "--data", dataDir})
+			code = cmdKBCreate([]string{"alpha", "--data", dataDir, "--no-remote"})
 		})
 	})
 	if code != 0 {
@@ -71,14 +72,14 @@ func TestCmdKBCreateSecondRunError(t *testing.T) {
 	dataDir := t.TempDir()
 
 	withNoGuidance(t, func() {
-		if code := cmdKBCreate([]string{"alpha", "--data", dataDir}); code != 0 {
+		if code := cmdKBCreate([]string{"alpha", "--data", dataDir, "--no-remote"}); code != 0 {
 			t.Fatalf("first cmdKBCreate = %d, want 0", code)
 		}
 	})
 
 	var code int
 	withNoGuidance(t, func() {
-		code = cmdKBCreate([]string{"alpha", "--data", dataDir})
+		code = cmdKBCreate([]string{"alpha", "--data", dataDir, "--no-remote"})
 	})
 	if code == 0 {
 		t.Fatal("second cmdKBCreate = 0, want non-zero (already exists)")
@@ -90,10 +91,117 @@ func TestCmdKBCreateInvalidName(t *testing.T) {
 
 	var code int
 	withNoGuidance(t, func() {
-		code = cmdKBCreate([]string{"not/valid", "--data", dataDir})
+		code = cmdKBCreate([]string{"not/valid", "--data", dataDir, "--no-remote"})
 	})
 	if code == 0 {
 		t.Fatal("cmdKBCreate with invalid name = 0, want non-zero")
+	}
+}
+
+// TestCmdKBCreateRequiresRemoteChoice covers D134's gate: neither flag, and
+// both flags, are usage errors (exit 2) that create nothing.
+func TestCmdKBCreateRequiresRemoteChoice(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"no choice", nil},
+		{"both", []string{"--remote", "file:///tmp/x.git", "--no-remote"}},
+	}
+	for _, tc := range cases {
+		dataDir := t.TempDir()
+		var code int
+		withNoGuidance(t, func() {
+			code = cmdKBCreate(append([]string{"alpha", "--data", dataDir}, tc.args...))
+		})
+		if code != 2 {
+			t.Errorf("%s: cmdKBCreate = %d, want 2", tc.name, code)
+		}
+		if _, err := os.Stat(filepath.Join(dataDir, "alpha")); !os.IsNotExist(err) {
+			t.Errorf("%s: KB created despite usage error: %v", tc.name, err)
+		}
+	}
+}
+
+// TestCmdKBCreateNoRemoteLeavesNoOrigin pins the opt-out: a KB is scaffolded,
+// and it has no origin configured.
+func TestCmdKBCreateNoRemoteLeavesNoOrigin(t *testing.T) {
+	if !hasGit() {
+		t.Skip("git not in PATH, skipping KB create remote test")
+	}
+
+	dataDir := t.TempDir()
+	var code int
+	withNoGuidance(t, func() {
+		code = cmdKBCreate([]string{"alpha", "--data", dataDir, "--no-remote"})
+	})
+	if code != 0 {
+		t.Fatalf("cmdKBCreate --no-remote = %d, want 0", code)
+	}
+	if _, err := gitx.RemoteURL(filepath.Join(dataDir, "alpha"), "origin"); err == nil {
+		t.Error("--no-remote KB has an origin remote, want none")
+	}
+}
+
+// TestCmdKBCreateWithRemotePushes checks the happy path end to end: origin is
+// attached and the initial commit is reachable from the remote's branch.
+func TestCmdKBCreateWithRemotePushes(t *testing.T) {
+	if !hasGit() {
+		t.Skip("git not in PATH, skipping KB create remote test")
+	}
+
+	tmp := t.TempDir()
+	bare := filepath.Join(tmp, "alpha.git")
+	mustRunGit(t, "", "init", "--bare", bare)
+	remote := "file://" + bare
+
+	dataDir := filepath.Join(tmp, "data")
+	var code int
+	withNoGuidance(t, func() {
+		code = cmdKBCreate([]string{"alpha", "--data", dataDir, "--remote", remote})
+	})
+	if code != 0 {
+		t.Fatalf("cmdKBCreate --remote = %d, want 0", code)
+	}
+
+	kbPath := filepath.Join(dataDir, "alpha")
+	got, err := gitx.RemoteURL(kbPath, "origin")
+	if err != nil {
+		t.Fatalf("origin not configured: %v", err)
+	}
+	if got != remote {
+		t.Errorf("origin = %q, want %q", got, remote)
+	}
+	local, err := gitx.HeadSHA(kbPath)
+	if err != nil {
+		t.Fatalf("HeadSHA: %v", err)
+	}
+	pushed, err := gitx.HeadSHAAt(bare, gitx.DefaultBranch)
+	if err != nil {
+		t.Fatalf("HeadSHAAt(bare, %s): %v", gitx.DefaultBranch, err)
+	}
+	if pushed != local {
+		t.Errorf("remote %s = %s, want local HEAD %s", gitx.DefaultBranch, pushed, local)
+	}
+}
+
+// TestCmdKBCreateRemoteFailureCleansScaffold pins the rollback invariant: an
+// unreachable remote must not leave a mountable KB behind.
+func TestCmdKBCreateRemoteFailureCleansScaffold(t *testing.T) {
+	if !hasGit() {
+		t.Skip("git not in PATH, skipping KB create remote test")
+	}
+
+	dataDir := t.TempDir()
+	var code int
+	withNoGuidance(t, func() {
+		code = cmdKBCreate([]string{"alpha", "--data", dataDir, "--remote", "file:///does-not-exist/missing.git"})
+	})
+	if code == 0 {
+		t.Fatal("cmdKBCreate with unreachable remote = 0, want non-zero")
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "alpha")); !os.IsNotExist(err) {
+		t.Fatalf("scaffold still exists after failed push: %v", err)
 	}
 }
 

--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -1,8 +1,10 @@
 # Agent-driven installation
 
-Use this runbook when the user supplies the Cartographer repository link and, optionally, the git
-remote for their first Knowledge Base (KB). Execute every command in order; report the expected
-result before continuing.
+Use this runbook when the user supplies the Cartographer repository link and the git remote for
+their first Knowledge Base (KB). A KB is a git repository and its remote is what makes it durable
+and syncable, so the remote is required: if the user did not supply one, **ask for it before step
+3** — an empty repository they own (GitHub, Gitea, or any git host). Execute every command in
+order; report the expected result before continuing.
 
 ## 1. Install Cartographer
 
@@ -53,7 +55,7 @@ Expected output: the native user service is installed and started. It listens on
 
 ## 3. Mount the first KB
 
-When the user supplied a KB remote, mount it through Cartographer:
+When the remote already contains a KB, mount it through Cartographer:
 
 ```bash
 cartographer kb clone <git-remote-url> --restart
@@ -62,13 +64,18 @@ cartographer kb clone <git-remote-url> --restart
 Expected output: `KB "<name>" mounted at <data-dir>/<name>`, followed by service restart and
 health guidance. Do not clone the repository into the service data directory yourself.
 
-When no remote was supplied, create a new KB instead:
+When the remote is an empty repository, create the KB in it:
 
 ```bash
-cartographer kb create <name> --restart
+cartographer kb create <name> --remote <git-remote-url> --restart
 ```
 
-Expected output: `KB "<name>" created at <data-dir>/<name>`, followed by `service healthy`.
+Expected output: `KB "<name>" created at <data-dir>/<name>`, then `origin: <git-remote-url>`,
+followed by `service healthy`.
+
+Ask for a remote before running either command. Only if the user explicitly accepts a throwaway,
+local-only KB — not backed up and never synchronized — fall back to `cartographer kb create <name>
+--no-remote --restart`, and state that limitation back to them.
 
 ## 4. Connect the executing agent
 
@@ -111,3 +118,6 @@ operations, diagnosis, upgrades, and synchronization after installation.
 | The service reports that port 39273 is busy | Stop or reconfigure the process using the port, then rerun `cartographer service install`. |
 | `kb clone` reports a git authentication failure | Configure ambient credentials (an SSH agent for SSH remotes or a git credential helper for HTTPS), then rerun the same `kb clone` command. |
 | `kb clone` says `not an OKF KB` | Use the `kb-import` skill to import the remote into an OKF KB, push it, then rerun `kb clone`. |
+| `kb create` says a KB needs a git remote | Ask the user for an empty repository URL and rerun with `--remote <url>`; use `--no-remote` only if they explicitly accept a local-only KB. |
+| `kb create --remote` fails to push (non-fast-forward, or the remote is not empty) | The repository already has content: mount it with `cartographer kb clone <git-remote-url> --restart` instead. |
+| `kb create --remote` reports a git authentication failure | Configure ambient credentials (an SSH agent for SSH remotes or a git credential helper for HTTPS), then rerun the same command — the failed scaffold was already removed. |

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -129,7 +129,7 @@ install and start the local service (`cartographer service install` with default
 `/health` for up to 10s, then an automatic re-probe). In the non-interactive path, a deferred
 materialization to a loopback URL only adds a hint on stderr suggesting
 `cartographer service install` when unreachable; a reachable 0-KB server instead prints
-`cartographer kb create <name>` followed by `cartographer service restart`. A successful connect
+`cartographer kb create <name> --remote <url>` followed by `cartographer service restart`. A successful connect
 prints the absolute paths of generated MCP configs and reminds the user to restart the selected
 agent sessions to load the MCP tools.
 

--- a/docs/decisions/deployment-release.md
+++ b/docs/decisions/deployment-release.md
@@ -211,7 +211,9 @@ actually accepted.
 <a id="d85"></a>
 ## D85 — `kb create` and first-KB onboarding: a CLI command, not only the agentic skill
 
-**Status: implemented (2026-07-24).**
+**Status: implemented (2026-07-24); amended by [D134](#d134)** — the remote-less
+creation this entry introduced as the default is now an explicit `--no-remote`
+opt-out.
 
 **Context.** With an empty data dir the server mounts 0 KBs and `/mcp` 400s, but nothing guided a
 first-time user to create one: the CLI dispatch had no `kb` subcommand — creation existed only as
@@ -345,3 +347,50 @@ imposed (a skew warning the user had to act on, plus providers left pointing at
 stale configuration until a manual sync) is no longer justified. D95's
 version-skew reporting remains as-is for Kubernetes, remote servers, and for
 any failure of this repair path.
+
+---
+
+<a id="d134"></a>
+## D134 — `kb create` requires a git remote
+
+**Status: implemented (2026-08-26); amends [D85](#d85).**
+
+**Context.** A KB is a git repository, and its `origin` is what makes it durable
+and reconstructible: the `kb-create` skill opens with a data-loss warning for
+exactly that reason, and every sync path degrades silently without one
+(`hasRemote` in `internal/kb/gitsync.go:27`, the `no_remote` git status, and
+`CARTOGRAPHER_GIT_SYNC` documented as inert for a remote-less KB). The local
+onboarding path did not enforce it: `cmdKBCreate` called `kb.Init` and nothing
+else, and `docs/agent-install.md` presented the remote as optional, falling back
+to a plain `kb create` whenever the user had not supplied one. Observed in the
+field: a from-scratch installation completed successfully and left a local-only
+KB, never prompting for a repository and never surfacing that the KB was neither
+backed up nor syncable.
+
+**Decision.** `cartographer kb create <name>` requires an explicit remote
+decision: `--remote <url>` or `--no-remote`, with neither (or both) a usage
+error (exit 2) that lists the three ways to get a KB — `--remote` for an empty
+repository, `kb clone` for a repository that already holds a KB, `--no-remote`
+for a local-only one. `--remote` attaches the URL as `origin` and pushes the
+initial commit with upstream tracking (`gitx.PushSetUpstream`, added next to
+`Push`, which must keep leaving tracking configuration alone for the sync
+paths). A failure to attach or push removes the scaffold entirely and exits 1,
+with hints separating an authentication failure from a non-empty remote — the
+same cleanup guarantee `kb clone` already gives, so auto-discovery never mounts
+a half-provisioned KB. `--no-remote` keeps the previous behavior and prints a
+stderr warning naming the cost and the recovery commands. The agent runbook
+(`docs/agent-install.md`) instructs the agent to ask for the repository before
+creating anything and to fall back to `--no-remote` only on the user's explicit
+acceptance.
+
+**Rationale.** D85 correctly separated the local CLI path from the GitOps skill,
+but made the remote optional to keep the path short, which made a non-durable KB
+the outcome of the shortest sequence of commands a first-time user runs. The
+product has no other moment where that state becomes visible: nothing prompts
+later, and the sync machinery treats it as normal. Requiring the choice at the
+only point where it is cheap to fix costs one flag and removes the silent
+failure mode; keeping `--no-remote` preserves the throwaway/dev case without
+making it the default.
+
+**Compatibility.** Breaking for scripted `cartographer kb create <name>`
+invocations: adding `--no-remote` restores the previous behavior exactly.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -267,7 +267,7 @@ cartographer service install                 # generates config + plist/unit, st
 cartographer service status                  # binary, config, installed/running/healthy
 cartographer service start|stop|restart
 cartographer service uninstall               # removes the service; config and data remain
-cartographer kb create <name>                # scaffolds a KB in the service's data dir (D85)
+cartographer kb create <name> --remote <url> # scaffolds a KB in the data dir, pushes it to <url> (D85, D134)
 cartographer kb clone <remote>               # mounts an existing remote KB in that data dir (D97)
 ```
 
@@ -277,7 +277,7 @@ cartographer kb clone <remote>               # mounts an existing remote KB in t
 - macOS: LaunchAgent `~/Library/LaunchAgents/com.cartographer.serve.plist` (`KeepAlive`, logging to `~/Library/Logs/cartographer/server.log`). The plist's binary path prefers a stable Homebrew symlink (`/opt/homebrew/bin/cartographer` or `/usr/local/bin/cartographer`) over the versioned Caskroom path, so it survives `brew upgrade` without a re-install (D83);
 - Linux: systemd user unit `~/.config/systemd/user/cartographer.service` (log via `journalctl --user -u cartographer`; on a headless host, `loginctl enable-linger <user>` is needed for the service to survive logout).
 
-Binds to **loopback** by default (`127.0.0.1:39273`) → auth stays in auto-off mode without exposing anything on the network. With an empty (or missing — D83: `serve` creates it and treats it as empty rather than failing) data dir the server starts with 0 KBs — `/health` is still up (liveness: `status:"ok"`) but `/ready` reports `503 {"ready":false}` (D84, §Observability): `cartographer kb create <name>` scaffolds a subfolder KB the same way `serve --kb <path> --init` would (D85), while `cartographer kb clone <remote>` mounts an existing OKF remote there (D97; `service install` itself prints a hint pointing at creation if it starts with 0 KBs mounted), or add `kbs:` entries to clone remotes (§Bootstrapping a KB) — either way, `service restart` (or `kb create --restart` / `kb clone --restart`, which do this for you and wait for the server to report healthy again) is what makes the new KB visible.
+Binds to **loopback** by default (`127.0.0.1:39273`) → auth stays in auto-off mode without exposing anything on the network. With an empty (or missing — D83: `serve` creates it and treats it as empty rather than failing) data dir the server starts with 0 KBs — `/health` is still up (liveness: `status:"ok"`) but `/ready` reports `503 {"ready":false}` (D84, §Observability): `cartographer kb create <name> --remote <url>` scaffolds a subfolder KB the same way `serve --kb <path> --init` would (D85) and pushes it to the empty repository at `<url>`, which becomes its `origin` — the remote is mandatory, `--no-remote` being the explicit opt-out for a local-only, non-durable KB (D134) — while `cartographer kb clone <remote>` mounts an existing OKF remote there (D97; `service install` itself prints a hint pointing at creation if it starts with 0 KBs mounted), or add `kbs:` entries to clone remotes (§Bootstrapping a KB) — either way, `service restart` (or `kb create --restart` / `kb clone --restart`, which do this for you and wait for the server to report healthy again) is what makes the new KB visible.
 
 `service status` uses systemctl-like exit codes: `0` running, `3` installed but stopped, `4` not installed — this is what lets `install.sh update` automatically restart only a running service (see §Client installation).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,13 +31,18 @@ so the server survives reboots and listens on `127.0.0.1:39273`:
 
 ```bash
 cartographer service install    # generates the config, installs and starts the service
-cartographer kb create my-kb --restart
+cartographer kb create my-kb --remote <git-remote-url> --restart
 ```
 
 `kb create` scaffolds the KB in the service's data dir: a git repository with
 `data/index.md` and `data/log.md`, plus a local search index under
-`.cartographer/` (never committed). `--restart` makes the running server pick
-it up. Every write from now on will be one git commit — the KB is a plain
+`.cartographer/` (never committed). `--remote` must point at an **empty**
+repository (GitHub, Gitea, a bare repo — anything git can push to): it becomes
+the KB's `origin`, which is what makes the KB durable and syncable, and the
+initial commit is pushed to it right away. For a repository that already
+contains a KB use `cartographer kb clone <url>` instead; for a throwaway local
+trial, `--no-remote` skips the remote and warns that the KB is neither backed
+up nor synced (D134). `--restart` makes the running server pick it up. Every write from now on will be one git commit — the KB is a plain
 folder of Markdown you can open in any editor or in Obsidian.
 
 > **Running it by hand instead.** For development you can skip the service and

--- a/internal/gitx/gitx.go
+++ b/internal/gitx/gitx.go
@@ -415,6 +415,19 @@ func Push(dir, remote, branch string, env ...string) error {
 	return nil
 }
 
+// PushSetUpstream pushes branch to remote and sets it as the branch's
+// upstream ("git push -u"). Used once, when a KB's origin is first attached
+// (kb create --remote): the sync paths in internal/kb use Push, which must
+// not touch tracking configuration.
+// env carries extra per-KB variables (e.g. GIT_SSH_COMMAND) — see runGitEnv.
+func PushSetUpstream(dir, remote, branch string, env ...string) error {
+	out, err := runGitEnv(dir, env, "push", "-u", remote, branch)
+	if err != nil {
+		return fmt.Errorf("git push -u %s %s: %w: %s", remote, branch, err, out)
+	}
+	return nil
+}
+
 // Rebase rebases current branch onto target (e.g. "origin/main").
 // Returns ErrConflict if there are unresolved conflicts.
 func Rebase(dir, onto string) error {

--- a/internal/skillbundle/bundled/cartographer-ops/SKILL.md
+++ b/internal/skillbundle/bundled/cartographer-ops/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cartographer-ops
 description: Configure, operate, troubleshoot, or upgrade a Cartographer server or client; connect agents and manage Knowledge Bases.
-version: "1.0"
+version: "1.1"
 ---
 # Cartographer Operations
 
@@ -18,7 +18,7 @@ around writes.
 |---|---|
 | `cartographer serve` | Starting the server directly, for development or a custom deployment. |
 | `cartographer service install\|status\|restart` | Installing, checking, or restarting the native local service. |
-| `cartographer kb create <name>` | Creating the first local KB in the service data directory. |
+| `cartographer kb create <name> --remote <url>` | Creating the first local KB in the service data directory, pushed to an empty repository that becomes its `origin`. `--no-remote` opts out into a local-only KB that is neither durable nor synced; the choice is mandatory. |
 | `cartographer kb clone <remote> [name]` | Mounting an existing OKF KB remote in the service data directory. |
 | `cartographer connect [provider\|all] [--agents a,b]` | Connecting one or more detected agent clients to a server. |
 | `cartographer status` | Checking client configuration and provisioning drift. |
@@ -28,7 +28,7 @@ around writes.
 
 `--agents claude,codex` selects a comma-separated subset for `connect` or `disconnect`; do not
 combine it with the positional provider. `connect` probes the server before writing: a reachable
-server with no KBs needs `kb create` followed by `service restart`.
+server with no KBs needs `kb create --remote <url>` followed by `service restart`.
 
 ## Configuration
 
@@ -49,8 +49,9 @@ variables or the platform secret store, not in a committed YAML file.
 
 1. Check `GET /health`. Its `status`, `version`, `ready`, and `kbs` fields distinguish a live
    process from a usable server.
-2. If `ready` is false or no KBs are mounted, run `cartographer kb create <name>` and then
-   `cartographer service restart` for a local service.
+2. If `ready` is false or no KBs are mounted, ask for the git remote the KB belongs to, then run
+   `cartographer kb create <name> --remote <url>` (or `cartographer kb clone <url>` if that
+   repository already holds a KB) and `cartographer service restart` for a local service.
 3. If client artifacts are stale or missing, run `cartographer sync`, then restart the affected
    agent session so it reloads MCP configuration and skills.
 4. If concepts are degraded after a git conflict, use the `kb-conflict-resolve` skill; do not

--- a/internal/skillbundle/bundled/kb-create/SKILL.md
+++ b/internal/skillbundle/bundled/kb-create/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-create
 description: Operator procedure to declare and provision a new Knowledge Base GitOps-style, so it survives pod restarts.
-version: "2.3"
+version: "2.4"
 ---
 # KB Create — Skill
 
@@ -17,6 +17,12 @@ exists as an ad-hoc runtime mount on an emptyDir is **not durable**.
 > rollout the directory is recreated empty and every concept written to it is gone. The
 > ConfigMap + Gitea repo declaration is what makes the KB persistent and reconstructible — the
 > server clones it fresh on every pod start (`docs/deployment.md` §Bootstrap KB da remote git).
+
+> **Local/native-service topology.** On a single machine served by the local service, the
+> equivalent one-liner is `cartographer kb create <name> --remote <url>`: it scaffolds the KB and
+> pushes it to the empty repository that becomes its `origin` (the remote is mandatory there too,
+> D134). This skill remains the procedure for the GitOps/Kubernetes topology below, where the KB
+> also has to be declared in the server's ConfigMap.
 
 ## Steps
 


### PR DESCRIPTION
Closes #130

`cartographer kb create <name>` now demands an explicit remote decision: `--remote <url>` attaches the URL as `origin` and pushes the initial commit with upstream tracking, `--no-remote` opts into a local-only KB and warns that it is neither durable nor synced. Neither flag (or both) is a usage error listing the three ways to get a KB. A failed attach/push removes the scaffold, so auto-discovery never mounts a half-provisioned KB — the same guarantee `kb clone` already gave.

The agent-driven runbook (`docs/agent-install.md`) now instructs the agent to ask for the repository before creating anything, and falls back to `--no-remote` only on the user's explicit acceptance. This is the field failure that motivated the change: a from-scratch installation completed successfully and left a local-only KB, never prompted for a remote, with nothing surfacing that it was neither backed up nor syncable.

Decision record: **D134** in `docs/decisions/deployment-release.md` (amends D85, whose status line is updated). Docs updated in the same change: `agent-install.md`, `getting-started.md`, `deployment.md`, `configurator.md`, `README.md`, plus the bundled `cartographer-ops` and `kb-create` skills (version bumped so `cartographer sync` re-provisions them).

New `gitx.PushSetUpstream` sits next to `Push`, which keeps pushing without `-u`: the sync paths in `internal/kb` must not touch tracking configuration.

Tests: usage-error paths create nothing, `--no-remote` leaves no origin, `--remote` against a bare repo pushes the initial commit, an unreachable remote leaves no scaffold behind. `make vet && make test` green.

> [!WARNING]
> BREAKING CHANGE: `cartographer kb create <name>` without `--remote` or `--no-remote` now exits 2; add `--no-remote` to restore the previous behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)