### PR TITLE
refactor(configurator): declarative provider registry (D137)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ internal/auth/               # TokenStore, Middleware, scopes, RBAC
 internal/skill/               # LoadSkill, Catalog, Validate (SKILL.md)
 internal/sops/               # Decrypt, ResolveRefs, EnvForSkill
 internal/configurator/       # multi-provider adapter (HTTP only): Claude Code, Codex, Kiro, OpenCode
+                             # registry.go: one descriptor per provider (identity, config file, detection)
 internal/provisioning/       # Manifest, Lock/LockFile, Diff, Apply, MergeArtifacts
 internal/agents/             # Detect() agents installed on the machine (claude/opencode/codex/kiro)
 internal/clientconfig/       # .cartographer.yaml (server_url, connected agents, etc.)

--- a/cmd/cartographer/clientsync.go
+++ b/cmd/cartographer/clientsync.go
@@ -299,14 +299,14 @@ func hookRegistrationManagedFile(provider string, w provisioning.ManagedFile) bo
 	if w.Kind != "hook" {
 		return false
 	}
-	switch configurator.Provider(provider) {
-	case configurator.ProviderClaudeCode, configurator.ProviderCodex:
-		return filepath.Base(w.Path) == "hook.json"
-	case configurator.ProviderOpenCode:
-		return filepath.Base(w.Path) == "cartographer-"+w.Name+".js"
-	default:
-		return false
+	p := configurator.Provider(provider)
+	if plugin := provisioning.HookPluginRelPath(p, w.Name); plugin != "" {
+		return filepath.Base(w.Path) == filepath.Base(plugin)
 	}
+	if provisioning.HookRegistrationFile(p) != "" {
+		return filepath.Base(w.Path) == "hook.json"
+	}
+	return false
 }
 
 // printHookRegistered prints the one-line confirmation that a materialized
@@ -315,14 +315,14 @@ func hookRegistrationManagedFile(provider string, w provisioning.ManagedFile) bo
 // the registration, so its own path is printed instead of a separate shared
 // file).
 func printHookRegistered(provider, dir string, w provisioning.ManagedFile) {
+	p := configurator.Provider(provider)
 	var registeredIn string
-	switch configurator.Provider(provider) {
-	case configurator.ProviderClaudeCode:
-		registeredIn = filepath.Join(dir, ".claude", "settings.json")
-	case configurator.ProviderCodex:
-		registeredIn = filepath.Join(dir, ".codex", "config.toml")
-	case configurator.ProviderOpenCode:
+	switch {
+	case provisioning.HookPluginRelPath(p, w.Name) != "":
+		// The generated plugin *is* the registration (D59): print its own path.
 		registeredIn = filepath.Join(dir, w.Path)
+	case provisioning.HookRegistrationFile(p) != "":
+		registeredIn = filepath.Join(dir, provisioning.HookRegistrationFile(p))
 	default:
 		return
 	}
@@ -394,12 +394,14 @@ func resolveProviderCSV(csv string) ([]string, error) {
 }
 
 func resolveProvider(target string) ([]string, error) {
-	switch configurator.Provider(target) {
-	case configurator.ProviderClaudeCode, configurator.ProviderOpenCode, configurator.ProviderCodex, configurator.ProviderKiro:
+	if _, ok := configurator.Lookup(configurator.Provider(target)); ok {
 		return []string{target}, nil
-	default:
-		return nil, fmt.Errorf("unknown provider %q (want claude|opencode|codex|kiro)", target)
 	}
+	names := make([]string, 0, len(configurator.ProviderList()))
+	for _, p := range configurator.ProviderList() {
+		names = append(names, string(p))
+	}
+	return nil, fmt.Errorf("unknown provider %q (want %s)", target, strings.Join(names, "|"))
 }
 
 // splitPositional extracts a single leading positional argument (one not starting

--- a/cmd/cartographer/multikb.go
+++ b/cmd/cartographer/multikb.go
@@ -152,10 +152,11 @@ func kiroFlatNamespaceWarning(providers []string, entries []mcpEntry) string {
 		return ""
 	}
 	for _, p := range providers {
-		if configurator.Provider(p) == configurator.ProviderKiro {
-			return fmt.Sprintf("kiro has a flat MCP tool namespace across servers: writing %d MCP entries "+
-				"means only one KB's tools will be reachable in a Kiro session unless the server mounts the "+
-				"others with a tool_prefix (see docs/deployment.md §MCP tool-name prefix)", len(entries))
+		if d, ok := configurator.Lookup(configurator.Provider(p)); ok && d.FlatToolNamespace {
+			return fmt.Sprintf("%s has a flat MCP tool namespace across servers: writing %d MCP entries "+
+				"means only one KB's tools will be reachable in a %s session unless the server mounts the "+
+				"others with a tool_prefix (see docs/deployment.md §MCP tool-name prefix)",
+				d.Provider, len(entries), d.DisplayName)
 		}
 	}
 	return ""
@@ -263,7 +264,9 @@ func applyMCPEntries(entries []mcpEntry, providers []string, dir string, auth bo
 			}
 			results = append(results, r)
 		}
-		if configurator.Provider(provider) == configurator.ProviderCodex && len(results) > 1 {
+		// TOML providers merge one marker-delimited block per file, so several
+		// entries are concatenated into a single EmitResult.
+		if d, ok := configurator.Lookup(configurator.Provider(provider)); ok && d.MCPFormat == configurator.FormatTOMLBlock && len(results) > 1 {
 			joined := *results[0]
 			for _, r := range results[1:] {
 				joined.Content = append(joined.Content, '\n')

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -308,6 +308,25 @@ found under `search_roots`, or an ambiguous key across several distinct remotes 
 stderr with the full form to use), `2` usage error (missing argument or not in the
 `repo:...`/`path:...` form).
 
+## Adding a provider
+
+Every supported provider is one descriptor in `internal/configurator/registry.go`
+([D137](decisions/client-configurator.md#d137)): its `Provider` constant and wire value, display
+name, native MCP config file and format (`FormatJSON` with its server key, or `FormatTOMLBlock`),
+whether that file may be deleted once emptied (never for Claude Code — `.claude.json` is Claude's
+own shared state), whether it can carry MCP auth headers, whether its MCP tool namespace is flat
+across servers, the detection evidence (binary name, config directories in probe order, optional
+macOS app bundle), and its emitter function.
+
+Two orders are exposed and both are user-visible: `Providers()` — the order `EmitAll` and the
+client subcommands iterate — and `DetectionOrder()`, the order `cartographer agents` and the TUI
+list agents in.
+
+Adding a provider therefore means: one descriptor, one emitter (the four output formats genuinely
+differ, so that stays code), its cells in the kind × provider matrix (`internal/provisioning`, see
+[`sync.md`](sync.md) §Kind × provider matrix), and — if it has a native hook mechanism — one entry
+in `hookMechanisms`. A missing matrix cell fails a completeness test; nothing else needs editing.
+
 ## Files generated per provider (HTTP transport)
 
 | Provider | Generated file | Key |

--- a/docs/decisions/client-configurator.md
+++ b/docs/decisions/client-configurator.md
@@ -347,3 +347,43 @@ where a command change is the most likely of the two. `internal/provisioning/hoo
 Claude Code's `settings.json`) has the same shape and the same blind spot, but no duplication was
 reproducible there — its JSON path never goes through orphan adoption — so it is left unchanged
 pending an actual reproduction.
+
+---
+
+<a id="d137"></a>
+## D137 — Declarative provider registry: two tables, owned by the packages that own the concepts
+
+**Decision.** Provider knowledge becomes data in two tables rather than one global registry.
+`internal/configurator/registry.go` owns provider **identity and config-file shape**: one
+`Descriptor` per provider with its constant and wire value, display name, native MCP config file
+and format (JSON with its server key, or a marker-delimited TOML block), whether that file may be
+deleted once emptied, whether it can carry MCP auth headers, whether its tool namespace is flat
+across servers, its detection evidence (binary, config directories in probe order, optional macOS
+app bundle), and its emitter. `internal/provisioning` owns the **kind × provider destination
+matrix** plus the `hookMechanisms` table describing how each provider registers a hook natively.
+Two orders are exported and both preserved because both are user-visible: `Providers()` (emission
+and client iteration) and `DetectionOrder()` (`cartographer agents` and the TUI).
+
+Every matrix cell either names a destination or is marked `unsupported`. A cell **missing** for a
+known (kind, provider) pair is a programming error caught by a completeness test, not a silent
+degradation to `Unsupported` at apply time — before this, a forgotten switch arm and a deliberate
+"this provider cannot do hooks" were the same empty string. An unknown *kind* or *provider*
+(a manifest from a newer server) still yields "" and is filtered upstream by `FilterForProvider`;
+previously an unknown kind fell through to the skill arm and would have been materialized as one.
+
+**What deliberately stays code.** The four MCP emitters and `translateAgentForProvider`: the output
+formats genuinely differ, and data-driving them would only relocate the difference. Two documented
+special cases keep naming a provider directly: `configurator.Remove`'s cleanup of the legacy
+`.codex/config.json` an old version wrote, and `sync_apply`
+(`internal/mcpserver/tools_sync.go`), where the server materializes for Claude Code by
+construction — it is not choosing among providers.
+
+**Rationale.** Adding a provider meant editing the same four constants across eight files, and the
+matrix documented in `sync.md` existed in the code only as five nested switches whose `default` arm
+returned a bare empty string — the shape was invisible to a reader and unenforced on a contributor.
+A single global registry was rejected: `provisioning` imports `configurator` and never the reverse,
+so putting destination paths in the lower layer would invert the dependency and place provisioning
+knowledge in the wrong package. Two tables, each owned where the concept lives, keep the direction
+intact. The refactor is behaviour-preserving by construction: the existing suite, including the
+connect/disconnect round trip and the configurator goldens, passes unmodified.
+

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -109,7 +109,7 @@ that same native service over loopback HTTP; any other endpoint is skipped rathe
 
 ## Kind × provider matrix
 
-Resolved by `destDir(kind, name, provider)`; an unmapped combination is `unsupported` (≠ `needs_approval`: no approval would unblock it) and clients filter it out upstream with `FilterForProvider` — it counts as neither drift nor pending ([D50](decisions/sync-provisioning.md#d50)).
+The matrix below is data in the code: `destinationMatrix` in `internal/provisioning/provisioning.go`, resolved by `destDir(kind, name, provider)` ([D137](decisions/client-configurator.md#d137)). Every cell either names a destination or is explicitly `unsupported` — a cell *missing* from the table fails a completeness test instead of degrading silently. `unsupported` is not `needs_approval` (no approval would unblock it): clients filter such artifacts out upstream with `FilterForProvider`, and they count as neither drift nor pending ([D50](decisions/sync-provisioning.md#d50)).
 
 | Kind | claude | opencode | codex | kiro |
 |---|---|---|---|---|

--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -37,71 +37,38 @@ func dirExists(path string) bool {
 	return err == nil && fi.IsDir()
 }
 
-// Detect probes the local machine for the four supported agent providers.
-// An agent is Installed if at least one heuristic matches (binary in PATH or
-// a well-known config directory present).
+// Detect probes the local machine for every supported provider, in the
+// registry's detection order (D137: identity and detection evidence live in
+// internal/configurator's descriptors, not in per-provider functions here).
+// An agent is Installed if at least one heuristic matches: its binary in PATH,
+// then its config directories in descriptor order, then — on darwin only — its
+// application bundle.
 func Detect() []Agent {
 	home, _ := userHomeDir()
-	return []Agent{
-		detectClaude(home),
-		detectOpenCode(home),
-		detectCodex(home),
-		detectKiro(home),
+	out := make([]Agent, 0, len(configurator.DetectionOrder()))
+	for _, d := range configurator.DetectionOrder() {
+		out = append(out, detect(d, home))
 	}
+	return out
 }
 
-func detectClaude(home string) Agent {
-	a := Agent{Provider: configurator.ProviderClaudeCode, Name: "Claude Code"}
-	if path, err := lookPath("claude"); err == nil {
-		a.Installed, a.Evidence = true, path
-		return a
+func detect(d configurator.Descriptor, home string) Agent {
+	a := Agent{Provider: d.Provider, Name: d.DisplayName}
+	if d.Binary != "" {
+		if path, err := lookPath(d.Binary); err == nil {
+			a.Installed, a.Evidence = true, path
+			return a
+		}
 	}
-	if dir := filepath.Join(home, ".claude"); dirExists(dir) {
-		a.Installed, a.Evidence = true, dir
+	for _, segments := range d.ConfigDirs {
+		dir := filepath.Join(append([]string{home}, segments...)...)
+		if dirExists(dir) {
+			a.Installed, a.Evidence = true, dir
+			return a
+		}
 	}
-	return a
-}
-
-func detectOpenCode(home string) Agent {
-	a := Agent{Provider: configurator.ProviderOpenCode, Name: "OpenCode"}
-	if path, err := lookPath("opencode"); err == nil {
-		a.Installed, a.Evidence = true, path
-		return a
-	}
-	if dir := filepath.Join(home, ".config", "opencode"); dirExists(dir) {
-		a.Installed, a.Evidence = true, dir
-		return a
-	}
-	if dir := filepath.Join(home, ".opencode"); dirExists(dir) {
-		a.Installed, a.Evidence = true, dir
-	}
-	return a
-}
-
-func detectCodex(home string) Agent {
-	a := Agent{Provider: configurator.ProviderCodex, Name: "Codex CLI"}
-	if path, err := lookPath("codex"); err == nil {
-		a.Installed, a.Evidence = true, path
-		return a
-	}
-	if dir := filepath.Join(home, ".codex"); dirExists(dir) {
-		a.Installed, a.Evidence = true, dir
-	}
-	return a
-}
-
-func detectKiro(home string) Agent {
-	a := Agent{Provider: configurator.ProviderKiro, Name: "Kiro"}
-	if path, err := lookPath("kiro"); err == nil {
-		a.Installed, a.Evidence = true, path
-		return a
-	}
-	if dir := filepath.Join(home, ".kiro"); dirExists(dir) {
-		a.Installed, a.Evidence = true, dir
-		return a
-	}
-	if goos == "darwin" && dirExists("/Applications/Kiro.app") {
-		a.Installed, a.Evidence = true, "/Applications/Kiro.app"
+	if d.DarwinAppDir != "" && goos == "darwin" && dirExists(d.DarwinAppDir) {
+		a.Installed, a.Evidence = true, d.DarwinAppDir
 	}
 	return a
 }

--- a/internal/configurator/configurator.go
+++ b/internal/configurator/configurator.go
@@ -119,18 +119,11 @@ func EmitServer(name string, spec ServerSpec, provider Provider) (*EmitResult, e
 	if err := validateServerSpec(name, spec); err != nil {
 		return nil, err
 	}
-	switch provider {
-	case ProviderClaudeCode:
-		return emitClaudeCodeServer(name, spec)
-	case ProviderCodex:
-		return emitCodexServer(name, spec)
-	case ProviderKiro:
-		return emitKiroServer(name, spec)
-	case ProviderOpenCode:
-		return emitOpenCodeServer(name, spec)
-	default:
+	d, ok := Lookup(provider)
+	if !ok {
 		return nil, fmt.Errorf("unknown provider: %s", provider)
 	}
+	return d.emit(name, spec)
 }
 
 // validateServerSpec keeps direct EmitServer callers from silently dropping
@@ -157,7 +150,7 @@ func validateServerSpec(name string, spec ServerSpec) error {
 
 // EmitAll generates the configuration for all providers.
 func EmitAll(cfg *ServerConfig) ([]*EmitResult, error) {
-	providers := []Provider{ProviderClaudeCode, ProviderCodex, ProviderKiro, ProviderOpenCode}
+	providers := ProviderList()
 	results := make([]*EmitResult, 0, len(providers))
 	for _, p := range providers {
 		r, err := Emit(cfg, p)
@@ -341,7 +334,7 @@ func Remove(cfg *ServerConfig, provider Provider, baseDir string, dryRun bool) (
 	// leaves nothing behind but that (now-deleted) key and, for opencode, the
 	// "$schema" hint, there is nothing worth keeping — delete the file outright
 	// instead of leaving an empty shell nobody reads.
-	if provider != ProviderClaudeCode && isEmptyProviderShell(root) {
+	if d, ok := Lookup(provider); ok && d.DeletableWhenEmpty && isEmptyProviderShell(root) {
 		if err := os.Remove(fullPath); err != nil {
 			return false, fmt.Errorf("remove %s: %w", fullPath, err)
 		}

--- a/internal/configurator/registry.go
+++ b/internal/configurator/registry.go
@@ -1,0 +1,169 @@
+package configurator
+
+import "path/filepath"
+
+// This file is the single description of every supported provider (D137):
+// identity, the native MCP config file and its format, and the evidence that
+// says the agent is installed on this machine. Adding a provider means adding
+// one descriptor here plus whatever genuinely differs (its emitter, and its
+// cells in internal/provisioning's kind × provider matrix) — not editing the
+// same four constants across eight files.
+//
+// This package owns provider *identity and config-file shape* only.
+// Destination paths for materialized artifacts belong to
+// internal/provisioning, which imports this package and never the reverse.
+
+// ConfigFormat is how a provider's MCP config file is written.
+type ConfigFormat int
+
+const (
+	// FormatJSON: the whole file is a JSON object, merged key by key.
+	FormatJSON ConfigFormat = iota
+	// FormatTOMLBlock: a hand-curated TOML file into which Cartographer
+	// merges only a marker-delimited managed block (D58).
+	FormatTOMLBlock
+)
+
+// Descriptor describes one supported provider.
+type Descriptor struct {
+	Provider    Provider
+	DisplayName string // human-readable, e.g. "Claude Code"
+
+	// MCPConfigPath is the provider's native MCP configuration file, relative
+	// to the client base dir. It is the file `cartographer connect` writes
+	// Cartographer's own entry into, and the same file KB-provided "mcp"
+	// artifacts are merged into (internal/provisioning/mcpsettings.go).
+	MCPConfigPath string
+	MCPFormat     ConfigFormat
+	// MCPServerKey is the top-level JSON key holding the map of MCP server
+	// entries. Empty for FormatTOMLBlock providers.
+	MCPServerKey string
+	// DeletableWhenEmpty says whether the config file may be deleted once
+	// removing Cartographer's entries leaves nothing worth keeping (D63).
+	// False for Claude Code: .claude.json is Claude's own shared state file
+	// (model, permissions, agent state) and is never deleted, only reduced.
+	DeletableWhenEmpty bool
+
+	// SupportsMCPHeaders says whether the provider can carry per-server HTTP
+	// headers (auth) in its MCP config. False for kiro, whose emitter has
+	// never represented them (D69): a KB-provided server with headers is
+	// materialized with a warning rather than silently unauthenticated.
+	SupportsMCPHeaders bool
+
+	// FlatToolNamespace marks a client whose MCP tool namespace is flat
+	// across servers, so two KBs mounted without a tool_prefix collide and
+	// only one stays reachable (D102/D144).
+	FlatToolNamespace bool
+
+	// Binary is the executable name looked up in PATH by internal/agents.
+	Binary string
+	// ConfigDirs are directories relative to the user's home, probed in this
+	// order when the binary is absent.
+	ConfigDirs [][]string
+	// DarwinAppDir, when set, is an absolute application bundle path probed
+	// last on darwin only.
+	DarwinAppDir string
+
+	// emit renders one MCP server entry for this provider. The four output
+	// formats genuinely differ, so this stays a function, not data.
+	emit func(name string, spec ServerSpec) (*EmitResult, error)
+}
+
+// descriptors is the registry, in the order EmitAll and the client
+// subcommands iterate providers. That order is user-visible; keep it stable.
+var descriptors = []Descriptor{
+	{
+		Provider:           ProviderClaudeCode,
+		DisplayName:        "Claude Code",
+		MCPConfigPath:      ".claude.json",
+		MCPFormat:          FormatJSON,
+		MCPServerKey:       "mcpServers",
+		DeletableWhenEmpty: false,
+		SupportsMCPHeaders: true,
+		Binary:             "claude",
+		ConfigDirs:         [][]string{{".claude"}},
+		emit:               emitClaudeCodeServer,
+	},
+	{
+		Provider:           ProviderCodex,
+		DisplayName:        "Codex CLI",
+		MCPConfigPath:      ".codex/config.toml",
+		MCPFormat:          FormatTOMLBlock,
+		DeletableWhenEmpty: true,
+		SupportsMCPHeaders: true,
+		Binary:             "codex",
+		ConfigDirs:         [][]string{{".codex"}},
+		emit:               emitCodexServer,
+	},
+	{
+		Provider:           ProviderKiro,
+		DisplayName:        "Kiro",
+		MCPConfigPath:      ".kiro/settings/mcp.json",
+		MCPFormat:          FormatJSON,
+		MCPServerKey:       "mcpServers",
+		DeletableWhenEmpty: true,
+		FlatToolNamespace:  true,
+		Binary:             "kiro",
+		ConfigDirs:         [][]string{{".kiro"}},
+		DarwinAppDir:       "/Applications/Kiro.app",
+		emit:               emitKiroServer,
+	},
+	{
+		Provider:           ProviderOpenCode,
+		DisplayName:        "OpenCode",
+		MCPConfigPath:      "opencode.json",
+		MCPFormat:          FormatJSON,
+		MCPServerKey:       "mcp",
+		DeletableWhenEmpty: true,
+		SupportsMCPHeaders: true,
+		Binary:             "opencode",
+		ConfigDirs:         [][]string{{".config", "opencode"}, {".opencode"}},
+		emit:               emitOpenCodeServer,
+	},
+}
+
+// detectionOrder is the order `cartographer agents` and the TUI list agents
+// in. It differs from the registry order above and is equally user-visible:
+// both are preserved deliberately rather than unified (D137).
+var detectionOrder = []Provider{ProviderClaudeCode, ProviderOpenCode, ProviderCodex, ProviderKiro}
+
+// Providers returns every supported provider's descriptor, in registry order.
+func Providers() []Descriptor {
+	out := make([]Descriptor, len(descriptors))
+	copy(out, descriptors)
+	return out
+}
+
+// DetectionOrder returns the descriptors in the order agent detection reports
+// them.
+func DetectionOrder() []Descriptor {
+	out := make([]Descriptor, 0, len(detectionOrder))
+	for _, p := range detectionOrder {
+		if d, ok := Lookup(p); ok {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// Lookup returns the descriptor for p, or ok=false for an unknown provider.
+func Lookup(p Provider) (Descriptor, bool) {
+	for _, d := range descriptors {
+		if d.Provider == p {
+			return d, true
+		}
+	}
+	return Descriptor{}, false
+}
+
+// ConfigPath returns MCPConfigPath in the local filesystem's separator form.
+func (d Descriptor) ConfigPath() string { return filepath.FromSlash(d.MCPConfigPath) }
+
+// ProviderList returns just the provider constants, in registry order.
+func ProviderList() []Provider {
+	out := make([]Provider, 0, len(descriptors))
+	for _, d := range descriptors {
+		out = append(out, d.Provider)
+	}
+	return out
+}

--- a/internal/configurator/registry_internal_test.go
+++ b/internal/configurator/registry_internal_test.go
@@ -1,0 +1,76 @@
+package configurator
+
+// Consistency tests for the provider registry (D137): the descriptors are the
+// single source of provider identity, so a missing or duplicated one must fail
+// here rather than degrade some caller at runtime.
+
+import "testing"
+
+func TestRegistryHasOneDescriptorPerProvider(t *testing.T) {
+	want := []Provider{ProviderClaudeCode, ProviderCodex, ProviderKiro, ProviderOpenCode}
+
+	if got := len(Providers()); got != len(want) {
+		t.Fatalf("Providers() has %d descriptors, want %d", got, len(want))
+	}
+	seen := map[Provider]bool{}
+	for _, d := range Providers() {
+		if seen[d.Provider] {
+			t.Errorf("duplicate descriptor for %q", d.Provider)
+		}
+		seen[d.Provider] = true
+
+		if d.DisplayName == "" {
+			t.Errorf("%q: empty DisplayName", d.Provider)
+		}
+		if d.MCPConfigPath == "" {
+			t.Errorf("%q: empty MCPConfigPath", d.Provider)
+		}
+		if d.emit == nil {
+			t.Errorf("%q: no emitter", d.Provider)
+		}
+		if d.Binary == "" && len(d.ConfigDirs) == 0 {
+			t.Errorf("%q: no detection evidence at all", d.Provider)
+		}
+		switch d.MCPFormat {
+		case FormatJSON:
+			if d.MCPServerKey == "" {
+				t.Errorf("%q: JSON provider without an MCP server key", d.Provider)
+			}
+		case FormatTOMLBlock:
+			if d.MCPServerKey != "" {
+				t.Errorf("%q: TOML provider must not declare an MCP server key", d.Provider)
+			}
+		}
+	}
+	for _, p := range want {
+		if !seen[p] {
+			t.Errorf("provider constant %q has no descriptor", p)
+		}
+	}
+
+	// The two user-visible orders are preserved deliberately and must cover
+	// exactly the same set.
+	if len(DetectionOrder()) != len(want) {
+		t.Errorf("DetectionOrder() has %d entries, want %d", len(DetectionOrder()), len(want))
+	}
+	if _, ok := Lookup(Provider("nope")); ok {
+		t.Error("Lookup accepted an unknown provider")
+	}
+}
+
+// .claude.json is Claude Code's own shared state file and is never deleted
+// (D63): the invariant lives in the descriptor now, so assert it there.
+func TestClaudeConfigIsNeverDeletable(t *testing.T) {
+	d, ok := Lookup(ProviderClaudeCode)
+	if !ok {
+		t.Fatal("no descriptor for claude")
+	}
+	if d.DeletableWhenEmpty {
+		t.Error("claude's config file must never be deletable when empty")
+	}
+	for _, other := range Providers() {
+		if other.Provider != ProviderClaudeCode && !other.DeletableWhenEmpty {
+			t.Errorf("%q: expected an MCP-only config file, deletable when empty", other.Provider)
+		}
+	}
+}

--- a/internal/provisioning/bootstrap.go
+++ b/internal/provisioning/bootstrap.go
@@ -93,8 +93,8 @@ func EnsureBootstrapHook(baseDir string, provider configurator.Provider, lock Lo
 			filepath.Join(destRel, "hook.json"),
 			filepath.Join(destRel, bootstrapScriptName),
 		}
-		if provider == configurator.ProviderOpenCode {
-			relPaths = append(relPaths, openCodePluginRelPath(BootstrapHookName))
+		if pluginRel := HookPluginRelPath(provider, BootstrapHookName); pluginRel != "" {
+			relPaths = append(relPaths, pluginRel)
 		}
 	} else {
 		fullDestDir := filepath.Join(baseDir, destRel)
@@ -123,37 +123,12 @@ func EnsureBootstrapHook(baseDir string, provider configurator.Provider, lock Lo
 		// Register in the provider's native mechanism, reusing exactly the
 		// D57/D58/D59 primitives — the very same code Apply uses for KB
 		// hooks, with the hook.json just written above acting as the bridge.
-		switch provider {
-		case configurator.ProviderClaudeCode:
-			if err := registerHookSettings(baseDir, BootstrapHookName, fullDestDir); err != nil {
-				return Lock{}, fmt.Errorf("provisioning: register bootstrap hook in settings.json: %w", err)
-			}
-		case configurator.ProviderCodex:
-			// The repair warning (D99) is dropped here: EnsureBootstrapHook has
-			// no warnings channel, and connect/sync already surface the same
-			// repair on the MCP entry, which is what makes the file visibly
-			// change.
-			if _, err := registerHookConfigTOML(baseDir, BootstrapHookName, fullDestDir); err != nil {
-				return Lock{}, fmt.Errorf("provisioning: register bootstrap hook in config.toml: %w", err)
-			}
-		case configurator.ProviderOpenCode:
-			// openCodePluginRelPath prefixes with "cartographer-" unconditionally
-			// (same helper every KB hook uses) — for BootstrapHookName
-			// ("cartographer-bootstrap") that yields a double-prefixed file name
-			// (cartographer-cartographer-bootstrap.js). Documented, deliberate
-			// (D60): reusing the shared helper verbatim keeps registration and
-			// removal (removeOpenCodePlugin, driven by PruneManaged/mf.Name) on
-			// the exact same path-derivation logic, with zero risk of the two
-			// drifting apart — a cosmetic double-prefix is a small price for
-			// that guarantee.
-			pluginRel, warning, err := registerOpenCodePlugin(baseDir, BootstrapHookName, fullDestDir)
+		if mechanism, ok := hookMechanisms[provider]; ok {
+			pluginRel, warning, err := mechanism.register(baseDir, BootstrapHookName, fullDestDir)
 			if err != nil {
-				return Lock{}, fmt.Errorf("provisioning: register bootstrap hook as opencode plugin: %w", err)
+				return Lock{}, err
 			}
-			if warning != "" {
-				// SessionStart is always mapped (openCodeHookEvents) — a warning
-				// here would mean the mapping regressed; treat as a hard error
-				// rather than silently leaving the bootstrap hook unregistered.
+			if warning != "" && mechanism.warningBlocksBootstrap {
 				return Lock{}, fmt.Errorf("provisioning: bootstrap hook: %s", warning)
 			}
 			if pluginRel != "" {
@@ -181,4 +156,100 @@ func EnsureBootstrapHook(baseDir string, provider configurator.Provider, lock Lo
 	}
 	lock.Managed = append(newManaged, managed...)
 	return lock, nil
+}
+
+// hookMechanism describes how a provider registers a materialized hook in its
+// own configuration (D137): claude patches settings.json (D57), codex a
+// marker-delimited block in config.toml (D58), opencode generates a plugin JS
+// file that *is* the registration (D59). A provider absent from
+// hookMechanisms has no hook mechanism at all — kiro, whose "hook" cell in
+// destinationMatrix is unsupported, so nothing reaches here for it.
+type hookMechanism struct {
+	// settingsFile is the provider-native file the registration is written
+	// into, relative to the base dir. Empty when the registration is a
+	// generated artifact of its own (opencode).
+	settingsFile []string
+	// pluginPath derives that generated artifact's path, relative to the base
+	// dir. Nil when the provider has none.
+	pluginPath func(name string) string
+	// warningBlocksBootstrap makes a non-fatal warning fatal for the
+	// bootstrap hook specifically. True only for opencode: its warning means
+	// the hook's event has no OpenCode equivalent, and SessionStart is always
+	// mapped (openCodeHookEvents) — a warning there would mean the mapping
+	// regressed, and silently leaving the bootstrap hook unregistered is
+	// worse than failing. Codex's warning is a D99 repair notice, informational.
+	warningBlocksBootstrap bool
+	// register performs the registration, returning the relative path of any
+	// generated artifact (so it is tracked as a managed file) plus any
+	// non-fatal warning for the caller to surface.
+	register func(baseDir, name, fullDestDir string) (relPath, warning string, err error)
+}
+
+var hookMechanisms = map[configurator.Provider]hookMechanism{
+	configurator.ProviderClaudeCode: {
+		settingsFile: []string{".claude", "settings.json"},
+		register: func(baseDir, name, fullDestDir string) (string, string, error) {
+			if err := registerHookSettings(baseDir, name, fullDestDir); err != nil {
+				return "", "", fmt.Errorf("provisioning: register hook %s in settings.json: %w", name, err)
+			}
+			return "", "", nil
+		},
+	},
+	configurator.ProviderCodex: {
+		settingsFile: []string{".codex", "config.toml"},
+		register: func(baseDir, name, fullDestDir string) (string, string, error) {
+			warning, err := registerHookConfigTOML(baseDir, name, fullDestDir)
+			if err != nil {
+				return "", "", fmt.Errorf("provisioning: register hook %s in config.toml: %w", name, err)
+			}
+			return "", warning, nil
+		},
+	},
+	configurator.ProviderOpenCode: {
+		pluginPath:             openCodePluginRelPath,
+		warningBlocksBootstrap: true,
+		register: func(baseDir, name, fullDestDir string) (string, string, error) {
+			// Unlike claude/codex (patching an existing shared file), here the
+			// registration produces a NEW dedicated file (the generated
+			// plugin, D59) — the caller appends it to the managed files so it
+			// is pruned like any other, not left as a silent side effect.
+			//
+			// openCodePluginRelPath prefixes with "cartographer-"
+			// unconditionally (same helper every KB hook uses) — for
+			// BootstrapHookName ("cartographer-bootstrap") that yields a
+			// double-prefixed file name. Documented, deliberate (D60):
+			// reusing the shared helper verbatim keeps registration and
+			// removal (removeOpenCodePlugin, driven by PruneManaged/mf.Name)
+			// on the exact same path-derivation logic.
+			pluginRel, warning, err := registerOpenCodePlugin(baseDir, name, fullDestDir)
+			if err != nil {
+				return "", "", fmt.Errorf("provisioning: register hook %s as opencode plugin: %w", name, err)
+			}
+			return pluginRel, warning, nil
+		},
+	},
+}
+
+// HookRegistrationFile returns the provider-native file a hook registration is
+// written into, relative to the client base dir, or "" when the provider
+// registers through a generated artifact instead (or has no hook mechanism).
+// Exported for the client's own output: `cartographer sync` reports where a
+// hook was registered.
+func HookRegistrationFile(provider configurator.Provider) string {
+	m, ok := hookMechanisms[provider]
+	if !ok || len(m.settingsFile) == 0 {
+		return ""
+	}
+	return filepath.Join(m.settingsFile...)
+}
+
+// HookPluginRelPath returns the path, relative to the client base dir, of the
+// dedicated registration artifact this provider generates for hook name — or
+// "" when it registers into a shared settings file instead.
+func HookPluginRelPath(provider configurator.Provider, name string) string {
+	m, ok := hookMechanisms[provider]
+	if !ok || m.pluginPath == nil {
+		return ""
+	}
+	return m.pluginPath(name)
 }

--- a/internal/provisioning/mcpsettings.go
+++ b/internal/provisioning/mcpsettings.go
@@ -22,15 +22,14 @@ import (
 	"github.com/BeppeTemp/cartographer/internal/configurator"
 )
 
-// mcpServerKey is the top-level JSON key each provider uses to hold its map of
-// MCP server entries — "mcp" for OpenCode, "mcpServers" for claude/kiro (see
-// internal/configurator's own mcpServerKeys, duplicated here since it is
-// unexported in that package).
+// mcpServerKey is the top-level JSON key the provider uses to hold its map of
+// MCP server entries, read from the provider descriptor (D137).
 func mcpServerKey(provider configurator.Provider) string {
-	if provider == configurator.ProviderOpenCode {
-		return "mcp"
+	d, ok := configurator.Lookup(provider)
+	if !ok {
+		return "mcpServers"
 	}
-	return "mcpServers"
+	return d.MCPServerKey
 }
 
 // mcpServerMarkers returns the begin/end comment markers that delimit name's
@@ -146,7 +145,7 @@ func removeMCPServer(baseDir, name string, provider configurator.Provider) error
 		settings[key] = servers
 	}
 
-	if provider != configurator.ProviderClaudeCode && isEmptyMCPProviderShell(settings) {
+	if d, ok := configurator.Lookup(provider); ok && d.DeletableWhenEmpty && isEmptyMCPProviderShell(settings) {
 		if err := os.Remove(fullPath); err != nil {
 			return fmt.Errorf("provisioning: remove %s: %w", fullPath, err)
 		}
@@ -178,16 +177,10 @@ func isEmptyMCPProviderShell(settings map[string]interface{}) bool {
 // (same pattern as hookProviderFromPath).
 func mcpProviderFromPath(path string) configurator.Provider {
 	slash := filepath.ToSlash(path)
-	switch slash {
-	case ".claude.json":
-		return configurator.ProviderClaudeCode
-	case filepath.ToSlash(filepath.Join(".codex", "config.toml")):
-		return configurator.ProviderCodex
-	case "opencode.json":
-		return configurator.ProviderOpenCode
-	case filepath.ToSlash(filepath.Join(".kiro", "settings", "mcp.json")):
-		return configurator.ProviderKiro
-	default:
-		return ""
+	for _, d := range configurator.Providers() {
+		if slash == d.MCPConfigPath {
+			return d.Provider
+		}
 	}
+	return ""
 }

--- a/internal/provisioning/provisioning.go
+++ b/internal/provisioning/provisioning.go
@@ -1159,13 +1159,13 @@ func Apply(m Manifest, opts ApplyOptions) (AppliedResult, error) {
 					return AppliedResult{}, fmt.Errorf("provisioning: mcp %s: %w", a.Name, specErr)
 				}
 				spec := configurator.ServerSpec{Type: kbSpec.Type, URL: kbSpec.URL, Command: kbSpec.Command, Args: kbSpec.Args, Headers: kbSpec.Headers, Env: kbSpec.Env}
-				if opts.Provider == configurator.ProviderKiro && len(kbSpec.Headers) > 0 {
-					// Kiro has never supported auth headers for MCP servers
-					// (pre-existing limit of the emitter, unchanged since D69) —
-					// warn instead of silently failing the authentication
-					// of the server distributed by the KB.
+				if d, ok := configurator.Lookup(opts.Provider); ok && !d.SupportsMCPHeaders && len(kbSpec.Headers) > 0 {
+					// A provider whose emitter cannot represent auth headers
+					// (kiro, unchanged since D69) — warn instead of silently
+					// failing the authentication of the server distributed by
+					// the KB.
 					result.Warnings = append(result.Warnings, fmt.Sprintf(
-						"mcp %q: kiro does not support headers for MCP servers, ignored", a.Name))
+						"mcp %q: %s does not support headers for MCP servers, ignored", a.Name, d.Provider))
 				}
 				rp, warnings, regErr := registerMCPServer(opts.BaseDir, a.Name, spec, opts.Provider)
 				if regErr != nil {
@@ -1219,33 +1219,16 @@ func Apply(m Manifest, opts ApplyOptions) (AppliedResult, error) {
 					return AppliedResult{}, fmt.Errorf("provisioning: copy %s %s: %w", a.Kind, a.Name, err)
 				}
 				if a.Kind == "hook" {
-					// destDir maps kind "hook" only for claude and codex (D57/D58) —
-					// register/update the entry in the provider's native file
-					// starting from the hook.json just materialized. Best-effort
-					// on a malformed hook.json (see registerHookSettings/
+					// Register the hook in the provider's native mechanism
+					// (D137's hookMechanisms table: settings.json D57,
+					// config.toml D58, generated plugin D59), starting from
+					// the hook.json just materialized. Best-effort on a
+					// malformed hook.json (see registerHookSettings/
 					// registerHookConfigTOML): doesn't fail materialization.
-					switch opts.Provider {
-					case configurator.ProviderClaudeCode:
-						if err := registerHookSettings(opts.BaseDir, a.Name, fullDestDir); err != nil {
-							return AppliedResult{}, fmt.Errorf("provisioning: register hook %s in settings.json: %w", a.Name, err)
-						}
-					case configurator.ProviderCodex:
-						warning, err := registerHookConfigTOML(opts.BaseDir, a.Name, fullDestDir)
-						if err != nil {
-							return AppliedResult{}, fmt.Errorf("provisioning: register hook %s in config.toml: %w", a.Name, err)
-						}
-						if warning != "" {
-							result.Warnings = append(result.Warnings, warning)
-						}
-					case configurator.ProviderOpenCode:
-						// Unlike claude/codex (patching an existing shared
-						// file), here the registration produces a NEW dedicated
-						// file (the generated plugin, D59) — it's appended to
-						// relPaths so it becomes a ManagedFile of its own, not just a
-						// silent side effect.
-						pluginRel, warning, err := registerOpenCodePlugin(opts.BaseDir, a.Name, fullDestDir)
-						if err != nil {
-							return AppliedResult{}, fmt.Errorf("provisioning: register hook %s as opencode plugin: %w", a.Name, err)
+					if mechanism, ok := hookMechanisms[opts.Provider]; ok {
+						pluginRel, warning, regErr := mechanism.register(opts.BaseDir, a.Name, fullDestDir)
+						if regErr != nil {
+							return AppliedResult{}, regErr
 						}
 						if warning != "" {
 							result.Warnings = append(result.Warnings, warning)
@@ -1826,6 +1809,85 @@ func principalFile(kind string) string {
 	}
 }
 
+// destination is one cell of the kind × provider matrix below: where an
+// artifact of that kind materializes for that provider. A cell either names a
+// destination or is explicitly unsupported — a *missing* cell is a
+// programming error, caught by TestDestinationMatrixIsComplete, not silently
+// degraded to Unsupported at apply time (D137).
+type destination struct {
+	// dir are the path segments, relative to the client base dir.
+	dir []string
+	// named marks a per-artifact destination: the artifact name is appended
+	// to dir, with suffix (e.g. ".md") if any. When false, dir is the whole
+	// path — one shared file for every artifact of that kind.
+	named  bool
+	suffix string
+	// unsupported marks a combination this provider cannot represent.
+	unsupported bool
+}
+
+func at(segments ...string) destination { return destination{dir: segments} }
+
+func perName(suffix string, segments ...string) destination {
+	return destination{dir: segments, named: true, suffix: suffix}
+}
+
+var unsupportedDest = destination{unsupported: true}
+
+// destinationMatrix is the kind × provider matrix documented in docs/sync.md,
+// as data (D137). Every kind in artifactKinds must have a cell for every
+// provider in configurator.Providers().
+//
+//   - "mcp"/"instructions" cells are one shared file per provider, the same
+//     for every artifact of that kind (the name is not part of the path): each
+//     MCP server occupies its own key/block inside that file (see
+//     mcpsettings.go), and the instructions block concatenates all KBs
+//     (applyInstructionsGroup).
+//   - "skill"/"hook" cells are directories materialized by copyArtifactFiles;
+//     "agent" cells are a single file, written directly by Apply.
+//   - kiro has no known native subagent directory and no native hook
+//     mechanism, hence the two unsupported cells.
+var destinationMatrix = map[string]map[configurator.Provider]destination{
+	"mcp": {
+		configurator.ProviderClaudeCode: at(".claude.json"),
+		configurator.ProviderCodex:      at(".codex", "config.toml"),
+		configurator.ProviderOpenCode:   at("opencode.json"),
+		configurator.ProviderKiro:       at(".kiro", "settings", "mcp.json"),
+	},
+	"instructions": {
+		configurator.ProviderClaudeCode: at(".claude", "CLAUDE.md"),
+		configurator.ProviderOpenCode:   at(".config", "opencode", "AGENTS.md"),
+		configurator.ProviderCodex:      at(".codex", "AGENTS.md"),
+		configurator.ProviderKiro:       at(".kiro", "steering", "cartographer.md"),
+	},
+	"agent": {
+		configurator.ProviderClaudeCode: perName(".md", ".claude", "agents"),
+		configurator.ProviderOpenCode:   perName(".md", ".opencode", "agent"),
+		configurator.ProviderCodex:      perName(".toml", ".codex", "agents"),
+		configurator.ProviderKiro:       unsupportedDest,
+	},
+	"hook": {
+		configurator.ProviderClaudeCode: perName("", ".claude", "hooks"),
+		configurator.ProviderCodex:      perName("", ".codex", "hooks"),
+		// Hook files (script + hook.json), same as for the other providers —
+		// the JS plugin that invokes them (D59) is generated elsewhere (Apply,
+		// registerOpenCodePlugin) in .config/opencode/plugins/, not here.
+		configurator.ProviderOpenCode: perName("", ".opencode", "hooks"),
+		configurator.ProviderKiro:     unsupportedDest,
+	},
+	"skill": {
+		configurator.ProviderClaudeCode: perName("", ".claude", "skills"),
+		configurator.ProviderCodex:      perName("", ".codex", "skills"),
+		configurator.ProviderKiro:       perName("", ".kiro", "skills"),
+		configurator.ProviderOpenCode:   perName("", ".opencode", "skills"),
+	},
+}
+
+// artifactKinds are the kinds the matrix must cover. A manifest built by a
+// newer server may carry a kind absent from this list; destDir returns "" for
+// it, exactly as it does for an unsupported cell.
+var artifactKinds = []string{"mcp", "instructions", "agent", "hook", "skill"}
+
 // destDir returns the destination path for an artifact, relative to the base-dir.
 //
 //   - kind "skill"/"hook": a directory, materialized by copyArtifactFiles with one
@@ -1834,104 +1896,30 @@ func principalFile(kind string) string {
 //     subagent .md), materialized by writing its sole file's content directly to
 //     that path (see Apply).
 //
-// Supported providers per kind:
-//   - skill: claude → .claude/skills/<name>/, codex → .codex/skills/<name>/,
-//     kiro → .kiro/skills/<name>/, opencode → .opencode/skills/<name>/.
-//   - agent: claude → .claude/agents/<name>.md (verbatim); opencode →
-//     .opencode/agent/<name>.md (D55 — note the singular "agent" dir, per
-//     OpenCode's own layout; content translated, see
-//     translateAgentForProvider). Not materializable on codex/kiro (no native
-//     subagent directory known).
-//   - hook: claude → .claude/hooks/<name>/, codex → .codex/hooks/<name>/,
-//     opencode → .opencode/hooks/<name>/. Not materializable on kiro (no
-//     native hook mechanism known). On claude/codex, Apply also registers the
-//     hook in the provider's own file (D57 settings.json, D58 config.toml —
-//     registerHookSettings/registerHookConfigTOML in hooksettings.go); on
-//     opencode it generates a whole plugin JS file instead (D59,
-//     registerOpenCodePlugin) when the hook's event has an OpenCode
-//     equivalent. All three are idempotent (re-apply never duplicates/drifts)
-//     and prunable (removed on diff.Removed/PruneManaged); see docs/sync.md
-//     §Hook.
+// Supported providers per kind are the destinationMatrix above; docs/sync.md
+// §Kind × provider renders the same matrix for the reader. On claude/codex,
+// Apply also registers a hook in the provider's own file (D57 settings.json,
+// D58 config.toml — registerHookSettings/registerHookConfigTOML in
+// hooksettings.go); on opencode it generates a whole plugin JS file instead
+// (D59, registerOpenCodePlugin) when the hook's event has an OpenCode
+// equivalent. All three are idempotent (re-apply never duplicates/drifts) and
+// prunable (removed on diff.Removed/PruneManaged); see docs/sync.md §Hook.
+// Agent content is translated per provider (D55/D58, see
+// translateAgentForProvider); kiro never reaches that function because its
+// "agent" cell is unsupported.
 //
-// Returns "" for unsupported kind×provider combos, which causes Apply to place the
+// Returns "" for an unsupported kind×provider combo — and likewise for a kind
+// or provider this binary does not know — which causes Apply to place the
 // artifact in Unsupported instead of materializing it.
 func destDir(kind, name string, provider configurator.Provider) string {
-	switch kind {
-	case "mcp":
-		// One shared file per provider (name ignored, as for "instructions"
-		// below) — but unlike "instructions" (a GROUP block concatenating all
-		// KBs) each MCP server occupies its own per-name key/block inside the
-		// same shared file (see internal/provisioning/mcpsettings.go,
-		// registerMCPServer/removeMCPServer) — the same file that
-		// `cartographer connect` writes for Cartographer's own "cartographer"
-		// entry via internal/configurator.
-		switch provider {
-		case configurator.ProviderClaudeCode:
-			return ".claude.json"
-		case configurator.ProviderCodex:
-			return filepath.Join(".codex", "config.toml")
-		case configurator.ProviderOpenCode:
-			return "opencode.json"
-		case configurator.ProviderKiro:
-			return filepath.Join(".kiro", "settings", "mcp.json")
-		default:
-			return ""
-		}
-	case "instructions":
-		// One shared file per provider, the same for every instructions
-		// artifact (name ignored): the managed block (§applyInstructionsGroup)
-		// concatenates ALL KBs into that single file, not one per KB.
-		switch provider {
-		case configurator.ProviderClaudeCode:
-			return filepath.Join(".claude", "CLAUDE.md")
-		case configurator.ProviderOpenCode:
-			return filepath.Join(".config", "opencode", "AGENTS.md")
-		case configurator.ProviderCodex:
-			return filepath.Join(".codex", "AGENTS.md")
-		case configurator.ProviderKiro:
-			return filepath.Join(".kiro", "steering", "cartographer.md")
-		default:
-			return ""
-		}
-	case "agent":
-		switch provider {
-		case configurator.ProviderClaudeCode:
-			return filepath.Join(".claude", "agents", name+".md")
-		case configurator.ProviderOpenCode:
-			return filepath.Join(".opencode", "agent", name+".md")
-		case configurator.ProviderCodex:
-			return filepath.Join(".codex", "agents", name+".toml")
-		default:
-			return ""
-		}
-	case "hook":
-		switch provider {
-		case configurator.ProviderClaudeCode:
-			return filepath.Join(".claude", "hooks", name)
-		case configurator.ProviderCodex:
-			return filepath.Join(".codex", "hooks", name)
-		case configurator.ProviderOpenCode:
-			// Hook files (script + hook.json), same as for the other providers —
-			// the JS plugin that invokes them (D59) is generated elsewhere (Apply,
-			// registerOpenCodePlugin) in .config/opencode/plugins/, not here.
-			return filepath.Join(".opencode", "hooks", name)
-		default:
-			return ""
-		}
-	default: // "skill"
-		switch provider {
-		case configurator.ProviderClaudeCode:
-			return filepath.Join(".claude", "skills", name)
-		case configurator.ProviderCodex:
-			return filepath.Join(".codex", "skills", name)
-		case configurator.ProviderKiro:
-			return filepath.Join(".kiro", "skills", name)
-		case configurator.ProviderOpenCode:
-			return filepath.Join(".opencode", "skills", name)
-		default:
-			return ""
-		}
+	cell, ok := destinationMatrix[kind][provider]
+	if !ok || cell.unsupported {
+		return ""
 	}
+	if !cell.named {
+		return filepath.Join(cell.dir...)
+	}
+	return filepath.Join(append(append([]string{}, cell.dir...), name+cell.suffix)...)
 }
 
 // translateAgentForProvider adapts an "agent" artifact's content (a Claude Code

--- a/internal/provisioning/registry_test.go
+++ b/internal/provisioning/registry_test.go
@@ -1,0 +1,91 @@
+package provisioning
+
+// Consistency tests for the declarative kind × provider matrix (D137): a
+// forgotten cell must be a red test here, never a silent Unsupported at apply
+// time.
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/BeppeTemp/cartographer/internal/configurator"
+)
+
+func TestDestinationMatrixIsComplete(t *testing.T) {
+	for _, kind := range artifactKinds {
+		cells, ok := destinationMatrix[kind]
+		if !ok {
+			t.Errorf("kind %q has no row in destinationMatrix", kind)
+			continue
+		}
+		for _, d := range configurator.Providers() {
+			cell, ok := cells[d.Provider]
+			if !ok {
+				t.Errorf("destinationMatrix[%q][%q] is missing: name a destination or mark it unsupported", kind, d.Provider)
+				continue
+			}
+			if cell.unsupported {
+				continue
+			}
+			if len(cell.dir) == 0 {
+				t.Errorf("destinationMatrix[%q][%q] is supported but names no path", kind, d.Provider)
+			}
+		}
+		for provider := range cells {
+			if _, known := configurator.Lookup(provider); !known {
+				t.Errorf("destinationMatrix[%q] has a cell for unknown provider %q", kind, provider)
+			}
+		}
+	}
+	for kind := range destinationMatrix {
+		found := false
+		for _, known := range artifactKinds {
+			if kind == known {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("destinationMatrix has row %q, absent from artifactKinds", kind)
+		}
+	}
+}
+
+// The matrix must reproduce, cell by cell, the paths in use before it existed.
+func TestDestDirPaths(t *testing.T) {
+	cases := []struct {
+		kind     string
+		provider configurator.Provider
+		want     string
+	}{
+		{"mcp", configurator.ProviderClaudeCode, ".claude.json"},
+		{"mcp", configurator.ProviderCodex, filepath.Join(".codex", "config.toml")},
+		{"mcp", configurator.ProviderOpenCode, "opencode.json"},
+		{"mcp", configurator.ProviderKiro, filepath.Join(".kiro", "settings", "mcp.json")},
+		{"instructions", configurator.ProviderClaudeCode, filepath.Join(".claude", "CLAUDE.md")},
+		{"instructions", configurator.ProviderOpenCode, filepath.Join(".config", "opencode", "AGENTS.md")},
+		{"instructions", configurator.ProviderCodex, filepath.Join(".codex", "AGENTS.md")},
+		{"instructions", configurator.ProviderKiro, filepath.Join(".kiro", "steering", "cartographer.md")},
+		{"agent", configurator.ProviderClaudeCode, filepath.Join(".claude", "agents", "demo.md")},
+		{"agent", configurator.ProviderOpenCode, filepath.Join(".opencode", "agent", "demo.md")},
+		{"agent", configurator.ProviderCodex, filepath.Join(".codex", "agents", "demo.toml")},
+		{"agent", configurator.ProviderKiro, ""},
+		{"hook", configurator.ProviderClaudeCode, filepath.Join(".claude", "hooks", "demo")},
+		{"hook", configurator.ProviderCodex, filepath.Join(".codex", "hooks", "demo")},
+		{"hook", configurator.ProviderOpenCode, filepath.Join(".opencode", "hooks", "demo")},
+		{"hook", configurator.ProviderKiro, ""},
+		{"skill", configurator.ProviderClaudeCode, filepath.Join(".claude", "skills", "demo")},
+		{"skill", configurator.ProviderCodex, filepath.Join(".codex", "skills", "demo")},
+		{"skill", configurator.ProviderKiro, filepath.Join(".kiro", "skills", "demo")},
+		{"skill", configurator.ProviderOpenCode, filepath.Join(".opencode", "skills", "demo")},
+		// A kind or provider this binary does not know is not materializable:
+		// a manifest from a newer server must not land somewhere arbitrary.
+		{"newkind", configurator.ProviderClaudeCode, ""},
+		{"skill", configurator.Provider("hermes"), ""},
+	}
+	for _, tc := range cases {
+		if got := destDir(tc.kind, "demo", tc.provider); got != tc.want {
+			t.Errorf("destDir(%q, demo, %q) = %q, want %q", tc.kind, tc.provider, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Implements the approved plan in #135 (D137). Third of the D135 → D143 series; prepares D140 and D141, which would otherwise touch all eight files twice.

## What changed

**WP1 — provider identity as data.** `internal/configurator/registry.go` holds one `Descriptor` per provider: constant and wire value, display name (previously duplicated in `internal/agents`), native MCP config file and format (`FormatJSON` + server key, or `FormatTOMLBlock`), `DeletableWhenEmpty` (false for Claude Code — `.claude.json` is Claude's own shared state, D63), `SupportsMCPHeaders`, `FlatToolNamespace`, the detection evidence (binary, config dirs in probe order, macOS app bundle), and the emitter. `EmitServer`, `EmitAll` and `Remove` read from it; `agents.Detect` is now one loop over `DetectionOrder()` with the four per-provider functions gone. **Both** user-visible orders are preserved deliberately and separately: `Providers()` (emission/iteration) and `DetectionOrder()` (`cartographer agents`, TUI) — they differ today and unifying them would change output.

**WP2 — the kind × provider matrix is readable.** `destinationMatrix` replaces the five nested switches in `destDir`, transcribed cell by cell, with `unsupported` as explicit data for (agent, kiro) and (hook, kiro). `destDir` keeps its signature and its contract (empty string ⇒ `Apply` puts the artifact in `Unsupported`), so `FilterForProvider` and `Apply` are untouched. A **missing** cell for a known pair now fails `TestDestinationMatrixIsComplete` instead of degrading silently at apply time.

**WP3 — no orphan switches.** `hookMechanisms` (settings file / generated plugin / registrar) replaces the per-provider switches in both `EnsureBootstrapHook` and `Apply`'s hook branch — including the dry-run branch that hardcoded the OpenCode plugin path — and exports `HookRegistrationFile`/`HookPluginRelPath` so `clientsync.go`'s display logic reads them instead of re-deriving paths. `mcpsettings.go` takes the server key, the deletable rule and the path→provider mapping from the descriptor; `multikb.go`'s Kiro and Codex checks become `FlatToolNamespace` and `MCPFormat` lookups; `resolveProvider` validates against the registry.

Left as code, deliberately and documented in D137: the four emitters and `translateAgentForProvider` (the formats genuinely differ); `Remove`'s cleanup of the legacy `.codex/config.json`; `sync_apply`'s Claude Code materialization, which is not a choice among providers.

## Behaviour

Preserving, with one deliberate narrowing the plan calls for: an **unknown kind** used to fall through `destDir`'s `default` arm and be materialized as a *skill*; it now returns "" and is filtered upstream like any unsupported combination — the correct answer for a manifest built by a newer server. Two cosmetic changes: the "unknown provider" error lists providers in registry order, and the Kiro flat-namespace warning renders its name from the descriptor.

## Tests

Existing suite unmodified — including `TestRoundTrip_ConnectDisconnect_NessunResiduo` and the configurator goldens, which are the invariant guards. Added: one descriptor per provider with no duplicates and format/key coherence; the never-deletable `.claude.json` rule asserted on the descriptor; matrix completeness; and a cell-by-cell `destDir` table pinning every path plus the unknown-kind and unknown-provider cases.

`make vet`, `make test` and `make e2e` (12/12) green.

## Docs

`docs/sync.md` §Kind × provider matrix names the code that owns it; `docs/configurator.md` gains an "Adding a provider" section (this is the page a contributor reads before D141); code map line in `AGENTS.md`/`CLAUDE.md`; D137 in `docs/decisions/client-configurator.md`.

## Release impact

None — internal refactor, no user-visible behaviour change.

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)