### PR TITLE
feat(client): scheduled sync trigger for clients with no session hook (D140)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ internal/provisioning/       # Manifest, Lock/LockFile, Diff, Apply, MergeArtifa
 internal/agents/             # Detect() agents installed on the machine (claude/opencode/codex/kiro)
 internal/clientconfig/       # .cartographer.yaml (server_url, connected agents, etc.)
 internal/client/             # minimal MCPClient (JSON-RPC 2.0 over HTTP) for the client subcommands
+internal/service/            # native per-user units: server (launchd/systemd) + synctimer.go (scheduled client sync)
 ```
 
 ## Code navigation

--- a/cmd/cartographer/connect.go
+++ b/cmd/cartographer/connect.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/BeppeTemp/cartographer/internal/client"
 	"github.com/BeppeTemp/cartographer/internal/clientconfig"
+	"github.com/BeppeTemp/cartographer/internal/configurator"
 	"github.com/BeppeTemp/cartographer/internal/defaults"
 	"github.com/BeppeTemp/cartographer/internal/provisioning"
 	"github.com/BeppeTemp/cartographer/internal/service"
@@ -433,6 +434,25 @@ func printConnectResult(dir string, providers []string, opts connectOptions, res
 	if res.Deferred {
 		fmt.Println("warning: skill sync deferred (server unreachable); run `cartographer sync` once the server is up")
 	}
+	printSyncTimerHint(providers)
+}
+
+// printSyncTimerHint names the scheduled trigger once per invocation when a
+// provider being configured has no session hook (D140): without it, that
+// client only syncs when a human remembers to. The timer is never installed
+// automatically — see cmdServiceSyncTimer.
+func printSyncTimerHint(providers []string) {
+	var hookless []string
+	for _, p := range providers {
+		if !provisioning.SupportsSessionHook(configurator.Provider(p)) {
+			hookless = append(hookless, p)
+		}
+	}
+	if len(hookless) == 0 {
+		return
+	}
+	fmt.Printf("%s has no session-start hook: it syncs only on demand — install the scheduled trigger with `cartographer service sync-timer install`\n",
+		strings.Join(hookless, ", "))
 }
 
 // connectOptions bundles the parameters of a connect operation, shared by the

--- a/cmd/cartographer/service.go
+++ b/cmd/cartographer/service.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/BeppeTemp/cartographer/internal/config"
 	"github.com/BeppeTemp/cartographer/internal/defaults"
@@ -54,6 +55,8 @@ func cmdService(args []string) int {
 		return cmdServiceRestart(rest)
 	case "status":
 		return cmdServiceStatus(rest)
+	case "sync-timer":
+		return cmdServiceSyncTimer(rest)
 	default:
 		fmt.Fprintln(os.Stderr, "Error: service action required")
 		printServiceUsage(os.Stderr)
@@ -63,6 +66,76 @@ func cmdService(args []string) int {
 
 func printServiceUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage: cartographer service <install|uninstall|start|stop|restart|status> [flags]")
+	fmt.Fprintln(w, "       cartographer service sync-timer <install|uninstall|status> [--interval <duration>]")
+}
+
+// syncTimerFns are indirected so the dispatch is testable without a real
+// launchctl/systemctl.
+var (
+	syncTimerInstallFn   = func(interval time.Duration) error { return service.NewManager().InstallSyncTimer(interval) }
+	syncTimerUninstallFn = func() error { return service.NewManager().UninstallSyncTimer() }
+	syncTimerStatusFn    = func() (service.SyncTimerStatus, error) { return service.NewManager().SyncTimerStatus() }
+)
+
+// cmdServiceSyncTimer manages the scheduled client sync (D140): the supported
+// trigger for providers with no session hook. Opt-in and explicit —
+// installing a launchd agent or a systemd user unit behind the user's back on
+// `connect` would be out of proportion.
+func cmdServiceSyncTimer(args []string) int {
+	action, rest := splitPositional(args, "")
+	switch action {
+	case "install":
+		fs := flag.NewFlagSet("service sync-timer install", flag.ExitOnError)
+		interval := fs.Duration("interval", service.DefaultSyncInterval, "How often to run `cartographer sync`")
+		fs.Parse(rest)
+		if *interval <= 0 {
+			fmt.Fprintln(os.Stderr, "Error: --interval must be positive")
+			return exitStatusError
+		}
+		if err := syncTimerInstallFn(*interval); err != nil {
+			fmt.Fprintln(os.Stderr, "Error:", err)
+			return exitStatusError
+		}
+		fmt.Printf("sync timer installed (every %s)\n", *interval)
+		// The timer never passes --auto-trust: an unattended job must not
+		// grant a trust the user never gave (D54).
+		fmt.Println("it runs `cartographer sync` without --auto-trust; the persisted `trust` setting still applies")
+		return 0
+	case "uninstall":
+		if err := syncTimerUninstallFn(); err != nil {
+			fmt.Fprintln(os.Stderr, "Error:", err)
+			return exitStatusError
+		}
+		fmt.Println("sync timer uninstalled")
+		return 0
+	case "status":
+		st, err := syncTimerStatusFn()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Error:", err)
+			return exitStatusError
+		}
+		if !st.Installed {
+			fmt.Println("sync timer not installed (cartographer service sync-timer install)")
+			return exitStatusNotInstalled
+		}
+		state := "installed"
+		if st.Active {
+			state = "active"
+		}
+		if st.Interval > 0 {
+			fmt.Printf("sync timer %s, every %s (%s)\n", state, st.Interval, st.Path)
+		} else {
+			fmt.Printf("sync timer %s (%s)\n", state, st.Path)
+		}
+		if !st.Active {
+			return exitStatusStopped
+		}
+		return exitStatusRunning
+	default:
+		fmt.Fprintln(os.Stderr, "Error: sync-timer action required")
+		printServiceUsage(os.Stderr)
+		return exitStatusError
+	}
 }
 
 func cmdServiceInstall(args []string) int {

--- a/cmd/cartographer/status.go
+++ b/cmd/cartographer/status.go
@@ -139,6 +139,17 @@ func renderStatus(output string, s statusSnapshot, code int) int {
 			fmt.Println("  MCP requires point approval: cartographer approve mcp <name> --kb <kb>")
 		}
 	}
+
+	// D140: a connected provider with no session hook syncs only on demand.
+	// Once per invocation, not once per provider.
+	var connected []string
+	for _, p := range s.Providers {
+		if p.Connected {
+			connected = append(connected, p.Name)
+		}
+	}
+	printSyncTimerHint(connected)
+
 	return code
 }
 

--- a/cmd/cartographer/synctimer_test.go
+++ b/cmd/cartographer/synctimer_test.go
@@ -1,0 +1,117 @@
+package main
+
+// Tests for the `service sync-timer` dispatch and the hook-less provider hint
+// (D140).
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BeppeTemp/cartographer/internal/service"
+)
+
+func TestCmdServiceSyncTimer_Dispatch(t *testing.T) {
+	oldInstall, oldUninstall, oldStatus := syncTimerInstallFn, syncTimerUninstallFn, syncTimerStatusFn
+	t.Cleanup(func() {
+		syncTimerInstallFn, syncTimerUninstallFn, syncTimerStatusFn = oldInstall, oldUninstall, oldStatus
+	})
+
+	t.Run("install passes the interval", func(t *testing.T) {
+		var got time.Duration
+		syncTimerInstallFn = func(interval time.Duration) error { got = interval; return nil }
+		out := withStdout(t, func() {
+			if code := cmdService([]string{"sync-timer", "install", "--interval", "5m"}); code != 0 {
+				t.Errorf("exit = %d, want 0", code)
+			}
+		})
+		if got != 5*time.Minute {
+			t.Errorf("interval = %v, want 5m", got)
+		}
+		if !strings.Contains(out, "without --auto-trust") {
+			t.Errorf("output must state the authorization boundary: %q", out)
+		}
+	})
+
+	t.Run("install defaults to 30m", func(t *testing.T) {
+		var got time.Duration
+		syncTimerInstallFn = func(interval time.Duration) error { got = interval; return nil }
+		withStdout(t, func() { cmdService([]string{"sync-timer", "install"}) })
+		if got != service.DefaultSyncInterval {
+			t.Errorf("interval = %v, want %v", got, service.DefaultSyncInterval)
+		}
+	})
+
+	t.Run("status exit codes", func(t *testing.T) {
+		syncTimerStatusFn = func() (service.SyncTimerStatus, error) { return service.SyncTimerStatus{}, nil }
+		withStdout(t, func() {
+			if code := cmdService([]string{"sync-timer", "status"}); code != exitStatusNotInstalled {
+				t.Errorf("not installed: exit = %d, want %d", code, exitStatusNotInstalled)
+			}
+		})
+		syncTimerStatusFn = func() (service.SyncTimerStatus, error) {
+			return service.SyncTimerStatus{Installed: true, Path: "/tmp/x.plist", Interval: 30 * time.Minute}, nil
+		}
+		withStdout(t, func() {
+			if code := cmdService([]string{"sync-timer", "status"}); code != exitStatusStopped {
+				t.Errorf("installed but inactive: exit = %d, want %d", code, exitStatusStopped)
+			}
+		})
+		syncTimerStatusFn = func() (service.SyncTimerStatus, error) {
+			return service.SyncTimerStatus{Installed: true, Active: true, Path: "/tmp/x.plist", Interval: 30 * time.Minute}, nil
+		}
+		out := withStdout(t, func() {
+			if code := cmdService([]string{"sync-timer", "status"}); code != exitStatusRunning {
+				t.Errorf("active: exit = %d, want %d", code, exitStatusRunning)
+			}
+		})
+		if !strings.Contains(out, "every 30m") {
+			t.Errorf("status output = %q, want the interval", out)
+		}
+	})
+
+	t.Run("uninstall", func(t *testing.T) {
+		called := false
+		syncTimerUninstallFn = func() error { called = true; return nil }
+		withStdout(t, func() { cmdService([]string{"sync-timer", "uninstall"}) })
+		if !called {
+			t.Error("uninstall was not called")
+		}
+	})
+}
+
+// The hint names the scheduled trigger once per invocation, and only for
+// providers that genuinely have no session hook.
+func TestPrintSyncTimerHint(t *testing.T) {
+	cases := []struct {
+		name      string
+		providers []string
+		want      bool
+		mentions  string
+	}{
+		{"hook-less provider", []string{"kiro"}, true, "kiro"},
+		{"hooked providers only", []string{"claude", "codex", "opencode"}, false, ""},
+		{"mixed", []string{"claude", "kiro"}, true, "kiro"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := withStdout(t, func() { printSyncTimerHint(tc.providers) })
+			printed := strings.Contains(out, "sync-timer install")
+			if printed != tc.want {
+				t.Fatalf("hint printed=%v, want %v (output %q)", printed, tc.want, out)
+			}
+			if !tc.want {
+				return
+			}
+			if strings.Count(out, "sync-timer install") != 1 {
+				t.Errorf("the hint must appear exactly once: %q", out)
+			}
+			if !strings.Contains(out, tc.mentions) {
+				t.Errorf("output = %q, want it to name %q", out, tc.mentions)
+			}
+			if strings.Contains(out, "claude") {
+				t.Errorf("a hooked provider must not be named: %q", out)
+			}
+		})
+	}
+}

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -226,6 +226,28 @@ in-process runner is what `cartographer upgrade-repair` calls (D121). `disconnec
 `connect` is never an upgrade step — it would delete user-owned configuration to rebuild it.
 Already-open provider sessions still need to be restarted to reopen the MCP connection.
 
+### `cartographer service sync-timer <action>`
+
+The scheduled sync trigger for clients with no session-start hook (D140) — distinct from the
+**server** service below, with its own unit files:
+
+```bash
+cartographer service sync-timer install [--interval 30m]
+cartographer service sync-timer uninstall
+cartographer service sync-timer status   # exit: 0 active, 3 installed but inactive, 4 not installed
+```
+
+| Platform | Files | Logs |
+|---|---|---|
+| macOS | `~/Library/LaunchAgents/com.cartographer.sync.plist` | `~/Library/Logs/cartographer/sync.log` |
+| Linux | `~/.config/systemd/user/cartographer-sync.{service,timer}` | journal (`journalctl --user -u cartographer-sync`) |
+
+`install` is idempotent (it overwrites and re-registers); uninstalling a timer that is not
+installed is a success. The timer runs `cartographer sync` **without** `--auto-trust`: an
+unattended job must not grant a trust the user never gave, while the persisted `trust` setting
+still applies. `connect` and `status` name this command once per invocation when a connected
+provider has no session hook — they never install it.
+
 ### `cartographer service <action>`
 
 Manages the **server** as a native user service on the machine (local mode, D73):

--- a/docs/decisions/sync-provisioning.md
+++ b/docs/decisions/sync-provisioning.md
@@ -606,3 +606,49 @@ what keeps the pruning guarantee intact: those blocks live in files the user als
 comparing their whole content would either produce permanent false drift or license rewriting
 someone else's file.
 
+---
+
+<a id="d140"></a>
+## D140 — A scheduled sync trigger for clients with no session hook; Kiro's hook deferred
+
+**WP1 finding (checked 2026-08-27, no Kiro installation available on the machine).** Three facts,
+from Kiro's own documentation:
+
+1. **User-level hooks exist.** The CLI 2.13 changelog (<https://kiro.dev/changelog/cli/2-13/>)
+   states: "Hooks placed in `~/.kiro/hooks/` now fire in every workspace automatically". The
+   feature page (<https://kiro.dev/docs/hooks/>) still documents only `.kiro/hooks/` in the project
+   root, so the two sources disagree on scope.
+2. **A spawn trigger exists and is CLI-only.** The trigger table
+   (<https://kiro.dev/docs/hooks/types/>) lists `agentSpawn` as available on the CLI and not in the
+   IDE, described as firing when the agent is first activated.
+3. **The literal trigger values in a hook file do not match that table.** The only complete JSON
+   examples on the feature page use `"trigger": "PostFileSave"` and `"trigger": "Stop"` — while the
+   table names those same triggers `fileSave` and `agentStop`. The exact string a spawn hook must
+   carry is therefore **not determinable from the documentation**, and no installation was
+   available to confirm it empirically.
+
+**Decision.** WP2 (the Kiro session-start hook) is **not implemented**. `hook` × `kiro` stays
+`unsupported` in the destination matrix. Writing a file into another tool's configuration
+directory with a guessed trigger value produces a hook that is silently ignored — the exact
+failure WP1 exists to prevent — and "silently ignored" is indistinguishable from "working" until a
+user notices their KB skills are months stale. Implementing it needs one confirmation: the literal
+`trigger` value a spawn hook carries, and that `~/.kiro/hooks/` is honoured by the CLI surface
+where that trigger fires.
+
+**Decision.** The scheduled trigger is implemented and is a first-class Layer 1 alternative:
+`cartographer service sync-timer install|uninstall|status`, with `--interval` (default 30 minutes),
+reusing the launchd/systemd machinery of the server service under its own label
+(`com.cartographer.sync`, `cartographer-sync.timer`) and its own log destination. It is opt-in and
+explicit: `connect` and `status` name the command once per invocation when a connected provider has
+no session-hook mechanism, and never install it — putting a background job on someone's machine as
+a side effect of connecting is out of proportion. It runs `cartographer sync` **without**
+`--auto-trust`: an unattended job must not grant a trust the user never gave, while the persisted
+`trust` setting still applies (D54). Install is idempotent; uninstalling what is not installed
+succeeds.
+
+**Rationale.** Kiro was the one supported provider syncing only when a human remembered to, and
+D141's Hermes will be a second by design — its configuration is owned by an Ansible role, with no
+place to register a hook. Both need the same thing: a trigger that does not depend on the client
+having hooks. The timer serves them today and keeps serving Kiro's IDE surface even after the CLI
+hook lands, since `agentSpawn` is CLI-only.
+

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -232,6 +232,13 @@ this value from a live `/health` snapshot before qualifying the tool name; they 
 it from the server's own YAML. A stale client selection (a configured KB no longer among the
 KBs the server currently advertises) is reported as an explicit error rather than guessed.
 
+> **Two different units.** `cartographer service install` manages the **server** as a per-user
+> service (`com.cartographer.serve` / `cartographer.service`). `cartographer service sync-timer
+> install` manages a **client-side** scheduled `cartographer sync`
+> (`com.cartographer.sync` / `cartographer-sync.timer`, D140). Both live under
+> `~/Library/LaunchAgents` and `~/.config/systemd/user`, with distinct names and separate logs;
+> installing or removing one never touches the other.
+
 ### Environment variables
 
 Every startup option has a corresponding environment variable (the CLI flag takes precedence):

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -51,7 +51,16 @@ Hook **`cartographer-bootstrap`** (reserved name, `provisioning.BootstrapHookNam
 | claude | `SessionStart` | entry in `~/.claude/settings.json` |
 | codex | `[[hooks.SessionStart]]` | managed block in `~/.codex/config.toml` |
 | opencode | `session.created` event | generated plugin in `~/.config/opencode/plugins/` |
-| kiro | — (no native hook) | falls back to Layer 2 |
+| kiro | — (not registrable from a user-level install, see [D140](decisions/sync-provisioning.md#d140)) | falls back to the scheduled trigger below, or Layer 2 |
+
+**Scheduled trigger (D140).** For a client with no session hook, `cartographer service sync-timer
+install [--interval 30m]` registers a launchd agent (macOS) or a systemd user timer (Linux) that
+runs `cartographer sync` on an interval. It is **opt-in**: installing a background job on the
+user's machine during `connect` would be out of proportion, so `connect` and `status` only name the
+command when a connected provider has no session hook. The timer runs sync **without**
+`--auto-trust` — an unattended job must not grant a trust the user never gave; the persisted
+`trust` setting in `.cartographer.yaml` still applies (D54). Logs: `~/Library/Logs/cartographer/sync.log`
+on macOS, the journal on Linux.
 
 Beyond the revision comparison, every `sync` also verifies the managed files on disk and restores
 what diverged — see §On-disk verification and healing.

--- a/internal/provisioning/bootstrap.go
+++ b/internal/provisioning/bootstrap.go
@@ -230,6 +230,19 @@ var hookMechanisms = map[configurator.Provider]hookMechanism{
 	},
 }
 
+// SupportsSessionHook reports whether the bootstrap hook (D60) can run at
+// session start for this provider: it needs both a destination for the hook's
+// files and a native registration mechanism. A provider without one syncs
+// only on demand, or on the scheduled trigger (D140,
+// `cartographer service sync-timer install`).
+func SupportsSessionHook(provider configurator.Provider) bool {
+	if destDir("hook", BootstrapHookName, provider) == "" {
+		return false
+	}
+	_, ok := hookMechanisms[provider]
+	return ok
+}
+
 // HookRegistrationFile returns the provider-native file a hook registration is
 // written into, relative to the client base dir, or "" when the provider
 // registers through a generated artifact instead (or has no hook mechanism).

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -809,3 +809,130 @@ func TestRestart_Linux_UsesSystemctlRestart(t *testing.T) {
 		t.Errorf("plain Restart calls = %v, want systemctl --user restart", stub.calls)
 	}
 }
+
+// --- Scheduled sync trigger (D140) ---
+
+func TestRenderSyncUnits(t *testing.T) {
+	plist := RenderSyncLaunchdPlist("/opt/homebrew/bin/cartographer", "/home/u/Library/Logs/cartographer/sync.log", 30*time.Minute)
+	for _, want := range []string{
+		"<string>com.cartographer.sync</string>",
+		"<string>/opt/homebrew/bin/cartographer</string>",
+		"<string>sync</string>",
+		"<key>StartInterval</key>\n\t<integer>1800</integer>",
+		"sync.log",
+	} {
+		if !strings.Contains(plist, want) {
+			t.Errorf("plist missing %q:\n%s", want, plist)
+		}
+	}
+	// The unattended job must never grant a trust the user did not give.
+	if strings.Contains(plist, "auto-trust") {
+		t.Errorf("the sync timer must not pass --auto-trust:\n%s", plist)
+	}
+	if got := intervalFromPlist(plist); got != 30*time.Minute {
+		t.Errorf("intervalFromPlist = %v, want 30m", got)
+	}
+
+	unit := RenderSyncSystemdService("/usr/local/bin/cartographer")
+	if !strings.Contains(unit, "ExecStart=/usr/local/bin/cartographer sync\n") || !strings.Contains(unit, "Type=oneshot") {
+		t.Errorf("unexpected sync unit:\n%s", unit)
+	}
+	if strings.Contains(unit, "auto-trust") {
+		t.Errorf("the sync unit must not pass --auto-trust:\n%s", unit)
+	}
+
+	timer := RenderSyncSystemdTimer(15 * time.Minute)
+	for _, want := range []string{"OnUnitActiveSec=900s", "Persistent=true", "WantedBy=timers.target"} {
+		if !strings.Contains(timer, want) {
+			t.Errorf("timer missing %q:\n%s", want, timer)
+		}
+	}
+	if got := intervalFromTimerUnit(timer); got != 15*time.Minute {
+		t.Errorf("intervalFromTimerUnit = %v, want 15m", got)
+	}
+}
+
+func TestSyncTimerInstallIsIdempotentAndUninstallable(t *testing.T) {
+	home := t.TempDir()
+	oldHome, oldGoos, oldExec := userHomeDir, goos, osExecutable
+	userHomeDir = func() (string, error) { return home, nil }
+	osExecutable = func() (string, error) { return "/usr/local/bin/cartographer", nil }
+	t.Cleanup(func() { userHomeDir, goos, osExecutable = oldHome, oldGoos, oldExec })
+
+	for _, platform := range []string{"darwin", "linux"} {
+		t.Run(platform, func(t *testing.T) {
+			goos = platform
+			var calls []string
+			m := &Manager{run: func(name string, args ...string) (string, error) {
+				calls = append(calls, name+" "+strings.Join(args, " "))
+				return "active", nil
+			}}
+
+			paths := func() []string {
+				if platform == "darwin" {
+					p, _ := SyncLaunchdPlistPath()
+					return []string{p}
+				}
+				svc, _ := SyncSystemdServicePath()
+				timer, _ := SyncSystemdTimerPath()
+				return []string{svc, timer}
+			}()
+
+			if err := m.InstallSyncTimer(20 * time.Minute); err != nil {
+				t.Fatalf("InstallSyncTimer: %v", err)
+			}
+			for _, p := range paths {
+				if _, err := os.Stat(p); err != nil {
+					t.Fatalf("expected %s to exist: %v", p, err)
+				}
+			}
+			st, err := m.SyncTimerStatus()
+			if err != nil {
+				t.Fatalf("SyncTimerStatus: %v", err)
+			}
+			if !st.Installed || st.Interval != 20*time.Minute {
+				t.Errorf("status = %+v, want installed with a 20m interval", st)
+			}
+
+			// Installing again overwrites and re-registers, never errors.
+			if err := m.InstallSyncTimer(20 * time.Minute); err != nil {
+				t.Fatalf("second InstallSyncTimer: %v", err)
+			}
+
+			if err := m.UninstallSyncTimer(); err != nil {
+				t.Fatalf("UninstallSyncTimer: %v", err)
+			}
+			for _, p := range paths {
+				if _, err := os.Stat(p); !os.IsNotExist(err) {
+					t.Errorf("%s survived uninstall", p)
+				}
+			}
+			// Uninstalling what is not installed is a success.
+			if err := m.UninstallSyncTimer(); err != nil {
+				t.Errorf("second UninstallSyncTimer: %v", err)
+			}
+			if len(calls) == 0 {
+				t.Error("no platform command was run")
+			}
+		})
+	}
+}
+
+// The client-side timer must never collide with the server unit's files.
+func TestSyncTimerFilesAreDistinctFromServerService(t *testing.T) {
+	home := t.TempDir()
+	oldHome := userHomeDir
+	userHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { userHomeDir = oldHome })
+
+	serverPlist, _ := LaunchdPlistPath()
+	syncPlist, _ := SyncLaunchdPlistPath()
+	serverUnit, _ := SystemdUnitPath()
+	syncTimer, _ := SyncSystemdTimerPath()
+	syncService, _ := SyncSystemdServicePath()
+	for _, pair := range [][2]string{{serverPlist, syncPlist}, {serverUnit, syncTimer}, {serverUnit, syncService}} {
+		if pair[0] == pair[1] {
+			t.Errorf("the sync timer reuses the server's file: %s", pair[0])
+		}
+	}
+}

--- a/internal/service/synctimer.go
+++ b/internal/service/synctimer.go
@@ -1,0 +1,314 @@
+package service
+
+// The scheduled sync trigger (D140): a first-class trigger for clients that
+// cannot be hooked at session start — Kiro's IDE surface, and any provider
+// whose configuration Cartographer does not own. It reuses the same
+// launchd/systemd machinery as the server unit, with its own label and files
+// so the two never collide.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Labels and unit names of the client-side sync timer, deliberately distinct
+// from the server's (launchdLabel / systemdUnit).
+const (
+	syncLaunchdLabel   = "com.cartographer.sync"
+	syncSystemdService = "cartographer-sync.service"
+	syncSystemdTimer   = "cartographer-sync.timer"
+
+	// DefaultSyncInterval is long enough to stay invisible, short enough that
+	// a skill published in the morning is present by mid-morning.
+	DefaultSyncInterval = 30 * time.Minute
+)
+
+// SyncLaunchdPlistPath returns ~/Library/LaunchAgents/com.cartographer.sync.plist.
+func SyncLaunchdPlistPath() (string, error) {
+	home, err := userHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "Library", "LaunchAgents", syncLaunchdLabel+".plist"), nil
+}
+
+// SyncLaunchdLogPath returns ~/Library/Logs/cartographer/sync.log — the same
+// split the server unit uses (launchd logs to a file, systemd to the journal).
+func SyncLaunchdLogPath() (string, error) {
+	home, err := userHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "Library", "Logs", "cartographer", "sync.log"), nil
+}
+
+// SyncSystemdServicePath returns ~/.config/systemd/user/cartographer-sync.service.
+func SyncSystemdServicePath() (string, error) {
+	return systemdUserPath(syncSystemdService)
+}
+
+// SyncSystemdTimerPath returns ~/.config/systemd/user/cartographer-sync.timer.
+func SyncSystemdTimerPath() (string, error) {
+	return systemdUserPath(syncSystemdTimer)
+}
+
+func systemdUserPath(name string) (string, error) {
+	home, err := userHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "systemd", "user", name), nil
+}
+
+// RenderSyncLaunchdPlist renders the launchd agent that runs
+// `<binPath> sync` every interval, logging to logPath.
+//
+// The command carries no --auto-trust: an unattended background job must not
+// grant a trust the user never gave. The persisted `trust` setting in
+// .cartographer.yaml still applies, which is the correct authorization
+// boundary (D54).
+func RenderSyncLaunchdPlist(binPath, logPath string, interval time.Duration) string {
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>%s</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>%s</string>
+		<string>sync</string>
+	</array>
+	<key>StartInterval</key>
+	<integer>%d</integer>
+	<key>RunAtLoad</key>
+	<false/>
+	<key>StandardOutPath</key>
+	<string>%s</string>
+	<key>StandardErrorPath</key>
+	<string>%s</string>
+</dict>
+</plist>
+`, syncLaunchdLabel, binPath, int(interval.Seconds()), logPath, logPath)
+}
+
+// RenderSyncSystemdService renders the oneshot unit the timer activates.
+func RenderSyncSystemdService(binPath string) string {
+	return fmt.Sprintf(`[Unit]
+Description=Cartographer client sync
+
+[Service]
+Type=oneshot
+ExecStart=%s sync
+`, binPath)
+}
+
+// RenderSyncSystemdTimer renders the timer that activates the unit above.
+// Persistent catches up a run missed while the machine was off.
+func RenderSyncSystemdTimer(interval time.Duration) string {
+	return fmt.Sprintf(`[Unit]
+Description=Cartographer client sync timer
+
+[Timer]
+OnBootSec=%ds
+OnUnitActiveSec=%ds
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+`, int(interval.Seconds()), int(interval.Seconds()))
+}
+
+// SyncTimerStatus reports the installed state of the scheduled sync trigger.
+type SyncTimerStatus struct {
+	Installed bool
+	Active    bool
+	// Path is the plist (darwin) or timer unit (linux) backing it.
+	Path string
+	// Interval is the configured period, when it could be read back.
+	Interval time.Duration
+}
+
+// InstallSyncTimer writes the platform unit(s) and registers them. Idempotent:
+// re-running it overwrites the definition and re-registers.
+func (m *Manager) InstallSyncTimer(interval time.Duration) error {
+	if interval <= 0 {
+		interval = DefaultSyncInterval
+	}
+	binPath, err := osExecutable()
+	if err != nil {
+		return fmt.Errorf("service: resolve binary path: %w", err)
+	}
+	binPath = resolveStableBinPath(binPath)
+
+	switch goos {
+	case "darwin":
+		logPath, err := SyncLaunchdLogPath()
+		if err != nil {
+			return fmt.Errorf("service: resolve sync log path: %w", err)
+		}
+		if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+			return fmt.Errorf("service: create log dir: %w", err)
+		}
+		plistPath, err := SyncLaunchdPlistPath()
+		if err != nil {
+			return fmt.Errorf("service: resolve sync plist path: %w", err)
+		}
+		if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+			return fmt.Errorf("service: create LaunchAgents dir: %w", err)
+		}
+		if err := os.WriteFile(plistPath, []byte(RenderSyncLaunchdPlist(binPath, logPath, interval)), 0o644); err != nil {
+			return fmt.Errorf("service: write sync plist: %w", err)
+		}
+		uid := os.Getuid()
+		// Best-effort: bootout fails when the job was not loaded yet.
+		m.run("launchctl", "bootout", fmt.Sprintf("gui/%d/%s", uid, syncLaunchdLabel))
+		if _, err := m.run("launchctl", "bootstrap", fmt.Sprintf("gui/%d", uid), plistPath); err != nil {
+			return fmt.Errorf("service: launchctl bootstrap sync timer: %w", err)
+		}
+		return nil
+	case "linux":
+		servicePath, err := SyncSystemdServicePath()
+		if err != nil {
+			return fmt.Errorf("service: resolve sync unit path: %w", err)
+		}
+		timerPath, err := SyncSystemdTimerPath()
+		if err != nil {
+			return fmt.Errorf("service: resolve sync timer path: %w", err)
+		}
+		if err := os.MkdirAll(filepath.Dir(timerPath), 0o755); err != nil {
+			return fmt.Errorf("service: create systemd user dir: %w", err)
+		}
+		if err := os.WriteFile(servicePath, []byte(RenderSyncSystemdService(binPath)), 0o644); err != nil {
+			return fmt.Errorf("service: write sync unit: %w", err)
+		}
+		if err := os.WriteFile(timerPath, []byte(RenderSyncSystemdTimer(interval)), 0o644); err != nil {
+			// Leave no half-installed state behind.
+			os.Remove(servicePath)
+			return fmt.Errorf("service: write sync timer: %w", err)
+		}
+		if _, err := m.run("systemctl", "--user", "daemon-reload"); err != nil {
+			return fmt.Errorf("service: systemctl daemon-reload: %w", err)
+		}
+		if _, err := m.run("systemctl", "--user", "enable", "--now", syncSystemdTimer); err != nil {
+			return fmt.Errorf("service: systemctl enable --now %s: %w", syncSystemdTimer, err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("service: unsupported platform %q", goos)
+	}
+}
+
+// UninstallSyncTimer unregisters and removes the unit(s). Uninstalling a timer
+// that is not installed is a success, not an error.
+func (m *Manager) UninstallSyncTimer() error {
+	switch goos {
+	case "darwin":
+		plistPath, err := SyncLaunchdPlistPath()
+		if err != nil {
+			return fmt.Errorf("service: resolve sync plist path: %w", err)
+		}
+		m.run("launchctl", "bootout", fmt.Sprintf("gui/%d/%s", os.Getuid(), syncLaunchdLabel))
+		if err := os.Remove(plistPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("service: remove sync plist: %w", err)
+		}
+		return nil
+	case "linux":
+		servicePath, err := SyncSystemdServicePath()
+		if err != nil {
+			return fmt.Errorf("service: resolve sync unit path: %w", err)
+		}
+		timerPath, err := SyncSystemdTimerPath()
+		if err != nil {
+			return fmt.Errorf("service: resolve sync timer path: %w", err)
+		}
+		m.run("systemctl", "--user", "disable", "--now", syncSystemdTimer)
+		for _, p := range []string{timerPath, servicePath} {
+			if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("service: remove %s: %w", filepath.Base(p), err)
+			}
+		}
+		_, err = m.run("systemctl", "--user", "daemon-reload")
+		return err
+	default:
+		return fmt.Errorf("service: unsupported platform %q", goos)
+	}
+}
+
+// SyncTimerStatus reports whether the scheduled trigger is installed and
+// active. A missing launchctl/systemctl leaves Active false rather than
+// failing: the file on disk is the authority on "installed".
+func (m *Manager) SyncTimerStatus() (SyncTimerStatus, error) {
+	var st SyncTimerStatus
+	switch goos {
+	case "darwin":
+		plistPath, err := SyncLaunchdPlistPath()
+		if err != nil {
+			return st, fmt.Errorf("service: resolve sync plist path: %w", err)
+		}
+		st.Path = plistPath
+		if data, err := os.ReadFile(plistPath); err == nil {
+			st.Installed = true
+			st.Interval = intervalFromPlist(string(data))
+		}
+		if _, err := m.run("launchctl", "print", fmt.Sprintf("gui/%d/%s", os.Getuid(), syncLaunchdLabel)); err == nil {
+			st.Active = true
+		}
+		return st, nil
+	case "linux":
+		timerPath, err := SyncSystemdTimerPath()
+		if err != nil {
+			return st, fmt.Errorf("service: resolve sync timer path: %w", err)
+		}
+		st.Path = timerPath
+		if data, err := os.ReadFile(timerPath); err == nil {
+			st.Installed = true
+			st.Interval = intervalFromTimerUnit(string(data))
+		}
+		if out, err := m.run("systemctl", "--user", "is-active", syncSystemdTimer); err == nil && len(out) > 0 {
+			st.Active = true
+		}
+		return st, nil
+	default:
+		return st, fmt.Errorf("service: unsupported platform %q", goos)
+	}
+}
+
+// intervalFromPlist recovers StartInterval from a rendered plist, so status
+// can report the period without a second source of truth. Zero when absent.
+func intervalFromPlist(plist string) time.Duration {
+	return durationFromMarker(plist, "<key>StartInterval</key>", "<integer>", "</integer>")
+}
+
+// intervalFromTimerUnit recovers OnUnitActiveSec from a rendered timer unit.
+func intervalFromTimerUnit(unit string) time.Duration {
+	return durationFromMarker(unit, "OnUnitActiveSec=", "", "s")
+}
+
+func durationFromMarker(content, key, open, close string) time.Duration {
+	idx := strings.Index(content, key)
+	if idx == -1 {
+		return 0
+	}
+	rest := content[idx+len(key):]
+	if open != "" {
+		start := strings.Index(rest, open)
+		if start == -1 {
+			return 0
+		}
+		rest = rest[start+len(open):]
+	}
+	end := strings.Index(rest, close)
+	if end == -1 {
+		return 0
+	}
+	seconds, err := strconv.Atoi(strings.TrimSpace(rest[:end]))
+	if err != nil {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
+}


### PR DESCRIPTION
Implements the approved plan in #138 (D140). Sixth of the D135 → D143 series.

## WP1 — the mandatory verification, and what it found

The plan makes WP1 blocking because the rest writes files into another tool's configuration directory. Checked 2026-08-27 against Kiro's documentation; **no Kiro installation was available on this machine**, so the empirical half of WP1 could not be done. Three facts:

1. **User-level hooks exist.** [CLI 2.13 changelog](https://kiro.dev/changelog/cli/2-13/): "Hooks placed in `~/.kiro/hooks/` now fire in every workspace automatically". The [feature page](https://kiro.dev/docs/hooks/) still documents only `.kiro/hooks/` in the project root — the two sources disagree on scope.
2. **A spawn trigger exists and is CLI-only.** The [trigger table](https://kiro.dev/docs/hooks/types/) lists `agentSpawn` as CLI-only, firing when the agent is first activated.
3. **The literal trigger values in a hook file do not match that table.** The only complete JSON examples in the docs use `"trigger": "PostFileSave"` and `"trigger": "Stop"`, while the table calls those same triggers `fileSave` and `agentStop`. The exact string a spawn hook must carry is therefore **not determinable from the documentation**.

**So WP2 is not implemented.** `hook` × `kiro` stays `unsupported`. A guessed trigger value produces a hook Kiro silently ignores — indistinguishable from a working one until someone notices their KB skills are months stale, which is exactly the failure WP1 exists to prevent. The finding, its sources and its date are recorded in D140, together with the single confirmation needed to unblock it: the literal `trigger` value of a spawn hook, and that `~/.kiro/hooks/` is honoured on the surface where it fires. **This is a deliberate scope reduction from the plan — flagging it explicitly rather than shipping a guess.**

## WP3 — the scheduled trigger (implemented)

`cartographer service sync-timer install [--interval 30m] | uninstall | status`, reusing the launchd/systemd machinery of the server service under its own label (`com.cartographer.sync`, `cartographer-sync.timer`) and its own logs (`~/Library/Logs/cartographer/sync.log` / the journal), so the two units never collide. It follows the existing stable-binary-path rule, so a `brew upgrade` does not break it (D83).

Opt-in and explicit: `connect` and `status` name the command **once per invocation** when a connected provider has no session-hook mechanism (`provisioning.SupportsSessionHook`), and never install it. It runs sync **without** `--auto-trust`: an unattended job must not grant a trust the user never gave, while the persisted `trust` setting still applies (D54). Install is idempotent; uninstalling what is not installed succeeds; a failed timer write removes the half-written unit.

## Tests

`internal/service`: rendered plist/unit/timer goldens including the interval and the absence of `--auto-trust`, the interval read back from each; install→install idempotent and uninstall→uninstall successful on both platforms with a stubbed runner; the sync files asserted distinct from the server's. `cmd/cartographer`: `--interval` reaches the installer, the default is 30m, the three status exit codes (0/3/4), and the hint printed exactly once for a hook-less provider, never for a hooked one, and naming only the hook-less ones.

`make vet`, `make test` and `make e2e` (12/12) green.

## Docs

`docs/sync.md` (Kiro's row updated with the finding, the scheduled trigger as a Layer 1 alternative with its authorization note), `docs/configurator.md` (all three verbs, platform files, logs), `docs/deployment.md` (one note distinguishing the two unit families), code map, and D140 in `docs/decisions/sync-provisioning.md`.

## Release impact

A new opt-in `service sync-timer` subcommand. No breaking change. Kiro users do **not** get automatic session-start sync in this PR — the timer is their supported trigger until WP2's open question is answered.

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)