### PR TITLE
feat(client): hermes as a supported provider with inbox skill delivery (D141)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ Cartographer offers **two complementary profiles**:
 - 🧩 **Domain skills** (`SKILL.md` / agentskills.io format) with provisioning and client↔server sync, including executable scripts and binary assets
 - 🔑 **Secrets via SOPS** — JSON Pointer references, scoped resolution and safe rotation; plaintext values never stored
 - ⚙️ **Multi-provider configurator** — generates MCP config for Claude Code, Codex CLI, Kiro,
-  OpenCode
+  OpenCode; Hermes Agent is supported for artifact delivery (skills are *delivered* to its inbox for
+  the agent to adopt, never installed over the ones it curates itself)
 - 📦 **OKF-compliant** — each KB is an OKF bundle and a standalone git repo, zero lock-in (just git +
   Markdown)
 
@@ -130,7 +131,7 @@ first KB, and connect an agent client to it.
 brew install beppetemp/tap/cartographer   # or curl install.sh, or `go install` (see Install above)
 cartographer service install              # generates config, installs and starts the service
 cartographer kb create <name> --remote <url>  # scaffolds a KB in the data dir, pushes it to <url>
-cartographer connect                      # connects an agent client (Claude Code, OpenCode, Codex, Kiro)
+cartographer connect                      # connects an agent client (Claude Code, OpenCode, Codex, Kiro, Hermes)
 ```
 
 `--remote <url>` is an **empty** git repository that becomes the KB's `origin`: a KB is a git

--- a/cmd/cartographer/clientsync.go
+++ b/cmd/cartographer/clientsync.go
@@ -147,7 +147,10 @@ func pinnedPublicKeys(cfg *clientconfig.Config) (map[string][]ed25519.PublicKey,
 
 // materializeForProviders applies manifest m for each provider in providers,
 // persisting a single v2 LockFile at <targetDir>/.cartographer-sync.lock.json (one
-// Lock entry per provider). autoTrust is explicit authorization for eligible
+// Lock entry per provider). The lockfile always lives in targetDir, but each
+// provider materializes under its OWN base dir (D141: every provider but
+// hermes shares targetDir; hermes writes under $HERMES_HOME), recorded in that
+// provider's Lock so prune and verification later find the same files. autoTrust is explicit authorization for eligible
 // unsigned KB artifacts, passed to ApplyOptions.AutoTrust; it never changes an
 // artifact's Signed verification result. searchRoots/paths come from the loaded
 // clientconfig.Config (cfg.SearchRoots/cfg.Paths) and drive placeholder expansion
@@ -168,15 +171,21 @@ func materializeForProviders(m provisioning.Manifest, providers []string, target
 	// Validate every authorized local command for every destination before any
 	// provider file or lockfile can change. Provider is carried into errors so
 	// a failed multi-provider sync identifies the configuration it protected.
+	baseDirs := make(map[string]string, len(providers))
 	for _, p := range providers {
-		if err := provisioning.PreflightStdioMCP(m, provisioning.ApplyOptions{Provider: configurator.Provider(p), BaseDir: targetDir, AutoTrust: autoTrust, ApprovedMCP: approvedMCP}); err != nil {
+		baseDir, err := provisioning.BaseDirFor(configurator.Provider(p), targetDir)
+		if err != nil {
+			return nil, err
+		}
+		baseDirs[p] = baseDir
+		if err := provisioning.PreflightStdioMCP(m, provisioning.ApplyOptions{Provider: configurator.Provider(p), BaseDir: baseDir, AutoTrust: autoTrust, ApprovedMCP: approvedMCP}); err != nil {
 			return nil, err
 		}
 	}
 	for _, p := range providers {
 		opts := provisioning.ApplyOptions{
 			Provider:           configurator.Provider(p),
-			BaseDir:            targetDir,
+			BaseDir:            baseDirs[p],
 			DryRun:             dryRun,
 			NoHeal:             noHeal,
 			AutoTrust:          autoTrust,
@@ -194,6 +203,12 @@ func materializeForProviders(m provisioning.Manifest, providers []string, target
 		applied, err := provisioning.Apply(provisioning.FilterForProvider(m, configurator.Provider(p)), opts)
 		if err != nil {
 			return nil, fmt.Errorf("apply %s: %w", p, err)
+		}
+		// Record the base dir only when it is not the lockfile's own
+		// directory: every existing lockfile keeps its current meaning and no
+		// migration runs (D141).
+		if baseDirs[p] != targetDir {
+			applied.NewLock.BaseDir = baseDirs[p]
 		}
 		lockFile.SetProvider(p, applied.NewLock)
 		results[p] = applied
@@ -394,7 +409,7 @@ func resolveProviderCSV(csv string) ([]string, error) {
 	for _, part := range strings.Split(csv, ",") {
 		name := strings.TrimSpace(part)
 		if name == "" {
-			return nil, fmt.Errorf("invalid --agents value %q (want comma-separated claude|opencode|codex|kiro)", csv)
+			return nil, fmt.Errorf("invalid --agents value %q (want comma-separated %s)", csv, providerNamesJoined())
 		}
 		provider, err := resolveProvider(name)
 		if err != nil {
@@ -412,11 +427,18 @@ func resolveProvider(target string) ([]string, error) {
 	if _, ok := configurator.Lookup(configurator.Provider(target)); ok {
 		return []string{target}, nil
 	}
+	return nil, fmt.Errorf("unknown provider %q (want %s)", target, providerNamesJoined())
+}
+
+// providerNamesJoined renders the supported provider identifiers for a usage
+// message, from the registry rather than a hand-kept list (D137/D141: adding a
+// provider must not leave stale help text behind).
+func providerNamesJoined() string {
 	names := make([]string, 0, len(configurator.ProviderList()))
 	for _, p := range configurator.ProviderList() {
 		names = append(names, string(p))
 	}
-	return nil, fmt.Errorf("unknown provider %q (want %s)", target, strings.Join(names, "|"))
+	return strings.Join(names, "|")
 }
 
 // splitPositional extracts a single leading positional argument (one not starting

--- a/cmd/cartographer/clientsync_test.go
+++ b/cmd/cartographer/clientsync_test.go
@@ -485,3 +485,71 @@ func TestMaterializeForProviders_StdioPreflightIsAtomic(t *testing.T) {
 		}
 	}
 }
+
+// A provider with a base dir of its own (D141) materializes into its own tree,
+// while the single v2 lockfile stays in the shared target dir and records that
+// base dir — so a later prune finds the same files. The provider that shares
+// the target dir keeps a lockfile entry with no base_dir at all: no migration,
+// no change of meaning for anything written before D141.
+func TestMaterializeForProviders_PerProviderBaseDir(t *testing.T) {
+	dir := t.TempDir()
+	hermesHome := t.TempDir()
+	t.Setenv("HERMES_HOME", hermesHome)
+
+	m := kbSkillManifest()
+	if _, err := materializeForProviders(m, []string{"claude", "hermes"}, dir, true, false /* dryRun */, false, nil, nil); err != nil {
+		t.Fatalf("materializeForProviders: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, ".claude", "skills", "example", "SKILL.md")); err != nil {
+		t.Errorf("claude materialized under the shared dir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(hermesHome, "skill-inbox", "example", "cartographer", "SKILL.md")); err != nil {
+		t.Errorf("hermes materialized under $HERMES_HOME: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "skill-inbox")); !os.IsNotExist(err) {
+		t.Errorf("hermes wrote into the shared dir too: %v", err)
+	}
+
+	lockFile, err := provisioning.ReadLockFile(lockFilePath(dir))
+	if err != nil {
+		t.Fatalf("read lockfile: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(hermesHome, provisioning.LockFileName)); !os.IsNotExist(err) {
+		t.Errorf("a second lockfile was written under $HERMES_HOME: %v", err)
+	}
+	if got := lockFile.ForProvider("hermes").BaseDir; got != hermesHome {
+		t.Errorf("hermes lock base_dir = %q, want %q", got, hermesHome)
+	}
+	if got := lockFile.ForProvider("claude").BaseDir; got != "" {
+		t.Errorf("claude lock base_dir = %q, want empty (the lockfile's own directory)", got)
+	}
+
+	// Prune resolved through LockBaseDir removes each provider's files inside
+	// its own tree only.
+	for _, p := range []string{"claude", "hermes"} {
+		lock := lockFile.ForProvider(p)
+		if _, err := provisioning.PruneManaged(lock.Managed, provisioning.LockBaseDir(lock, dir), false); err != nil {
+			t.Fatalf("prune %s: %v", p, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(hermesHome, "skill-inbox", "example")); !os.IsNotExist(err) {
+		t.Errorf("hermes delivery survived the prune: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".claude", "skills", "example")); !os.IsNotExist(err) {
+		t.Errorf("claude skill survived the prune: %v", err)
+	}
+}
+
+// $HERMES_HOME unset is a failure that names the variable, not a silent
+// fallback to the home directory (D141).
+func TestMaterializeForProviders_MissingProviderBaseDir(t *testing.T) {
+	t.Setenv("HERMES_HOME", "")
+	_, err := materializeForProviders(kbSkillManifest(), []string{"hermes"}, t.TempDir(), true, false, false, nil, nil)
+	if err == nil {
+		t.Fatal("materializeForProviders succeeded with $HERMES_HOME unset")
+	}
+	if !strings.Contains(err.Error(), "HERMES_HOME") {
+		t.Errorf("error %q does not name the variable", err)
+	}
+}

--- a/cmd/cartographer/connect.go
+++ b/cmd/cartographer/connect.go
@@ -262,7 +262,7 @@ func cmdConnect(args []string) int {
 		return 2
 	}
 	if len(providers) == 0 {
-		fmt.Fprintln(os.Stderr, "No agent detected on this machine; nothing to connect (pass an explicit provider name to force it: claude|opencode|codex|kiro).")
+		fmt.Fprintf(os.Stderr, "No agent detected on this machine; nothing to connect (pass an explicit provider name to force it: %s).\n", providerNamesJoined())
 		return 1
 	}
 
@@ -501,6 +501,15 @@ type connectResult struct {
 func doConnect(opts connectOptions) (connectResult, error) {
 	if len(opts.Providers) == 0 {
 		return connectResult{}, fmt.Errorf("no providers to connect")
+	}
+
+	// A provider with a root of its own (D141: $HERMES_HOME) cannot be
+	// connected without it. Fail here, naming the variable, rather than
+	// materializing into the home directory where the agent never looks.
+	for _, p := range opts.Providers {
+		if _, err := provisioning.BaseDirFor(configurator.Provider(p), opts.Dir); err != nil {
+			return connectResult{}, err
+		}
 	}
 
 	// 1. Discover mounted KBs before generating MCP entries. A down server

--- a/cmd/cartographer/connectform.go
+++ b/cmd/cartographer/connectform.go
@@ -36,6 +36,11 @@ const (
 	fieldSubmit
 )
 
+// formProviders are the providers the interactive connect form offers: the
+// ones whose MCP configuration `connect` actually writes. hermes is
+// deliberately absent (D141) — it has no MCP config to write and needs
+// $HERMES_HOME set in the environment, so it is connected from the CLI
+// (`cartographer connect hermes`), where that failure can be stated plainly.
 var formProviders = []string{"claude", "opencode", "codex", "kiro"}
 
 func providerForField(f connectField) (string, bool) {

--- a/cmd/cartographer/disconnect.go
+++ b/cmd/cartographer/disconnect.go
@@ -135,7 +135,10 @@ func doDisconnect(opts disconnectOptions) (disconnectResult, error) {
 		pr.ConfigRemoved = removed[p]
 
 		lock := lockFile.ForProvider(p)
-		pruned, err := provisioning.PruneManaged(lock.Managed, opts.Dir, opts.DryRun)
+		// The managed paths are relative to the base dir the provider actually
+		// materialized under, which the Lock records when it is not opts.Dir
+		// (D141) — pruning against the wrong one silently no-ops.
+		pruned, err := provisioning.PruneManaged(lock.Managed, provisioning.LockBaseDir(lock, opts.Dir), opts.DryRun)
 		if err != nil {
 			return disconnectResult{}, fmt.Errorf("prune skills for %s: %w", p, err)
 		}

--- a/cmd/cartographer/multikb.go
+++ b/cmd/cartographer/multikb.go
@@ -256,6 +256,14 @@ func applyMCPEntries(entries []mcpEntry, providers []string, dir string, auth bo
 	written = make([]string, 0, len(providers))
 	seenPaths := map[string]bool{}
 	for _, provider := range providers {
+		if !configurator.ManagesMCPConfig(configurator.Provider(provider)) {
+			// A provider whose MCP endpoints are configured outside
+			// Cartographer (D141, hermes: its config.yaml is rendered by its
+			// Ansible role). Say so — silently writing nothing would look
+			// like a bug the first time someone connects it.
+			warnings = append(warnings, unmanagedMCPConfigNote(configurator.Provider(provider)))
+			continue
+		}
 		results := make([]*configurator.EmitResult, 0, len(entries))
 		for _, entry := range entries {
 			r, err := configurator.Emit(&configurator.ServerConfig{Name: entry.Name, URL: entry.URL, AuthEnabled: auth, TokenEnv: tokenEnv}, configurator.Provider(provider))
@@ -295,6 +303,11 @@ func applyMCPEntries(entries []mcpEntry, providers []string, dir string, auth bo
 func removeMCPEntries(baseName string, kbs []string, providers []string, dir string, auth bool, tokenEnv string, dryRun bool) (map[string]bool, error) {
 	removed := make(map[string]bool, len(providers))
 	for _, provider := range providers {
+		if !configurator.ManagesMCPConfig(configurator.Provider(provider)) {
+			// Nothing was ever written for it (D141), so there is nothing to
+			// remove and no config file to look for.
+			continue
+		}
 		for _, name := range managedEntryNames(baseName, kbs) {
 			ok, err := configurator.Remove(&configurator.ServerConfig{Name: name, AuthEnabled: auth, TokenEnv: tokenEnv}, configurator.Provider(provider), dir, dryRun)
 			if err != nil {
@@ -304,4 +317,16 @@ func removeMCPEntries(baseName string, kbs []string, providers []string, dir str
 		}
 	}
 	return removed, nil
+}
+
+// unmanagedMCPConfigNote is what `connect` reports for a provider whose MCP
+// configuration Cartographer does not own (D141). It names the provider and
+// what stays the operator's job, so the absence of a written config file reads
+// as a decision rather than a failure.
+func unmanagedMCPConfigNote(provider configurator.Provider) string {
+	name := string(provider)
+	if d, ok := configurator.Lookup(provider); ok {
+		name = d.DisplayName
+	}
+	return fmt.Sprintf("%s: registered for artifact delivery; its MCP endpoint is NOT configured by Cartographer (it is rendered by %s' own deployment) — point it at this server yourself", name, provider)
 }

--- a/cmd/cartographer/multikb_test.go
+++ b/cmd/cartographer/multikb_test.go
@@ -378,3 +378,69 @@ func TestFlatNamespaceMountWarning(t *testing.T) {
 		})
 	}
 }
+
+// D141: connecting hermes registers it for artifact delivery without writing
+// any MCP configuration — its endpoints are rendered by its own deployment —
+// and says so, because silently writing nothing would read as a bug.
+func TestDoConnect_Hermes_NoMCPConfigButSaysSo(t *testing.T) {
+	srv := multiKBServer(t, `{"status":"ok","kbs":[{"name":"alpha"}]}`)
+	defer srv.Close()
+	dir := t.TempDir()
+	hermesHome := t.TempDir()
+	t.Setenv("HERMES_HOME", hermesHome)
+
+	res, err := doConnect(connectOptions{Providers: []string{"hermes"}, Dir: dir, ServerURL: srv.URL + "/mcp", Name: "cartographer", TokenEnv: "TOKEN", Trust: true})
+	if err != nil {
+		t.Fatalf("doConnect: %v", err)
+	}
+	if len(res.ConfigsWritten) != 0 {
+		t.Errorf("connect hermes wrote MCP configs: %v", res.ConfigsWritten)
+	}
+	said := false
+	for _, w := range res.Warnings {
+		if strings.Contains(w, "MCP endpoint is NOT configured") {
+			said = true
+		}
+	}
+	if !said {
+		t.Errorf("connect hermes said nothing about the MCP endpoint: %v", res.Warnings)
+	}
+	for _, root := range []string{dir, hermesHome} {
+		for _, name := range []string{".claude.json", "opencode.json"} {
+			if _, err := os.Stat(filepath.Join(root, name)); !os.IsNotExist(err) {
+				t.Errorf("unexpected %s under %s: %v", name, root, err)
+			}
+		}
+		if _, err := os.Stat(filepath.Join(root, "skills")); !os.IsNotExist(err) {
+			t.Errorf("HERMES_HOME/skills/ must never be created (%s): %v", root, err)
+		}
+	}
+
+	cfg, err := clientconfig.Load(dir)
+	if err != nil || strings.Join(cfg.Agents, ",") != "hermes" {
+		t.Fatalf("persisted agents = %v, err=%v", cfg.Agents, err)
+	}
+
+	// Disconnect touches nothing else and leaves no agent behind.
+	if _, err := doDisconnect(disconnectOptions{Providers: []string{"hermes"}, Dir: dir}); err != nil {
+		t.Fatalf("doDisconnect: %v", err)
+	}
+	cfg, err = clientconfig.Load(dir)
+	if err != nil || len(cfg.Agents) != 0 {
+		t.Fatalf("agents after disconnect = %v, err=%v", cfg.Agents, err)
+	}
+}
+
+// Connecting a provider whose root directory is not configured fails naming
+// the variable, before anything is written (D141).
+func TestDoConnect_Hermes_MissingHome(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HERMES_HOME", "")
+	_, err := doConnect(connectOptions{Providers: []string{"hermes"}, Dir: dir, ServerURL: "http://127.0.0.1:1/mcp", Name: "cartographer"})
+	if err == nil || !strings.Contains(err.Error(), "HERMES_HOME") {
+		t.Fatalf("doConnect error = %v, want one naming HERMES_HOME", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".cartographer.yaml")); !os.IsNotExist(err) {
+		t.Errorf("a failed connect persisted config anyway: %v", err)
+	}
+}

--- a/cmd/cartographer/status_snapshot.go
+++ b/cmd/cartographer/status_snapshot.go
@@ -173,7 +173,8 @@ func snapshotForConfig(dir string, cfg *clientconfig.Config, includeService bool
 		// On-disk verification (D139): the manifest↔lockfile comparison says
 		// nothing about what is actually on disk, so an artifact edited or
 		// deleted locally used to report in-sync.
-		p.Diverged = snapshotDiverged(provisioning.VerifyManaged(lockFile.ForProvider(p.Name), configurator.Provider(p.Name), dir))
+		lock := lockFile.ForProvider(p.Name)
+		p.Diverged = snapshotDiverged(provisioning.VerifyManaged(lock, configurator.Provider(p.Name), provisioning.LockBaseDir(lock, dir)))
 		if d.InSync && len(p.Diverged) == 0 {
 			p.State = "in_sync"
 			continue

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -34,9 +34,10 @@ errors. `service status` retains 0 running, 3 stopped and 4 not installed.
 
 ### `cartographer agents`
 
-Lists the four supported providers, whether they are installed on the machine (`internal/agents.Detect`:
-binary in PATH or a known config directory) and whether they are connected (present in the
-machine-wide `.cartographer.yaml`, `~/.cartographer.yaml`).
+Lists the supported providers, whether they are installed on the machine (`internal/agents.Detect`:
+binary in PATH, a known config directory, or — for a provider with a root of its own — that root,
+`$HERMES_HOME`) and whether they are connected (present in the machine-wide `.cartographer.yaml`,
+`~/.cartographer.yaml`).
 
 ```bash
 cartographer agents
@@ -91,7 +92,7 @@ cartographer connect all --auto-trust --dry-run
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| (positional) | `all` | `claude` \| `opencode` \| `codex` \| `kiro` \| `all` (all detected agents) |
+| (positional) | `all` | `claude` \| `opencode` \| `codex` \| `kiro` \| `hermes` \| `all` (all detected agents) |
 | `--agents` | *(unset)* | Comma-separated subset (`claude,codex`); cannot be combined with the positional provider |
 | `--server-url` | `http://localhost:39273/mcp` | Cartographer server URL |
 | `--auth` | `false` | Enables the Bearer header in generated configs |
@@ -156,7 +157,7 @@ cartographer disconnect all --dry-run  # preview without writing
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| (positional) | `all` | `claude` \| `opencode` \| `codex` \| `kiro` \| `all` (every connected provider) |
+| (positional) | `all` | `claude` \| `opencode` \| `codex` \| `kiro` \| `hermes` \| `all` (every connected provider) |
 | `--agents` | *(unset)* | Comma-separated subset (`claude,codex`); cannot be combined with the positional provider |
 | `--dry-run` | `false` | Prints without removing |
 
@@ -358,6 +359,29 @@ Adding a provider therefore means: one descriptor, one emitter (the four output 
 differ, so that stays code), its cells in the kind × provider matrix (`internal/provisioning`, see
 [`sync.md`](sync.md) §Kind × provider matrix), and — if it has a native hook mechanism — one entry
 in `hookMechanisms`. A missing matrix cell fails a completeness test; nothing else needs editing.
+A provider whose MCP configuration Cartographer does not own declares neither a config file nor an
+emitter and is skipped by `connect`/`disconnect` (`ManagesMCPConfig`); one that materializes outside
+the shared base dir declares `BaseDirEnv` instead ([D141](decisions/client-configurator.md#d141)).
+
+### Hermes Agent
+
+`cartographer connect hermes` registers Hermes for **artifact delivery only**. It writes no MCP
+configuration: Hermes' endpoint list lives in a `config.yaml` rendered by its Ansible role and
+recreated on the next playbook run, so anything written there would be lost — `connect` says so
+explicitly rather than silently doing nothing, and pointing Hermes at the server stays the
+operator's job. For the same reason Hermes is absent from the interactive connect form, which offers
+the providers whose MCP configuration `connect` writes.
+
+- **`$HERMES_HOME` is required**: it is the base dir artifacts are materialized under, recorded as
+  `base_dir` in that provider's lockfile entry. Unset, `connect hermes` fails naming the variable
+  instead of writing into the home directory, where the agent would never look.
+- **Only `skill` is supported**, and it is *delivered* to `skill-inbox/<name>/cartographer/` rather
+  than installed — adoption is the agent's own decision, via `skill_manage`. Nothing is ever written
+  under `$HERMES_HOME/skills/`. See [`sync.md`](sync.md) §Hermes.
+- **The trigger is the scheduled timer** (`cartographer service sync-timer install`): Hermes has no
+  session hook, so nothing fires at conversation start.
+- `disconnect hermes` prunes the delivered inbox directories and drops the provider from
+  `.cartographer.yaml`; it touches nothing else.
 
 ## Files generated per provider (HTTP transport)
 
@@ -367,6 +391,7 @@ in `hookMechanisms`. A missing matrix cell fails a completeness test; nothing el
 | Codex CLI | `.codex/config.toml` | managed block `[mcp_servers.cartographer]` (TOML, marker `cartographer:mcp:*`) |
 | Kiro | `.kiro/settings/mcp.json` | `mcpServers` (JSON) |
 | OpenCode | `opencode.json` | `mcp` (JSON) |
+| Hermes Agent | none — see below | — |
 
 KB-provided stdio descriptors (D116) share these same files with per-name ownership. Claude Code,
 Codex and Kiro receive native `command`, `args` and `env` fields (Kiro also keeps `autoApprove: []`);

--- a/docs/decisions/client-configurator.md
+++ b/docs/decisions/client-configurator.md
@@ -387,3 +387,52 @@ knowledge in the wrong package. Two tables, each owned where the concept lives, 
 intact. The refactor is behaviour-preserving by construction: the existing suite, including the
 connect/disconnect round trip and the configurator goldens, passes unmodified.
 
+## D141 — Hermes is a supported provider that receives deliveries, not installations
+
+`hermes` is a provider in the registry (D137) with exactly one supported kind, `skill`, and four
+explicitly unsupported cells. Its skills are **delivered** to
+`$HERMES_HOME/skill-inbox/<name>/cartographer/` — the skill's files, provenance-stamped as
+everywhere else (D138), plus a generated `SOURCE.md` — and the agent adopts what it chooses through
+its own `skill_manage` tool. **Nothing is ever written under `$HERMES_HOME/skills/`.**
+
+**Why delivery and not installation.** That directory belongs to Hermes' own curator, which
+archives unused skills, keeps telemetry and honours pins by rewriting what it owns from its
+learning loop. Materializing there would put Cartographer and the curator in a permanent fight —
+one overwriting from the server, the other rewriting from its own experience — and the loser is the
+agent's accumulated learning, which no sync can restore. The convention for *proposing* a skill from
+outside already existed (`skill-inbox/`), and it is a curatorial handoff, not an install.
+
+**The four unsupported cells**, each for a stated reason rather than by omission: `agent` — no
+native subagent directory; `hook` — no hook mechanism at all, nothing fires at conversation start;
+`mcp` — `config.yaml` is rendered by an Ansible role and recreated on the next playbook run;
+`instructions` — `SOUL.md`, its always-on slot, is operator-owned and rendered from a template.
+Anything Cartographer wrote into the last two would be silently destroyed by the next deploy.
+`Unsupported` already means "no approval unblocks it" everywhere in the client (D50), so nothing
+else changes. Its trigger is therefore the scheduled timer from D140: with no session hook, the
+timer is Hermes' Layer 1.
+
+**No timestamp in the delivery path**, deliberately departing from the
+`skill-inbox/<skill>/<timestamp>/` convention. Provisioning must be idempotent: a timestamped
+directory per sync would accumulate a fresh copy every timer tick and no prune could tell stale from
+current. One stable directory per (skill, source) is updated in place — the last path segment names
+the proposer, so another source never collides — and the history of the proposal lives in the KB's
+git log, which is where it belongs. `SOURCE.md` carries the artifact's content hash, so the agent
+distinguishes an unchanged re-delivery from a new proposal. `SOURCE.md` is generated, so a KB skill
+shipping its own is a collision: that one artifact fails with a warning naming it and is not
+recorded in the lockfile, while the rest of the sync completes.
+
+**Per-provider base directories.** Every other provider materializes under one shared base dir;
+Hermes' root is elsewhere on the machine (`/opt/data` in the reference deployment), so `Lock` gains
+an optional `base_dir` recording the directory its `ManagedFile` paths are relative to. Empty — every
+lockfile written before this, and every other provider — means "the lockfile's own directory", so
+no migration runs and nothing changes meaning. Prune and on-disk verification (D139) read it through
+`LockBaseDir`; the lockfile itself stays a **single v2 file** in the client's target directory with
+one `Lock` per provider. `$HERMES_HOME` unset makes `connect hermes` fail naming the variable,
+before anything is written: falling back to the home directory would scatter files where the agent
+never looks.
+
+**Connect says what it does not do.** Hermes has no MCP emitter, so `connect hermes` writes no MCP
+entry and reports that its endpoint stays the operator's job — silently doing nothing there would
+read as a bug. For the same reason it is absent from the interactive connect form, which offers the
+providers whose MCP configuration `connect` actually writes; Hermes is connected from the CLI, where
+the missing-`$HERMES_HOME` failure can be stated plainly.

--- a/docs/interoperability.md
+++ b/docs/interoperability.md
@@ -58,3 +58,22 @@ Current limitations are documented once in the relevant table/section rather
 than repeated here. In particular, Kiro's flat MCP tool namespace may require
 the server's per-KB tool prefix, and provider translations intentionally drop
 fields that cannot be represented safely.
+
+### Instruction slots Cartographer deliberately does not write
+
+Leveraging a provider to the fullest also means declining to write where the
+write would not survive, or would destroy what another owner maintains. Two
+Hermes slots are unsupported for that reason
+([D141](decisions/client-configurator.md#d141)), not for lack of a mapping:
+
+- **`SOUL.md`**, its always-on instruction slot — operator-owned and rendered
+  from a template by an Ansible role, so a managed block written there is gone
+  on the next playbook run. The imprinting that reaches every other provider as
+  a `kind: instructions` block simply does not reach Hermes;
+- **`config.yaml`**, its MCP endpoint list — rendered by the same role, for the
+  same reason. `connect hermes` therefore configures no MCP entry and says so.
+
+- **`$HERMES_HOME/skills/`** is a third: not an instruction slot but the
+  agent's own curated skill store, rewritten by its curator from its learning
+  loop. Cartographer delivers proposals to `skill-inbox/<name>/cartographer/`
+  and the agent adopts what it chooses — see [`sync.md`](sync.md) §Hermes.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -176,13 +176,43 @@ every sync and was reported as permanent drift.
 
 The matrix below is data in the code: `destinationMatrix` in `internal/provisioning/provisioning.go`, resolved by `destDir(kind, name, provider)` ([D137](decisions/client-configurator.md#d137)). Every cell either names a destination or is explicitly `unsupported` — a cell *missing* from the table fails a completeness test instead of degrading silently. `unsupported` is not `needs_approval` (no approval would unblock it): clients filter such artifacts out upstream with `FilterForProvider`, and they count as neither drift nor pending ([D50](decisions/sync-provisioning.md#d50)).
 
-| Kind | claude | opencode | codex | kiro |
-|---|---|---|---|---|
-| `skill` | `.claude/skills/<name>/` | `.opencode/skills/<name>/` | `.codex/skills/<name>/` | `.kiro/skills/<name>/` |
-| `agent` | `.claude/agents/<name>.md` (verbatim) | `.opencode/agent/<name>.md` (translated) | `.codex/agents/<name>.toml` (translated) | unsupported |
-| `hook` | `.claude/hooks/<name>/` + registration in `settings.json` | `.opencode/hooks/<name>/` + generated JS plugin | `.codex/hooks/<name>/` + block in `config.toml` | unsupported |
-| `instructions` | managed block in `.claude/CLAUDE.md` | block in `.config/opencode/AGENTS.md` | block in `.codex/AGENTS.md` | file `.kiro/steering/cartographer.md` |
-| `mcp` | key `mcpServers.<name>` in `.claude.json` | key `mcp.<name>` in `opencode.json` | block `[mcp_servers.<name>]` in `config.toml` | key `mcpServers.<name>` in `.kiro/settings/mcp.json` |
+| Kind | claude | opencode | codex | kiro | hermes |
+|---|---|---|---|---|---|
+| `skill` | `.claude/skills/<name>/` | `.opencode/skills/<name>/` | `.codex/skills/<name>/` | `.kiro/skills/<name>/` | `skill-inbox/<name>/cartographer/` (delivered, see below) |
+| `agent` | `.claude/agents/<name>.md` (verbatim) | `.opencode/agent/<name>.md` (translated) | `.codex/agents/<name>.toml` (translated) | unsupported | unsupported — no native subagent directory |
+| `hook` | `.claude/hooks/<name>/` + registration in `settings.json` | `.opencode/hooks/<name>/` + generated JS plugin | `.codex/hooks/<name>/` + block in `config.toml` | unsupported | unsupported — no hook mechanism at all |
+| `instructions` | managed block in `.claude/CLAUDE.md` | block in `.config/opencode/AGENTS.md` | block in `.codex/AGENTS.md` | file `.kiro/steering/cartographer.md` | unsupported — `SOUL.md` is operator-owned, rendered from a template |
+| `mcp` | key `mcpServers.<name>` in `.claude.json` | key `mcp.<name>` in `opencode.json` | block `[mcp_servers.<name>]` in `config.toml` | key `mcpServers.<name>` in `.kiro/settings/mcp.json` | unsupported — `config.yaml` is rendered by an Ansible role |
+
+Paths are relative to the client **base dir**, which is the user's home for every provider but
+`hermes`: that one materializes under `$HERMES_HOME`, recorded as `base_dir` in its entry of the
+single lockfile ([D141](decisions/client-configurator.md#d141)). An entry with no `base_dir` — every
+lockfile written before that, and every other provider — means the lockfile's own directory, so
+nothing migrated.
+
+### Hermes: delivery, not installation
+
+Hermes' skills live in `$HERMES_HOME/skills/` and are **owned by the agent itself**: a curator
+archives unused ones, keeps telemetry and honours pins, rewriting what it owns from its own learning
+loop. Cartographer therefore **never writes there**. A KB skill is instead delivered to
+`$HERMES_HOME/skill-inbox/<name>/cartographer/` as a **proposal**: the skill's files (provenance
+block included, D138) plus a generated `SOURCE.md` naming the source KB, the artifact path, its
+content hash, and the fact that adopting it is the agent's own `skill_manage` decision. Cartographer
+delivers; Hermes adopts.
+
+The delivery path deliberately carries **no timestamp**, departing from the
+`skill-inbox/<skill>/<timestamp>/` convention: provisioning must be idempotent, and one directory
+per sync would accumulate a copy on every timer tick with no way to tell stale from current. One
+stable directory per (skill, source), updated in place — the last segment names the proposer, so
+another source never collides — with the content hash in `SOURCE.md` distinguishing an unchanged
+re-delivery from a new proposal; the proposal's history lives in the KB's git log. Pruning removes
+exactly `skill-inbox/<name>/cartographer/` (and `skill-inbox/<name>/` if that empties it), never an
+adopted copy under `skills/` and never the shared `skill-inbox/` root. A KB skill that ships its own
+`SOURCE.md` is a collision: that one artifact is not delivered and produces a warning naming it,
+while the rest of the sync completes.
+
+Hermes has no session hook, so its trigger is the scheduled timer (`cartographer service sync-timer
+install`, D140).
 
 ## Agents and hooks
 

--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -1,5 +1,5 @@
 // Package agents detects which LLM agent CLIs/apps are installed on the local
-// machine (Claude Code, OpenCode, Codex CLI, Kiro), so `cartographer agents`
+// machine (Claude Code, OpenCode, Codex CLI, Kiro, Hermes), so `cartographer agents`
 // and `cartographer connect all` know which providers to target.
 package agents
 
@@ -25,6 +25,7 @@ type Agent struct {
 var (
 	lookPath    = exec.LookPath
 	userHomeDir = os.UserHomeDir
+	getenv      = os.Getenv
 	goos        = runtime.GOOS
 )
 
@@ -41,8 +42,8 @@ func dirExists(path string) bool {
 // registry's detection order (D137: identity and detection evidence live in
 // internal/configurator's descriptors, not in per-provider functions here).
 // An agent is Installed if at least one heuristic matches: its binary in PATH,
-// then its config directories in descriptor order, then — on darwin only — its
-// application bundle.
+// then its config directories in descriptor order, then its own root directory
+// if it declares one (D141), then — on darwin only — its application bundle.
 func Detect() []Agent {
 	home, _ := userHomeDir()
 	out := make([]Agent, 0, len(configurator.DetectionOrder()))
@@ -64,6 +65,14 @@ func detect(d configurator.Descriptor, home string) Agent {
 		dir := filepath.Join(append([]string{home}, segments...)...)
 		if dirExists(dir) {
 			a.Installed, a.Evidence = true, dir
+			return a
+		}
+	}
+	// A provider with its own root directory (D141: $HERMES_HOME) is installed
+	// if that root exists — it is the same evidence `connect` needs anyway.
+	if d.BaseDirEnv != "" {
+		if root := getenv(d.BaseDirEnv); dirExists(root) {
+			a.Installed, a.Evidence = true, root
 			return a
 		}
 	}

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -9,11 +9,13 @@ import (
 	"github.com/BeppeTemp/cartographer/internal/configurator"
 )
 
-// withStubs temporarily replaces lookPath/userHomeDir/goos and restores them
-// via t.Cleanup, so tests never touch the real PATH/filesystem/OS.
+// withStubs temporarily replaces lookPath/userHomeDir/getenv/goos and restores
+// them via t.Cleanup, so tests never touch the real PATH/filesystem/OS/env.
+// The environment starts empty: a provider detected through its own root
+// directory (D141) is invisible unless a test sets it via withEnv.
 func withStubs(t *testing.T, home string, found map[string]string, os_ string) {
 	t.Helper()
-	origLookPath, origHome, origGOOS := lookPath, userHomeDir, goos
+	origLookPath, origHome, origGetenv, origGOOS := lookPath, userHomeDir, getenv, goos
 	lookPath = func(name string) (string, error) {
 		if p, ok := found[name]; ok {
 			return p, nil
@@ -21,12 +23,21 @@ func withStubs(t *testing.T, home string, found map[string]string, os_ string) {
 		return "", errors.New("not found")
 	}
 	userHomeDir = func() (string, error) { return home, nil }
+	getenv = func(string) string { return "" }
 	if os_ != "" {
 		goos = os_
 	}
 	t.Cleanup(func() {
-		lookPath, userHomeDir, goos = origLookPath, origHome, origGOOS
+		lookPath, userHomeDir, getenv, goos = origLookPath, origHome, origGetenv, origGOOS
 	})
+}
+
+// withEnv stubs the environment lookup with a fixed map, on top of withStubs.
+func withEnv(t *testing.T, env map[string]string) {
+	t.Helper()
+	orig := getenv
+	getenv = func(name string) string { return env[name] }
+	t.Cleanup(func() { getenv = orig })
 }
 
 func TestDetect_NothingInstalled(t *testing.T) {
@@ -34,8 +45,8 @@ func TestDetect_NothingInstalled(t *testing.T) {
 	withStubs(t, home, nil, "linux")
 
 	got := Detect()
-	if len(got) != 4 {
-		t.Fatalf("expected 4 agents, got %d", len(got))
+	if want := len(configurator.DetectionOrder()); len(got) != want {
+		t.Fatalf("expected %d agents, got %d", want, len(got))
 	}
 	for _, a := range got {
 		if a.Installed {
@@ -111,6 +122,36 @@ func TestDetect_OpenCodeXDGConfigDir(t *testing.T) {
 			if !a.Installed || a.Evidence != filepath.Join(home, ".config", "opencode") {
 				t.Errorf("opencode: expected Installed=true evidence=%s, got %+v", filepath.Join(home, ".config", "opencode"), a)
 			}
+		}
+	}
+}
+
+// A provider whose evidence is its own root directory (D141, hermes) is
+// detected from $HERMES_HOME when the binary is absent — and only when that
+// directory actually exists.
+func TestDetect_ProviderRootDir(t *testing.T) {
+	home := t.TempDir()
+	root := filepath.Join(t.TempDir(), "hermes")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	withStubs(t, home, nil, "linux")
+	withEnv(t, map[string]string{"HERMES_HOME": root})
+	for _, a := range Detect() {
+		if a.Provider != configurator.ProviderHermes {
+			continue
+		}
+		if !a.Installed || a.Evidence != root {
+			t.Fatalf("hermes: expected Installed=true evidence=%q, got %+v", root, a)
+		}
+	}
+
+	// Pointing at a directory that does not exist is not evidence.
+	withEnv(t, map[string]string{"HERMES_HOME": filepath.Join(root, "nope")})
+	for _, a := range Detect() {
+		if a.Provider == configurator.ProviderHermes && a.Installed {
+			t.Fatalf("hermes: expected not installed, got %+v", a)
 		}
 	}
 }

--- a/internal/configurator/configurator.go
+++ b/internal/configurator/configurator.go
@@ -74,6 +74,10 @@ const (
 	ProviderCodex      Provider = "codex"
 	ProviderKiro       Provider = "kiro"
 	ProviderOpenCode   Provider = "opencode"
+	// ProviderHermes is Hermes Agent (D141). It is a supported destination
+	// for artifact delivery only: its MCP endpoints are rendered by its own
+	// deployment role, so it has no emitter and no MCP config file here.
+	ProviderHermes Provider = "hermes"
 )
 
 // EmitResult contains the generated config for a provider.
@@ -123,6 +127,12 @@ func EmitServer(name string, spec ServerSpec, provider Provider) (*EmitResult, e
 	if !ok {
 		return nil, fmt.Errorf("unknown provider: %s", provider)
 	}
+	if d.emit == nil {
+		// A provider whose MCP configuration Cartographer does not own (D141:
+		// hermes' endpoints are rendered by its Ansible role). Callers skip it
+		// via ManagesMCPConfig; reaching here is a bug, not a user error.
+		return nil, fmt.Errorf("provider %s has no MCP emitter: its MCP configuration is not managed by Cartographer", provider)
+	}
 	return d.emit(name, spec)
 }
 
@@ -153,6 +163,11 @@ func EmitAll(cfg *ServerConfig) ([]*EmitResult, error) {
 	providers := ProviderList()
 	results := make([]*EmitResult, 0, len(providers))
 	for _, p := range providers {
+		if !ManagesMCPConfig(p) {
+			// Nothing to emit for a provider whose MCP configuration lives
+			// outside Cartographer (D141).
+			continue
+		}
 		r, err := Emit(cfg, p)
 		if err != nil {
 			return nil, fmt.Errorf("emit %s: %w", p, err)

--- a/internal/configurator/registry.go
+++ b/internal/configurator/registry.go
@@ -1,6 +1,12 @@
 package configurator
 
-import "path/filepath"
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
 
 // This file is the single description of every supported provider (D137):
 // identity, the native MCP config file and its format, and the evidence that
@@ -54,6 +60,13 @@ type Descriptor struct {
 	// across servers, so two KBs mounted without a tool_prefix collide and
 	// only one stays reachable (D102/D144).
 	FlatToolNamespace bool
+
+	// BaseDirEnv, when set, names the environment variable holding this
+	// provider's own root directory: artifacts are materialized there
+	// instead of under the shared client base dir (D141 — Hermes' root is
+	// wherever it was deployed, typically /opt/data, not the user's home).
+	// Empty means the shared base dir, which is every other provider.
+	BaseDirEnv string
 
 	// Binary is the executable name looked up in PATH by internal/agents.
 	Binary string
@@ -109,6 +122,18 @@ var descriptors = []Descriptor{
 		emit:               emitKiroServer,
 	},
 	{
+		Provider:    ProviderHermes,
+		DisplayName: "Hermes Agent",
+		// No MCPConfigPath and no emitter on purpose (D141): Hermes' MCP
+		// endpoint list lives in a config.yaml rendered by its Ansible role
+		// and recreated on the next playbook run, so anything Cartographer
+		// wrote there would be lost. `connect hermes` registers the provider
+		// for artifact delivery and says so.
+		DeletableWhenEmpty: true,
+		BaseDirEnv:         "HERMES_HOME",
+		Binary:             "hermes",
+	},
+	{
 		Provider:           ProviderOpenCode,
 		DisplayName:        "OpenCode",
 		MCPConfigPath:      "opencode.json",
@@ -125,7 +150,7 @@ var descriptors = []Descriptor{
 // detectionOrder is the order `cartographer agents` and the TUI list agents
 // in. It differs from the registry order above and is equally user-visible:
 // both are preserved deliberately rather than unified (D137).
-var detectionOrder = []Provider{ProviderClaudeCode, ProviderOpenCode, ProviderCodex, ProviderKiro}
+var detectionOrder = []Provider{ProviderClaudeCode, ProviderOpenCode, ProviderCodex, ProviderKiro, ProviderHermes}
 
 // Providers returns every supported provider's descriptor, in registry order.
 func Providers() []Descriptor {
@@ -158,6 +183,40 @@ func Lookup(p Provider) (Descriptor, bool) {
 
 // ConfigPath returns MCPConfigPath in the local filesystem's separator form.
 func (d Descriptor) ConfigPath() string { return filepath.FromSlash(d.MCPConfigPath) }
+
+// ManagesMCPConfig reports whether `cartographer connect`/`disconnect` writes
+// this provider's MCP configuration. False only for a provider whose endpoint
+// list is owned elsewhere (D141, hermes): connect must skip it and say so,
+// rather than silently doing nothing.
+func (d Descriptor) ManagesMCPConfig() bool { return d.MCPConfigPath != "" && d.emit != nil }
+
+// ManagesMCPConfig reports the same for a provider identifier. An unknown
+// provider is not managed.
+func ManagesMCPConfig(p Provider) bool {
+	d, ok := Lookup(p)
+	return ok && d.ManagesMCPConfig()
+}
+
+// ErrBaseDirUnset is returned by ResolveBaseDir when a provider declares a
+// BaseDirEnv that is not set in the environment.
+var ErrBaseDirUnset = errors.New("provider base directory environment variable is not set")
+
+// ResolveBaseDir returns the directory this provider's artifacts are
+// materialized under: defaultDir for every provider that shares the client
+// base dir, or the value of BaseDirEnv for one that has its own root (D141).
+// An unset or empty BaseDirEnv is an error naming the variable — writing into
+// the home directory instead would scatter an agent's files somewhere it never
+// looks.
+func (d Descriptor) ResolveBaseDir(defaultDir string) (string, error) {
+	if d.BaseDirEnv == "" {
+		return defaultDir, nil
+	}
+	value := strings.TrimSpace(os.Getenv(d.BaseDirEnv))
+	if value == "" {
+		return "", fmt.Errorf("%s: $%s is unset: %w", d.Provider, d.BaseDirEnv, ErrBaseDirUnset)
+	}
+	return value, nil
+}
 
 // ProviderList returns just the provider constants, in registry order.
 func ProviderList() []Provider {

--- a/internal/configurator/registry_internal_test.go
+++ b/internal/configurator/registry_internal_test.go
@@ -4,10 +4,14 @@ package configurator
 // single source of provider identity, so a missing or duplicated one must fail
 // here rather than degrade some caller at runtime.
 
-import "testing"
+import (
+	"errors"
+	"strings"
+	"testing"
+)
 
 func TestRegistryHasOneDescriptorPerProvider(t *testing.T) {
-	want := []Provider{ProviderClaudeCode, ProviderCodex, ProviderKiro, ProviderOpenCode}
+	want := []Provider{ProviderClaudeCode, ProviderCodex, ProviderKiro, ProviderOpenCode, ProviderHermes}
 
 	if got := len(Providers()); got != len(want) {
 		t.Fatalf("Providers() has %d descriptors, want %d", got, len(want))
@@ -22,14 +26,20 @@ func TestRegistryHasOneDescriptorPerProvider(t *testing.T) {
 		if d.DisplayName == "" {
 			t.Errorf("%q: empty DisplayName", d.Provider)
 		}
-		if d.MCPConfigPath == "" {
-			t.Errorf("%q: empty MCPConfigPath", d.Provider)
-		}
-		if d.emit == nil {
-			t.Errorf("%q: no emitter", d.Provider)
-		}
-		if d.Binary == "" && len(d.ConfigDirs) == 0 {
+		if d.Binary == "" && len(d.ConfigDirs) == 0 && d.BaseDirEnv == "" {
 			t.Errorf("%q: no detection evidence at all", d.Provider)
+		}
+		// A provider whose MCP configuration Cartographer does not own (D141)
+		// declares neither a config file nor an emitter — the two must agree,
+		// or callers would emit into a path nobody writes (or vice versa).
+		if (d.MCPConfigPath == "") != (d.emit == nil) {
+			t.Errorf("%q: MCPConfigPath and emitter disagree (path=%q, emitter=%v)", d.Provider, d.MCPConfigPath, d.emit != nil)
+		}
+		if !d.ManagesMCPConfig() {
+			if d.MCPServerKey != "" {
+				t.Errorf("%q: no MCP config file but an MCP server key", d.Provider)
+			}
+			continue
 		}
 		switch d.MCPFormat {
 		case FormatJSON:
@@ -72,5 +82,63 @@ func TestClaudeConfigIsNeverDeletable(t *testing.T) {
 		if other.Provider != ProviderClaudeCode && !other.DeletableWhenEmpty {
 			t.Errorf("%q: expected an MCP-only config file, deletable when empty", other.Provider)
 		}
+	}
+}
+
+// D141: a provider with a root of its own resolves it from the environment,
+// and refuses to fall back to the shared base dir when the variable is unset —
+// materializing into the home directory would put the files where the agent
+// never looks.
+func TestResolveBaseDir(t *testing.T) {
+	shared := "/home/user"
+
+	claude, _ := Lookup(ProviderClaudeCode)
+	if got, err := claude.ResolveBaseDir(shared); err != nil || got != shared {
+		t.Errorf("claude.ResolveBaseDir = %q, %v; want %q, nil", got, err, shared)
+	}
+
+	hermes, ok := Lookup(ProviderHermes)
+	if !ok {
+		t.Fatal("no descriptor for hermes")
+	}
+	t.Setenv(hermes.BaseDirEnv, "/opt/data")
+	if got, err := hermes.ResolveBaseDir(shared); err != nil || got != "/opt/data" {
+		t.Errorf("hermes.ResolveBaseDir = %q, %v; want /opt/data, nil", got, err)
+	}
+
+	t.Setenv(hermes.BaseDirEnv, "  ")
+	_, err := hermes.ResolveBaseDir(shared)
+	if !errors.Is(err, ErrBaseDirUnset) {
+		t.Fatalf("unset base dir: got %v, want ErrBaseDirUnset", err)
+	}
+	if !strings.Contains(err.Error(), hermes.BaseDirEnv) {
+		t.Errorf("error %q does not name %s", err, hermes.BaseDirEnv)
+	}
+}
+
+// The MCP emitter must never be reached for a provider Cartographer does not
+// configure (D141): a nil emitter is a bug, not a panic.
+func TestEmitServerRejectsUnmanagedProvider(t *testing.T) {
+	if ManagesMCPConfig(ProviderHermes) {
+		t.Fatal("hermes must not be reported as an MCP-managed provider")
+	}
+	_, err := EmitServer("cartographer", ServerSpec{Type: "http", URL: "http://localhost:8080/mcp"}, ProviderHermes)
+	if err == nil {
+		t.Fatal("EmitServer(hermes) succeeded, want an error")
+	}
+
+	// EmitAll skips it instead of failing: connect must still configure every
+	// other provider.
+	results, err := EmitAll(&ServerConfig{Name: "cartographer", URL: "http://localhost:8080/mcp"})
+	if err != nil {
+		t.Fatalf("EmitAll: %v", err)
+	}
+	for _, r := range results {
+		if r.Provider == ProviderHermes {
+			t.Error("EmitAll emitted a config for hermes")
+		}
+	}
+	if want := len(Providers()) - 1; len(results) != want {
+		t.Errorf("EmitAll returned %d results, want %d", len(results), want)
 	}
 }

--- a/internal/mcpserver/docs_test.go
+++ b/internal/mcpserver/docs_test.go
@@ -55,6 +55,10 @@ var docsNonTools = map[string]bool{
 	"search_roots": true, "resolution_strategy": true, "resolution_body": true,
 	// kb_status / sync_status output fields (D145), not tools
 	"git_workflow": true, "git_profile": true, "git_sync": true,
+	// a tool of ANOTHER agent, cited where Cartographer explains what it
+	// deliberately leaves to it (D141: Hermes adopts a delivered skill with
+	// its own skill_manage)
+	"skill_manage": true,
 	// intentionally absent, documented as not implemented (D77, YAGNI)
 	"concept_collapse": true,
 }

--- a/internal/provisioning/hermes.go
+++ b/internal/provisioning/hermes.go
@@ -1,0 +1,69 @@
+package provisioning
+
+// Hermes delivery (D141). Hermes owns its own skills: a curator under
+// HERMES_HOME/skills/ archives, rewrites and pins them from its own learning
+// loop. Materializing there would put Cartographer and the curator in a
+// permanent fight, so a KB skill is DELIVERED to skill-inbox/<name>/cartographer/
+// as a proposal, with a generated SOURCE.md saying where it came from and what
+// adopting it means. The agent decides; Cartographer never installs.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/BeppeTemp/cartographer/internal/configurator"
+)
+
+// generatedArtifactFiles returns the files Cartographer adds to an artifact's
+// materialized directory beyond the KB's own — today only hermes' SOURCE.md.
+//
+// A KB skill that already ships a file with a generated name is a collision:
+// overwriting it would silently destroy KB content, and delivering both is
+// impossible. That one artifact fails with a warning naming it; the rest of
+// the sync completes, and the collision persists (nothing is recorded in the
+// lockfile) until the KB is fixed.
+func generatedArtifactFiles(a Artifact, provider configurator.Provider, files []ArtifactFile) (generated []ArtifactFile, warning string, ok bool) {
+	if provider != configurator.ProviderHermes || a.Kind != "skill" {
+		return nil, "", true
+	}
+	for _, f := range files {
+		if strings.EqualFold(strings.TrimPrefix(f.Path, "./"), hermesSourceFile) {
+			return nil, fmt.Sprintf(
+				"skill %q ships its own %s: not delivered to the hermes inbox, which generates that file (rename it in the KB)",
+				a.Name, hermesSourceFile), false
+		}
+	}
+	return []ArtifactFile{{Path: hermesSourceFile, Content: hermesSourceDoc(a)}}, "", true
+}
+
+// hermesSourceDoc renders the delivery note. Deterministic — no timestamp, no
+// manifest revision — so an unchanged skill re-delivers byte-identically and
+// the sync stays idempotent; the artifact's content hash is what distinguishes
+// a new proposal from a re-delivery.
+func hermesSourceDoc(a Artifact) []byte {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "# Cartographer delivery: %s\n\n", a.Name)
+	sb.WriteString("This directory was delivered by Cartographer. It is a **proposal**, not an installed skill:\n")
+	sb.WriteString("nothing under `$HERMES_HOME/skills/` was written, and nothing here is active.\n\n")
+
+	kb, fromKB := kbSourceName(a)
+	if fromKB {
+		fmt.Fprintf(&sb, "- Source: KB %q, path `%s`\n", kb, artifactSourcePath(a))
+	} else {
+		sb.WriteString("- Source: bundled with the Cartographer server\n")
+	}
+	fmt.Fprintf(&sb, "- Artifact content hash: `%s`\n\n", a.ContentHash)
+
+	sb.WriteString("Adopting it is `skill_manage`'s job: compare it with the skill you already have, take what is\n")
+	sb.WriteString("worth taking, then reload and verify. Cartographer re-delivers this directory in place on every\n")
+	sb.WriteString("sync — the content hash above is what tells an unchanged re-delivery from a new proposal.\n\n")
+
+	if fromKB {
+		fmt.Fprintf(&sb, "To change this skill for every client, change it in the KB: `artifact_write` on KB %q, path\n`%s`. Edits made here reach nothing else and are replaced on the next sync.\n",
+			kb, artifactSourcePath(a))
+	} else {
+		sb.WriteString("This skill ships inside the Cartographer binary: changing it for every client means changing\n")
+		sb.WriteString("the release. Edits made here reach nothing else and are replaced on the next sync.\n")
+	}
+	return []byte(sb.String())
+}

--- a/internal/provisioning/hermes_test.go
+++ b/internal/provisioning/hermes_test.go
@@ -1,0 +1,300 @@
+package provisioning
+
+// Delivery to the Hermes inbox (D141): Cartographer proposes, the agent
+// adopts. The invariant these tests guard is that nothing is ever written
+// under HERMES_HOME/skills/ — a regression there destroys the agent's own
+// curated learning, which no sync can restore.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BeppeTemp/cartographer/internal/configurator"
+)
+
+// hermesKB writes a one-skill KB and returns its root.
+func hermesKB(t *testing.T, body string) string {
+	t.Helper()
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "skills", "runbooks")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
+		[]byte("---\nname: runbooks\ndescription: d\n---\n"+body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func hermesApplyOptions(kbRoot, baseDir string, lock Lock) ApplyOptions {
+	return ApplyOptions{
+		AutoTrust: true,
+		KBRoots:   map[string]string{"kb": kbRoot},
+		Provider:  configurator.ProviderHermes,
+		BaseDir:   baseDir,
+		Lock:      lock,
+	}
+}
+
+func TestApply_HermesDeliversToInbox(t *testing.T) {
+	kbRoot := hermesKB(t, "The runbooks.\n")
+	// An agent artifact too: hermes has no subagent directory, so it must land
+	// in Unsupported rather than anywhere on disk.
+	if err := os.MkdirAll(filepath.Join(kbRoot, "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(kbRoot, "agents", "reviewer.md"), []byte("---\nname: reviewer\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, BuildOptions{})
+	if err != nil {
+		t.Fatalf("BuildManifest: %v", err)
+	}
+	baseDir := t.TempDir()
+	res, err := Apply(m, hermesApplyOptions(kbRoot, baseDir, Lock{}))
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	inbox := filepath.Join(baseDir, "skill-inbox", "runbooks", "cartographer")
+	skillMD, err := os.ReadFile(filepath.Join(inbox, "SKILL.md"))
+	if err != nil {
+		t.Fatalf("delivered SKILL.md: %v", err)
+	}
+	if !strings.Contains(string(skillMD), provenanceBlockBeginPrefix) {
+		t.Error("delivered SKILL.md carries no provenance block")
+	}
+
+	source, err := os.ReadFile(filepath.Join(inbox, hermesSourceFile))
+	if err != nil {
+		t.Fatalf("delivered SOURCE.md: %v", err)
+	}
+	var skillHash string
+	for _, a := range m.Artifacts {
+		if a.Kind == "skill" && a.Name == "runbooks" {
+			skillHash = a.ContentHash
+		}
+	}
+	for _, want := range []string{"proposal", `KB "kb"`, "skills/runbooks/SKILL.md", skillHash, "skill_manage", "artifact_write"} {
+		if !strings.Contains(string(source), want) {
+			t.Errorf("SOURCE.md does not mention %q:\n%s", want, source)
+		}
+	}
+
+	// The invariant: the agent's own skills directory is never created.
+	if _, err := os.Stat(filepath.Join(baseDir, "skills")); !os.IsNotExist(err) {
+		t.Fatalf("HERMES_HOME/skills/ must never be written: stat = %v", err)
+	}
+
+	for _, a := range res.Unsupported {
+		if a.Kind == "skill" {
+			t.Errorf("skill %q reported unsupported for hermes", a.Name)
+		}
+	}
+	unsupported := map[string]bool{}
+	for _, a := range res.Unsupported {
+		unsupported[a.Kind] = true
+	}
+	for _, kind := range []string{"agent", "instructions"} {
+		if !unsupported[kind] {
+			t.Errorf("kind %q should be unsupported for hermes, got %+v", kind, res.Unsupported)
+		}
+	}
+
+	// Both delivered files are managed, so D139 verification covers them —
+	// including the generated SOURCE.md.
+	managed := map[string]bool{}
+	for _, mf := range res.NewLock.Managed {
+		managed[filepath.Base(mf.Path)] = true
+	}
+	if !managed["SKILL.md"] || !managed[hermesSourceFile] {
+		t.Errorf("delivered files not recorded as managed: %+v", res.NewLock.Managed)
+	}
+	if f := VerifyManaged(res.NewLock, configurator.ProviderHermes, baseDir); len(f) != 0 {
+		t.Errorf("fresh delivery already reports drift: %+v", f)
+	}
+}
+
+// A second sync of an unchanged skill rewrites nothing: the delivery path
+// carries no timestamp precisely so it stays a fixed point (D141).
+func TestApply_HermesDeliveryIsIdempotent(t *testing.T) {
+	kbRoot := hermesKB(t, "The runbooks.\n")
+	m, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, BuildOptions{})
+	if err != nil {
+		t.Fatalf("BuildManifest: %v", err)
+	}
+	baseDir := t.TempDir()
+	first, err := Apply(m, hermesApplyOptions(kbRoot, baseDir, Lock{}))
+	if err != nil {
+		t.Fatalf("Apply 1: %v", err)
+	}
+	inbox := filepath.Join(baseDir, "skill-inbox", "runbooks", "cartographer")
+	before, err := os.ReadFile(filepath.Join(inbox, hermesSourceFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Compare only what hermes can materialize: an unsupported kind is not
+	// drift, it simply does not concern the provider.
+	if d := ComputeDiff(FilterForProvider(m, configurator.ProviderHermes), first.NewLock); !d.InSync {
+		t.Errorf("re-sync of an unchanged manifest is not in sync: %+v", d)
+	}
+	second, err := Apply(m, hermesApplyOptions(kbRoot, baseDir, first.NewLock))
+	if err != nil {
+		t.Fatalf("Apply 2: %v", err)
+	}
+	after, err := os.ReadFile(filepath.Join(inbox, hermesSourceFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Errorf("SOURCE.md changed on an unchanged re-delivery:\n--- before\n%s\n--- after\n%s", before, after)
+	}
+	if len(second.Written) != 0 {
+		t.Errorf("unchanged re-sync rewrote %d files: %+v", len(second.Written), second.Written)
+	}
+
+	// A changed skill re-delivers with the new hash: that is what tells the
+	// curator a new proposal from a re-delivery.
+	if err := os.WriteFile(filepath.Join(kbRoot, "skills", "runbooks", "SKILL.md"),
+		[]byte("---\nname: runbooks\ndescription: d\n---\nRewritten.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m2, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, BuildOptions{})
+	if err != nil {
+		t.Fatalf("BuildManifest 2: %v", err)
+	}
+	if _, err := Apply(m2, hermesApplyOptions(kbRoot, baseDir, first.NewLock)); err != nil {
+		t.Fatalf("Apply 3: %v", err)
+	}
+	updated, err := os.ReadFile(filepath.Join(inbox, hermesSourceFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(updated) == string(before) {
+		t.Error("SOURCE.md unchanged after the skill changed: the content hash must follow it")
+	}
+	body, err := os.ReadFile(filepath.Join(inbox, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "Rewritten.") {
+		t.Error("changed skill not re-delivered")
+	}
+}
+
+// Removing the skill from the KB prunes exactly its delivery: the inbox root
+// is shared with other proposers and never removed.
+func TestApply_HermesPruneStopsAtInboxRoot(t *testing.T) {
+	kbRoot := hermesKB(t, "The runbooks.\n")
+	m, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, BuildOptions{})
+	if err != nil {
+		t.Fatalf("BuildManifest: %v", err)
+	}
+	baseDir := t.TempDir()
+	first, err := Apply(m, hermesApplyOptions(kbRoot, baseDir, Lock{}))
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// Another proposer's delivery, which the prune must not touch.
+	other := filepath.Join(baseDir, "skill-inbox", "elsewhere")
+	if err := os.MkdirAll(other, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.RemoveAll(filepath.Join(kbRoot, "skills", "runbooks")); err != nil {
+		t.Fatal(err)
+	}
+	empty, err := BuildManifest(nil, map[string]string{"kb": kbRoot}, BuildOptions{})
+	if err != nil {
+		t.Fatalf("BuildManifest 2: %v", err)
+	}
+	if _, err := Apply(empty, hermesApplyOptions(kbRoot, baseDir, first.NewLock)); err != nil {
+		t.Fatalf("Apply 2: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(baseDir, "skill-inbox", "runbooks")); !os.IsNotExist(err) {
+		t.Errorf("the delivered skill's inbox directory survived the prune: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(baseDir, "skill-inbox")); err != nil {
+		t.Errorf("the inbox root must never be removed: %v", err)
+	}
+	if _, err := os.Stat(other); err != nil {
+		t.Errorf("another proposer's delivery was removed: %v", err)
+	}
+}
+
+// A KB skill that ships its own SOURCE.md would be silently overwritten by the
+// generated one: that single artifact fails with a warning naming it, and the
+// rest of the sync completes.
+func TestApply_HermesSourceFileCollision(t *testing.T) {
+	baseDir := t.TempDir()
+	m := Manifest{
+		Revision: "r1",
+		Artifacts: []Artifact{
+			{
+				Kind: "skill", Name: "runbooks", Source: "kb:kb", ContentHash: "h1",
+				Files: []ArtifactFile{
+					{Path: "SKILL.md", Content: []byte("---\nname: runbooks\n---\nbody\n")},
+					{Path: hermesSourceFile, Content: []byte("mine\n")},
+				},
+			},
+			{
+				Kind: "skill", Name: "other", Source: "kb:kb", ContentHash: "h2",
+				Files: []ArtifactFile{{Path: "SKILL.md", Content: []byte("---\nname: other\n---\nbody\n")}},
+			},
+		},
+	}
+	res, err := Apply(m, hermesApplyOptions(t.TempDir(), baseDir, Lock{}))
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	found := false
+	for _, w := range res.Warnings {
+		if strings.Contains(w, "runbooks") && strings.Contains(w, hermesSourceFile) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no warning naming the colliding skill: %+v", res.Warnings)
+	}
+	if _, err := os.Stat(filepath.Join(baseDir, "skill-inbox", "runbooks")); !os.IsNotExist(err) {
+		t.Errorf("the colliding skill was delivered anyway: %v", err)
+	}
+	for _, mf := range res.NewLock.Managed {
+		if mf.Name == "runbooks" {
+			t.Errorf("the colliding skill was recorded as managed: %+v", mf)
+		}
+	}
+	// The other skill in the same sync is delivered normally.
+	if _, err := os.Stat(filepath.Join(baseDir, "skill-inbox", "other", "cartographer", "SKILL.md")); err != nil {
+		t.Errorf("the rest of the sync did not complete: %v", err)
+	}
+}
+
+// LockBaseDir is what every prune/verify call site must go through: a Lock
+// that records its own base dir wins over the lockfile's directory (D141).
+func TestLockBaseDir(t *testing.T) {
+	if got := LockBaseDir(Lock{}, "/home/user"); got != "/home/user" {
+		t.Errorf("LockBaseDir(no base dir) = %q, want the default", got)
+	}
+	if got := LockBaseDir(Lock{BaseDir: "/opt/data"}, "/home/user"); got != "/opt/data" {
+		t.Errorf("LockBaseDir(recorded) = %q, want /opt/data", got)
+	}
+}
+
+func TestBaseDirFor(t *testing.T) {
+	if got, err := BaseDirFor(configurator.ProviderClaudeCode, "/home/user"); err != nil || got != "/home/user" {
+		t.Errorf("BaseDirFor(claude) = %q, %v", got, err)
+	}
+	t.Setenv("HERMES_HOME", "/opt/data")
+	if got, err := BaseDirFor(configurator.ProviderHermes, "/home/user"); err != nil || got != "/opt/data" {
+		t.Errorf("BaseDirFor(hermes) = %q, %v", got, err)
+	}
+}

--- a/internal/provisioning/provisioning.go
+++ b/internal/provisioning/provisioning.go
@@ -110,6 +110,36 @@ type Lock struct {
 	AppliedRevision string        `json:"applied_revision"`
 	Provider        string        `json:"provider"`
 	Managed         []ManagedFile `json:"managed"`
+	// BaseDir is the directory the Path of every ManagedFile above is
+	// relative to, recorded only for a provider that materializes outside the
+	// shared client base dir (D141, hermes under $HERMES_HOME). Empty — every
+	// lockfile written before D141, and every other provider — means "the
+	// lockfile's own directory", so nothing migrates. Read it through
+	// LockBaseDir, never directly: pruning or verifying against the wrong base
+	// dir deletes the wrong files or silently finds nothing.
+	BaseDir string `json:"base_dir,omitempty"`
+}
+
+// LockBaseDir returns the directory lock's managed paths are relative to:
+// lock.BaseDir when the provider has its own root (D141), defaultDir — the
+// directory holding the lockfile — otherwise.
+func LockBaseDir(lock Lock, defaultDir string) string {
+	if lock.BaseDir != "" {
+		return lock.BaseDir
+	}
+	return defaultDir
+}
+
+// BaseDirFor returns the directory provider materializes its artifacts under,
+// given the shared client base dir. It is the registry descriptor's
+// ResolveBaseDir (D141): every provider but hermes returns defaultDir
+// unchanged, and hermes fails naming $HERMES_HOME when it is unset.
+func BaseDirFor(provider configurator.Provider, defaultDir string) (string, error) {
+	d, ok := configurator.Lookup(provider)
+	if !ok {
+		return defaultDir, nil
+	}
+	return d.ResolveBaseDir(defaultDir)
 }
 
 // Diff is the result of comparing Manifest ↔ Lock.
@@ -1713,6 +1743,10 @@ var provisioningRootDirs = map[string]bool{
 	".opencode":                          true,
 	".config":                            true,
 	filepath.Join(".config", "opencode"): true,
+	// The hermes inbox root (D141): pruning the last delivered skill empties
+	// skill-inbox/<name>/cartographer and skill-inbox/<name>, never
+	// skill-inbox itself — other sources deliver there too.
+	hermesInboxRoot: true,
 }
 
 // pruneEmptyDirs removes every directory left empty by the removal of the file at
@@ -1860,6 +1894,11 @@ type destination struct {
 	// path — one shared file for every artifact of that kind.
 	named  bool
 	suffix string
+	// tail are extra segments appended AFTER the artifact name, for a
+	// destination that nests the artifact's files one level deeper (D141:
+	// skill-inbox/<name>/cartographer/, whose last segment names the
+	// proposer so a second source never collides with Cartographer's).
+	tail []string
 	// unsupported marks a combination this provider cannot represent.
 	unsupported bool
 }
@@ -1868,6 +1907,12 @@ func at(segments ...string) destination { return destination{dir: segments} }
 
 func perName(suffix string, segments ...string) destination {
 	return destination{dir: segments, named: true, suffix: suffix}
+}
+
+// perNameIn is perName with extra segments below the artifact's own
+// directory: dir/<name>/tail... .
+func perNameIn(tail []string, segments ...string) destination {
+	return destination{dir: segments, named: true, tail: tail}
 }
 
 var unsupportedDest = destination{unsupported: true}
@@ -1885,24 +1930,35 @@ var unsupportedDest = destination{unsupported: true}
 //     "agent" cells are a single file, written directly by Apply.
 //   - kiro has no known native subagent directory and no native hook
 //     mechanism, hence the two unsupported cells.
+//   - hermes supports exactly one kind, "skill", and delivers it to an inbox
+//     for the agent to adopt rather than installing it (D141). Its four other
+//     cells are unsupported for stated reasons, not by omission.
 var destinationMatrix = map[string]map[configurator.Provider]destination{
 	"mcp": {
 		configurator.ProviderClaudeCode: at(".claude.json"),
 		configurator.ProviderCodex:      at(".codex", "config.toml"),
 		configurator.ProviderOpenCode:   at("opencode.json"),
 		configurator.ProviderKiro:       at(".kiro", "settings", "mcp.json"),
+		// hermes: config.yaml is rendered by its Ansible role and recreated on
+		// the next playbook run (D141).
+		configurator.ProviderHermes: unsupportedDest,
 	},
 	"instructions": {
 		configurator.ProviderClaudeCode: at(".claude", "CLAUDE.md"),
 		configurator.ProviderOpenCode:   at(".config", "opencode", "AGENTS.md"),
 		configurator.ProviderCodex:      at(".codex", "AGENTS.md"),
 		configurator.ProviderKiro:       at(".kiro", "steering", "cartographer.md"),
+		// hermes: SOUL.md, its always-on instruction slot, is operator-owned
+		// and rendered from a template (D141).
+		configurator.ProviderHermes: unsupportedDest,
 	},
 	"agent": {
 		configurator.ProviderClaudeCode: perName(".md", ".claude", "agents"),
 		configurator.ProviderOpenCode:   perName(".md", ".opencode", "agent"),
 		configurator.ProviderCodex:      perName(".toml", ".codex", "agents"),
 		configurator.ProviderKiro:       unsupportedDest,
+		// hermes: no native subagent directory (D141).
+		configurator.ProviderHermes: unsupportedDest,
 	},
 	"hook": {
 		configurator.ProviderClaudeCode: perName("", ".claude", "hooks"),
@@ -1912,14 +1968,36 @@ var destinationMatrix = map[string]map[configurator.Provider]destination{
 		// registerOpenCodePlugin) in .config/opencode/plugins/, not here.
 		configurator.ProviderOpenCode: perName("", ".opencode", "hooks"),
 		configurator.ProviderKiro:     unsupportedDest,
+		// hermes: no hook mechanism at all — nothing fires at conversation
+		// start, so its trigger is the scheduled timer (D140/D141).
+		configurator.ProviderHermes: unsupportedDest,
 	},
 	"skill": {
 		configurator.ProviderClaudeCode: perName("", ".claude", "skills"),
 		configurator.ProviderCodex:      perName("", ".codex", "skills"),
 		configurator.ProviderKiro:       perName("", ".kiro", "skills"),
 		configurator.ProviderOpenCode:   perName("", ".opencode", "skills"),
+		// hermes: DELIVERED, not installed (D141). HERMES_HOME/skills/ belongs
+		// to the agent's own curator, which rewrites what it owns; writing
+		// there would destroy its learning. The proposal lands in the inbox
+		// with a generated SOURCE.md and the agent adopts it via skill_manage.
+		configurator.ProviderHermes: perNameIn([]string{hermesInboxSource}, hermesInboxRoot),
 	},
 }
+
+// The hermes inbox (D141): <HERMES_HOME>/skill-inbox/<name>/cartographer/.
+// The last segment names the proposer, so a proposal from another source never
+// collides with Cartographer's. Deliberately without the timestamp the
+// skill-inbox convention allows: provisioning must be idempotent, and one
+// directory per sync would accumulate a copy every timer tick with no way to
+// tell stale from current. SOURCE.md carries the content hash instead, so the
+// agent can tell an unchanged re-delivery from a new proposal.
+const (
+	hermesInboxRoot   = "skill-inbox"
+	hermesInboxSource = "cartographer"
+	// hermesSourceFile is generated by Cartographer, never taken from the KB.
+	hermesSourceFile = "SOURCE.md"
+)
 
 // artifactKinds are the kinds the matrix must cover. A manifest built by a
 // newer server may carry a kind absent from this list; destDir returns "" for
@@ -1957,7 +2035,8 @@ func destDir(kind, name string, provider configurator.Provider) string {
 	if !cell.named {
 		return filepath.Join(cell.dir...)
 	}
-	return filepath.Join(append(append([]string{}, cell.dir...), name+cell.suffix)...)
+	segments := append(append([]string{}, cell.dir...), name+cell.suffix)
+	return filepath.Join(append(segments, cell.tail...)...)
 }
 
 // translateAgentForProvider adapts an "agent" artifact's content (a Claude Code
@@ -2115,6 +2194,24 @@ func copyArtifactFiles(a Artifact, opts ApplyOptions, fullDestDir string, tracke
 			return nil, "", "", err
 		}
 	}
+
+	// Files Cartographer generates on top of the KB's own (D141, hermes'
+	// SOURCE.md). A collision with a KB file of the same name fails this one
+	// artifact — with a warning, before anything is written — and leaves the
+	// rest of the sync to complete.
+	generated, collision, ok := generatedArtifactFiles(a, opts.Provider, files)
+	if !ok {
+		// The caller created fullDestDir just before this call: remove it
+		// again so a refused delivery leaves no empty directory that looks
+		// like one. os.Remove refuses a non-empty directory, so an earlier
+		// successful delivery survives untouched.
+		_ = os.Remove(fullDestDir)
+		if rel, relErr := filepath.Rel(opts.BaseDir, fullDestDir); relErr == nil {
+			pruneEmptyDirs(opts.BaseDir, rel)
+		}
+		return nil, "", collision, nil
+	}
+	files = append(append([]ArtifactFile{}, files...), generated...)
 
 	expanded := make([]ArtifactFile, 0, len(files))
 	// Only a skill's principal file carries the provenance block; every other

--- a/internal/provisioning/registry_test.go
+++ b/internal/provisioning/registry_test.go
@@ -78,10 +78,16 @@ func TestDestDirPaths(t *testing.T) {
 		{"skill", configurator.ProviderCodex, filepath.Join(".codex", "skills", "demo")},
 		{"skill", configurator.ProviderKiro, filepath.Join(".kiro", "skills", "demo")},
 		{"skill", configurator.ProviderOpenCode, filepath.Join(".opencode", "skills", "demo")},
+		// hermes delivers skills to its inbox and supports nothing else (D141).
+		{"skill", configurator.ProviderHermes, filepath.Join("skill-inbox", "demo", "cartographer")},
+		{"agent", configurator.ProviderHermes, ""},
+		{"hook", configurator.ProviderHermes, ""},
+		{"mcp", configurator.ProviderHermes, ""},
+		{"instructions", configurator.ProviderHermes, ""},
 		// A kind or provider this binary does not know is not materializable:
 		// a manifest from a newer server must not land somewhere arbitrary.
 		{"newkind", configurator.ProviderClaudeCode, ""},
-		{"skill", configurator.Provider("hermes"), ""},
+		{"skill", configurator.Provider("nope"), ""},
 	}
 	for _, tc := range cases {
 		if got := destDir(tc.kind, "demo", tc.provider); got != tc.want {


### PR DESCRIPTION
Hermes talks to a Cartographer server over MCP but was invisible to provisioning: not in `configurator.Provider`, not in `agents.Detect`, no cell in the kind × provider matrix. A KB skill published through `artifact_write` reached Claude Code, Codex and OpenCode automatically and never reached Hermes at all.

## Delivery, not installation

`$HERMES_HOME/skills/` belongs to the agent's own curator, which archives, pins and rewrites what it owns from its learning loop. Materializing there would put Cartographer and the curator in a permanent fight, and the loser is the agent's accumulated learning. So a KB skill is **delivered** to `$HERMES_HOME/skill-inbox/<name>/cartographer/` — the files, provenance-stamped as everywhere else (D138), plus a generated `SOURCE.md` naming the source KB, the artifact path, its content hash and the fact that adopting it is `skill_manage`'s decision. **Nothing is ever written under `skills/`**, and a test guards it.

The delivery path carries **no timestamp**, deliberately departing from the `skill-inbox/<skill>/<timestamp>/` convention: provisioning must be idempotent, and one directory per sync would accumulate a copy on every timer tick with no way to tell stale from current. One stable directory per (skill, source), updated in place; the content hash in `SOURCE.md` is what distinguishes an unchanged re-delivery from a new proposal.

## The four unsupported cells

Each with a stated reason, not by omission: `agent` — no native subagent directory; `hook` — no hook mechanism at all; `mcp` — `config.yaml` is rendered by its Ansible role; `instructions` — `SOUL.md` is operator-owned. The last two would be destroyed by the next playbook run. `connect hermes` therefore writes no MCP entry **and says so** — silently doing nothing would read as a bug. Its trigger is the scheduled timer from D140.

## Per-provider base directories (WP1)

`Lock` gains an optional `base_dir` recording the directory its `ManagedFile` paths are relative to. Empty — every existing lockfile, every other provider — means "the lockfile's own directory", so no migration runs and nothing changes meaning. `materializeForProviders` resolves the base dir per provider; prune and D139's on-disk verification read it through `LockBaseDir`. The lockfile stays a **single v2 file** in the client's target dir. `$HERMES_HOME` unset fails `connect hermes` naming the variable, before anything is written.

## Tests

Delivery + `SOURCE.md` content + the `skills/` invariant; idempotence across two syncs and hash propagation on a changed skill; prune stopping at the shared `skill-inbox/` root and sparing another proposer's delivery; the `SOURCE.md` collision failing one artifact with a warning while the rest of the sync completes; two-provider materialization into two trees with one lockfile; detection via `$HERMES_HOME`; `connect`/`disconnect` round trip writing no MCP config.

`make vet && make test && make e2e` green (12/12 scenarios).

Closes #139