### PR TITLE
docs(sync): settle Kiro's session-hook question with an installed CLI (D140 WP2)

### DIFF
--- a/docs/decisions/sync-provisioning.md
+++ b/docs/decisions/sync-provisioning.md
@@ -609,31 +609,42 @@ someone else's file.
 ---
 
 <a id="d140"></a>
-## D140 — A scheduled sync trigger for clients with no session hook; Kiro's hook deferred
+## D140 — A scheduled sync trigger for clients with no session hook; Kiro has no registrable one
 
-**WP1 finding (checked 2026-08-27, no Kiro installation available on the machine).** Three facts,
-from Kiro's own documentation:
+**WP1 finding (documentation only, 2026-08-27 — no Kiro installation available at the time).** The
+docs were self-contradictory: the trigger table (<https://kiro.dev/docs/hooks/types/>) named a
+CLI-only `agentSpawn` trigger, while the only complete JSON examples on the feature page
+(<https://kiro.dev/docs/hooks/>) used `"trigger": "PostFileSave"` and `"trigger": "Stop"` for
+triggers that table calls `fileSave` and `agentStop`. The literal value a spawn hook must carry was
+therefore not determinable, and WP2 was deferred rather than implemented on a guess.
 
-1. **User-level hooks exist.** The CLI 2.13 changelog (<https://kiro.dev/changelog/cli/2-13/>)
-   states: "Hooks placed in `~/.kiro/hooks/` now fire in every workspace automatically". The
-   feature page (<https://kiro.dev/docs/hooks/>) still documents only `.kiro/hooks/` in the project
-   root, so the two sources disagree on scope.
-2. **A spawn trigger exists and is CLI-only.** The trigger table
-   (<https://kiro.dev/docs/hooks/types/>) lists `agentSpawn` as available on the CLI and not in the
-   IDE, described as firing when the agent is first activated.
-3. **The literal trigger values in a hook file do not match that table.** The only complete JSON
-   examples on the feature page use `"trigger": "PostFileSave"` and `"trigger": "Stop"` — while the
-   table names those same triggers `fileSave` and `agentStop`. The exact string a spawn hook must
-   carry is therefore **not determinable from the documentation**, and no installation was
-   available to confirm it empirically.
+**WP1 confirmed empirically (Kiro CLI 2.20.0, installed 2026-08-27).** Three facts, each verified
+against the binary rather than the documentation:
 
-**Decision.** WP2 (the Kiro session-start hook) is **not implemented**. `hook` × `kiro` stays
-`unsupported` in the destination matrix. Writing a file into another tool's configuration
-directory with a guessed trigger value produces a hook that is silently ignored — the exact
-failure WP1 exists to prevent — and "silently ignored" is indistinguishable from "working" until a
-user notices their KB skills are months stale. Implementing it needs one confirmation: the literal
-`trigger` value a spawn hook carries, and that `~/.kiro/hooks/` is honoured by the CLI surface
-where that trigger fires.
+1. **The trigger set is exactly `agentSpawn`, `userPromptSubmit`, `preToolUse`, `postToolUse`,
+   `stop`** — the serde variant table in `kiro-cli-chat`, confirmed by `kiro-cli-chat agent
+   validate`, which accepts those five and rejects `AgentSpawn`, `Spawn`, `SessionStart`,
+   `sessionStart`, `agentStop` and `fileSave`. The documented `PostFileSave`/`Stop` examples are
+   simply wrong for the CLI; the camelCase table is right.
+2. **`~/.kiro/hooks/` plays no role.** It appears nowhere in the CLI's path table. Hooks are a
+   `hooks` map **inside an agent config** — `~/.kiro/agents/<name>.json` globally, or
+   `<workspace>/.kiro/agents/<name>.json` — each entry an object with a `command`. A global agent
+   config is discovered from any working directory, and its `agentSpawn` hook does fire (verified
+   with a sentinel file: "1 of 1 hooks finished").
+3. **Hooks are per agent, and the agent that runs by default cannot carry one.** The hook fires
+   only for the agent selected with `--agent`; running the default agent does not fire it. The
+   built-in `kiro_default` cannot be shadowed by a global config of the same name (it stays
+   `(Built-in)` and its hook never runs), and `~/.kiro/settings/cli.json` has no global hooks key —
+   only display settings such as `hooks.showStatus`.
+
+**Decision.** WP2 (the Kiro session-start hook) is **not implemented**, and this is now settled
+rather than pending. `hook` × `kiro` stays `unsupported` in the destination matrix. The mechanism
+the plan assumed — a hook file in a directory Cartographer owns — does not exist; the mechanism
+that does exist cannot deliver an unconditional session-start hook, because the only way to reach
+the agent the user actually runs is to write into an agent configuration Cartographer does not own.
+Claiming a user's agent config to install a sync hook is a larger intrusion than the problem
+warrants, and a Cartographer-owned agent nobody selects is a hook that never fires — the same
+silent failure the deferral existed to prevent.
 
 **Decision.** The scheduled trigger is implemented and is a first-class Layer 1 alternative:
 `cartographer service sync-timer install|uninstall|status`, with `--interval` (default 30 minutes),
@@ -647,8 +658,8 @@ a side effect of connecting is out of proportion. It runs `cartographer sync` **
 succeeds.
 
 **Rationale.** Kiro was the one supported provider syncing only when a human remembered to, and
-D141's Hermes will be a second by design — its configuration is owned by an Ansible role, with no
-place to register a hook. Both need the same thing: a trigger that does not depend on the client
-having hooks. The timer serves them today and keeps serving Kiro's IDE surface even after the CLI
-hook lands, since `agentSpawn` is CLI-only.
+D141's Hermes is a second by design — its configuration is owned by an Ansible role, with no place
+to register a hook. Both need the same thing: a trigger that does not depend on the client having
+hooks. For Kiro the timer is not a fallback but the answer: `agentSpawn` is CLI-only and would
+never have covered the IDE surface anyway, and it fires per agent rather than per machine.
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -53,7 +53,7 @@ Hook **`cartographer-bootstrap`** (reserved name, `provisioning.BootstrapHookNam
 | claude | `SessionStart` | entry in `~/.claude/settings.json` |
 | codex | `[[hooks.SessionStart]]` | managed block in `~/.codex/config.toml` |
 | opencode | `session.created` event | generated plugin in `~/.config/opencode/plugins/` |
-| kiro | — (not registrable from a user-level install, see [D140](decisions/sync-provisioning.md#d140)) | falls back to the scheduled trigger below, or Layer 2 |
+| kiro | — (its hooks are declared per agent, not per machine, so none fires for the agent the user runs — see [D140](decisions/sync-provisioning.md#d140)) | the scheduled trigger below, or Layer 2 |
 
 **Scheduled trigger (D140).** For a client with no session hook, `cartographer service sync-timer
 install [--interval 30m]` registers a launchd agent (macOS) or a systemd user timer (Linux) that

--- a/internal/provisioning/provisioning.go
+++ b/internal/provisioning/provisioning.go
@@ -1934,8 +1934,9 @@ var unsupportedDest = destination{unsupported: true}
 //     (applyInstructionsGroup).
 //   - "skill"/"hook" cells are directories materialized by copyArtifactFiles;
 //     "agent" cells are a single file, written directly by Apply.
-//   - kiro has no known native subagent directory and no native hook
-//     mechanism, hence the two unsupported cells.
+//   - kiro has no known native subagent directory, and its hooks are declared
+//     per agent rather than per machine (D140), so neither cell is
+//     materializable — hence the two unsupported ones.
 //   - hermes supports exactly one kind, "skill", and delivers it to an inbox
 //     for the agent to adopt rather than installing it (D141). Its four other
 //     cells are unsupported for stated reasons, not by omission.
@@ -1973,7 +1974,12 @@ var destinationMatrix = map[string]map[configurator.Provider]destination{
 		// the JS plugin that invokes them (D59) is generated elsewhere (Apply,
 		// registerOpenCodePlugin) in .config/opencode/plugins/, not here.
 		configurator.ProviderOpenCode: perName("", ".opencode", "hooks"),
-		configurator.ProviderKiro:     unsupportedDest,
+		// kiro: hooks are a `hooks` map inside an AGENT config
+		// (~/.kiro/agents/<name>.json), not files in a directory of their own,
+		// and they fire only for the agent that declares them — so no hook
+		// Cartographer owns can fire for the agent the user actually runs
+		// (D140). Its trigger is the scheduled timer.
+		configurator.ProviderKiro: unsupportedDest,
 		// hermes: no hook mechanism at all — nothing fires at conversation
 		// start, so its trigger is the scheduled timer (D140/D141).
 		configurator.ProviderHermes: unsupportedDest,


### PR DESCRIPTION
D140 deferred the Kiro session-start hook on one unanswered question: the literal value a spawn hook's `trigger` field must carry. Kiro's own docs contradicted themselves — the trigger table named `agentSpawn`/`fileSave`/`agentStop` while the only complete JSON examples used `"PostFileSave"` and `"Stop"` — and no installation was available to settle it. Kiro CLI **2.20.0** is now installed, so the question is answered against the binary rather than the documentation.

## What the trigger literal is

`agentSpawn`. The full set is exactly `agentSpawn`, `userPromptSubmit`, `preToolUse`, `postToolUse`, `stop` — the serde variant table inside `kiro-cli-chat`, confirmed by `kiro-cli-chat agent validate`, which accepts those five and rejects `AgentSpawn`, `Spawn`, `SessionStart`, `sessionStart`, `agentStop` and `fileSave`. The documented `PostFileSave`/`Stop` examples are simply wrong for the CLI.

## Why the hook still cannot be registered

The location the plan assumed **does not exist**. `~/.kiro/hooks/` appears nowhere in the CLI's path table. Hooks are a `hooks` map **inside an agent config** — `~/.kiro/agents/<name>.json` globally, or `<workspace>/.kiro/agents/<name>.json` — each entry an object carrying a `command`.

Verified empirically with a sentinel file:

- a global agent config **is** discovered from any working directory, and its `agentSpawn` hook **does** fire when that agent is selected (`✓ 1 of 1 hooks finished`);
- running the **default** agent fires nothing;
- the built-in `kiro_default` **cannot** be shadowed by a global config of the same name — it stays `(Built-in)` and the hook never runs;
- `~/.kiro/settings/cli.json` has no global hooks key, only display settings like `hooks.showStatus`.

So hooks are per agent, and there is no agent Cartographer can attach one to that the user actually runs.

## Outcome

`hook` × `kiro` stays `unsupported`, now for a **settled structural reason rather than a pending unknown**. Reaching the agent the user runs would mean writing into an agent configuration Cartographer does not own — a larger intrusion than the problem warrants — and a Cartographer-owned agent nobody selects is a hook that never fires, which is the same silent failure the deferral existed to prevent.

The scheduled timer shipped in D140 is therefore not a fallback for Kiro but the answer: `agentSpawn` is CLI-only and would never have covered Kiro's IDE surface, and it fires per agent rather than per machine.

Documentation only — the D140 record, the Layer 1 table in `docs/sync.md`, and the two matrix comments. No behaviour change; `make vet && make test` green.

Closes #153