### PR TITLE
fix(agents): detect Kiro from its standalone CLI binary

### DIFF
--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -35,7 +35,8 @@ errors. `service status` retains 0 running, 3 stopped and 4 not installed.
 ### `cartographer agents`
 
 Lists the supported providers, whether they are installed on the machine (`internal/agents.Detect`:
-binary in PATH, a known config directory, or — for a provider with a root of its own — that root,
+any of its binaries in PATH (Kiro ships as `kiro` from the IDE and `kiro-cli` standalone), a known
+config directory, or — for a provider with a root of its own — that root,
 `$HERMES_HOME`) and whether they are connected (present in the machine-wide `.cartographer.yaml`,
 `~/.cartographer.yaml`).
 

--- a/docs/decisions/client-configurator.md
+++ b/docs/decisions/client-configurator.md
@@ -358,8 +358,9 @@ pending an actual reproduction.
 `Descriptor` per provider with its constant and wire value, display name, native MCP config file
 and format (JSON with its server key, or a marker-delimited TOML block), whether that file may be
 deleted once emptied, whether it can carry MCP auth headers, whether its tool namespace is flat
-across servers, its detection evidence (binary, config directories in probe order, optional macOS
-app bundle), and its emitter. `internal/provisioning` owns the **kind × provider destination
+across servers, its detection evidence (executable names in probe order — a provider may ship its
+IDE and CLI surfaces under different ones, as Kiro does with `kiro` and `kiro-cli` — config
+directories in probe order, optional macOS app bundle), and its emitter. `internal/provisioning` owns the **kind × provider destination
 matrix** plus the `hookMechanisms` table describing how each provider registers a hook natively.
 Two orders are exported and both preserved because both are user-visible: `Providers()` (emission
 and client iteration) and `DetectionOrder()` (`cartographer agents` and the TUI).

--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -41,7 +41,7 @@ func dirExists(path string) bool {
 // Detect probes the local machine for every supported provider, in the
 // registry's detection order (D137: identity and detection evidence live in
 // internal/configurator's descriptors, not in per-provider functions here).
-// An agent is Installed if at least one heuristic matches: its binary in PATH,
+// An agent is Installed if at least one heuristic matches: any of its binaries in PATH,
 // then its config directories in descriptor order, then its own root directory
 // if it declares one (D141), then — on darwin only — its application bundle.
 func Detect() []Agent {
@@ -55,8 +55,8 @@ func Detect() []Agent {
 
 func detect(d configurator.Descriptor, home string) Agent {
 	a := Agent{Provider: d.Provider, Name: d.DisplayName}
-	if d.Binary != "" {
-		if path, err := lookPath(d.Binary); err == nil {
+	for _, binary := range d.Binaries {
+		if path, err := lookPath(binary); err == nil {
 			a.Installed, a.Evidence = true, path
 			return a
 		}

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -155,3 +155,24 @@ func TestDetect_ProviderRootDir(t *testing.T) {
 		}
 	}
 }
+
+// A provider whose surfaces ship under different executable names is detected
+// from any of them: Kiro's IDE installs `kiro`, its standalone CLI installs
+// `kiro-cli`, and either is the same provider.
+func TestDetect_AlternateBinaryName(t *testing.T) {
+	home := t.TempDir()
+	withStubs(t, home, map[string]string{"kiro-cli": "/opt/homebrew/bin/kiro-cli"}, "linux")
+
+	for _, a := range Detect() {
+		switch a.Provider {
+		case configurator.ProviderKiro:
+			if !a.Installed || a.Evidence != "/opt/homebrew/bin/kiro-cli" {
+				t.Errorf("kiro: expected detection from kiro-cli, got %+v", a)
+			}
+		default:
+			if a.Installed {
+				t.Errorf("%s: expected not installed, got %+v", a.Name, a)
+			}
+		}
+	}
+}

--- a/internal/configurator/registry.go
+++ b/internal/configurator/registry.go
@@ -68,8 +68,12 @@ type Descriptor struct {
 	// Empty means the shared base dir, which is every other provider.
 	BaseDirEnv string
 
-	// Binary is the executable name looked up in PATH by internal/agents.
-	Binary string
+	// Binaries are the executable names looked up in PATH by internal/agents,
+	// probed in this order. More than one because a provider can ship its
+	// surfaces under different names: Kiro's IDE installs `kiro` while its
+	// standalone CLI installs `kiro-cli`, and either is evidence that the
+	// provider is on this machine.
+	Binaries []string
 	// ConfigDirs are directories relative to the user's home, probed in this
 	// order when the binary is absent.
 	ConfigDirs [][]string
@@ -93,7 +97,7 @@ var descriptors = []Descriptor{
 		MCPServerKey:       "mcpServers",
 		DeletableWhenEmpty: false,
 		SupportsMCPHeaders: true,
-		Binary:             "claude",
+		Binaries:           []string{"claude"},
 		ConfigDirs:         [][]string{{".claude"}},
 		emit:               emitClaudeCodeServer,
 	},
@@ -104,7 +108,7 @@ var descriptors = []Descriptor{
 		MCPFormat:          FormatTOMLBlock,
 		DeletableWhenEmpty: true,
 		SupportsMCPHeaders: true,
-		Binary:             "codex",
+		Binaries:           []string{"codex"},
 		ConfigDirs:         [][]string{{".codex"}},
 		emit:               emitCodexServer,
 	},
@@ -116,10 +120,12 @@ var descriptors = []Descriptor{
 		MCPServerKey:       "mcpServers",
 		DeletableWhenEmpty: true,
 		FlatToolNamespace:  true,
-		Binary:             "kiro",
-		ConfigDirs:         [][]string{{".kiro"}},
-		DarwinAppDir:       "/Applications/Kiro.app",
-		emit:               emitKiroServer,
+		// The IDE installs `kiro`, the standalone CLI installs `kiro-cli`
+		// (verified on 2.20.0): both are the same provider.
+		Binaries:     []string{"kiro", "kiro-cli"},
+		ConfigDirs:   [][]string{{".kiro"}},
+		DarwinAppDir: "/Applications/Kiro.app",
+		emit:         emitKiroServer,
 	},
 	{
 		Provider:    ProviderHermes,
@@ -131,7 +137,7 @@ var descriptors = []Descriptor{
 		// for artifact delivery and says so.
 		DeletableWhenEmpty: true,
 		BaseDirEnv:         "HERMES_HOME",
-		Binary:             "hermes",
+		Binaries:           []string{"hermes"},
 	},
 	{
 		Provider:           ProviderOpenCode,
@@ -141,7 +147,7 @@ var descriptors = []Descriptor{
 		MCPServerKey:       "mcp",
 		DeletableWhenEmpty: true,
 		SupportsMCPHeaders: true,
-		Binary:             "opencode",
+		Binaries:           []string{"opencode"},
 		ConfigDirs:         [][]string{{".config", "opencode"}, {".opencode"}},
 		emit:               emitOpenCodeServer,
 	},

--- a/internal/configurator/registry_internal_test.go
+++ b/internal/configurator/registry_internal_test.go
@@ -26,7 +26,7 @@ func TestRegistryHasOneDescriptorPerProvider(t *testing.T) {
 		if d.DisplayName == "" {
 			t.Errorf("%q: empty DisplayName", d.Provider)
 		}
-		if d.Binary == "" && len(d.ConfigDirs) == 0 && d.BaseDirEnv == "" {
+		if len(d.Binaries) == 0 && len(d.ConfigDirs) == 0 && d.BaseDirEnv == "" {
 			t.Errorf("%q: no detection evidence at all", d.Provider)
 		}
 		// A provider whose MCP configuration Cartographer does not own (D141)


### PR DESCRIPTION
Kiro's descriptor looked up a single executable name, `kiro`, which is what the IDE installs. The standalone CLI installs **`kiro-cli`** instead — verified on 2.20.0 from the Homebrew cask, which symlinks `/opt/homebrew/bin/kiro-cli`.

So a machine with only the CLI and no `~/.kiro` yet — a fresh install before its first run — reported Kiro as **not installed**, and `cartographer connect all` skipped it. On a machine that has run Kiro once the config directory covers it, which is why this went unnoticed.

`Descriptor.Binary` becomes `Descriptor.Binaries`, probed in order, because the underlying fact is that one provider can ship its surfaces under different executable names. Every other descriptor carries a single-element list and behaves exactly as before; the detection order within a provider — binaries, then config directories, then the macOS app bundle — is unchanged.

Found while confirming Kiro's hook contract for #153.

`make vet && make test` green, with a new case asserting detection from the alternate name alone.