### PR TITLE
fix(doctor): name the command that actually clears an unverifiable entry

### DIFF
--- a/cmd/cartographer/doctor.go
+++ b/cmd/cartographer/doctor.go
@@ -292,10 +292,17 @@ func checkManagedFiles(dir string, providers []string, lockFile provisioning.Loc
 		// Reported once, in aggregate: these entries predate materialized
 		// hashes, so nothing about them can be verified — and treating that as
 		// drift would rewrite every artifact on every client at once.
+		//
+		// The fix is `reconnect`, not `sync`: an entry with no materialized
+		// hash is DriftUnknown, which is deliberately not healable, and
+		// ComputeDiff sees no change either, so a sync re-materializes only
+		// the artifacts whose content actually changed and leaves the rest
+		// exactly as they are. Only a rebuild rewrites all of them, and with
+		// them their hashes.
 		out = append(out, doctorFinding{
 			Check: "managed-files", Severity: doctorInfo, Path: lockFilePath(dir),
 			Message: fmt.Sprintf("%d managed artifact(s) recorded before content hashes existed cannot be verified", unknown),
-			Fix:     "cartographer sync",
+			Fix:     "cartographer reconnect",
 		})
 	}
 	return out

--- a/cmd/cartographer/doctor_test.go
+++ b/cmd/cartographer/doctor_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/BeppeTemp/cartographer/internal/agents"
 	"github.com/BeppeTemp/cartographer/internal/clientconfig"
 	"github.com/BeppeTemp/cartographer/internal/configurator"
+	"github.com/BeppeTemp/cartographer/internal/provisioning"
 	"github.com/BeppeTemp/cartographer/internal/service"
 )
 
@@ -324,5 +325,41 @@ func TestSortDoctorFindings(t *testing.T) {
 	}
 	if strings.Join(order, "") != "cbda" {
 		t.Errorf("order = %v, want [c b d a]", order)
+	}
+}
+
+// An entry with no materialized hash is DriftUnknown, which is deliberately
+// not healable and which ComputeDiff does not see either — so `sync`
+// re-materializes only what actually changed and leaves the finding standing.
+// The suggested command must therefore be the rebuild, not the sync: a
+// diagnosis that names a command which does not resolve it is exactly the
+// noise D143 forbids.
+func TestRunDoctor_UnknownHashSuggestsRebuild(t *testing.T) {
+	doctorStubs(t, []string{"claude"}, false)
+	dir := doctorFixture(t, "claude")
+
+	// A lockfile as an older client wrote it: managed entries, no hashes.
+	lockFile, err := provisioning.ReadLockFile(lockFilePath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lock := lockFile.ForProvider("claude")
+	for i := range lock.Managed {
+		lock.Managed[i].MaterializedHash = ""
+	}
+	lockFile.SetProvider("claude", lock)
+	if err := provisioning.WriteLockFile(lockFilePath(dir), lockFile); err != nil {
+		t.Fatal(err)
+	}
+
+	found := findingsFor(runDoctor(dir, ""), "managed-files")
+	if len(found) != 1 {
+		t.Fatalf("expected one aggregate finding, got %+v", found)
+	}
+	if found[0].Severity != doctorInfo {
+		t.Errorf("severity = %q, want %q", found[0].Severity, doctorInfo)
+	}
+	if found[0].Fix != "cartographer reconnect" {
+		t.Errorf("fix = %q, want the rebuild: a sync leaves these entries untouched", found[0].Fix)
 	}
 }


### PR DESCRIPTION
Found by running the command I shipped an hour ago against a real client upgraded from 0.7.0:

```
info    [managed-files] 33 managed artifact(s) recorded before content hashes existed cannot be verified
        fix: cartographer sync
```

Running that sync left all 33 exactly where they were.

An entry with no materialized hash is `DriftUnknown`, which `Healable()` deliberately excludes, and `ComputeDiff` sees no change either — so a sync re-materializes only the artifacts whose content actually changed and leaves the rest untouched. Only a rebuild rewrites all of them, and with them their hashes.

The finding stays informational and still never changes the exit code; only the command it names changes, from `sync` to `reconnect`. A diagnosis pointing at a command that does not resolve it is exactly the noise D143 exists to avoid.

Regression test asserts the suggested command on a lockfile shaped the way an older client wrote it.