### PR TITLE
fix(sync): verify artifact existence without a recorded hash (D146)

### DIFF
--- a/docs/decisions/client-configurator.md
+++ b/docs/decisions/client-configurator.md
@@ -530,3 +530,28 @@ verification could not check them and `doctor` would have reported "unverifiable
 machine forever. `EnsureBootstrapHook` now records the hash of the two files it writes — computed
 from the same constants, never read back — which makes the client-generated hook verifiable like any
 other managed artifact.
+
+## D146 — Existence and content are verified with different evidence
+
+D139 gated its whole on-disk check behind a recorded `materialized_hash`: an entry without one
+returned `unknown` before the filesystem was ever touched. `unknown` is not healable by design, and
+`status` drops non-healable findings, so a managed artifact **deleted from disk** kept reporting
+`in-sync` on any client whose lockfile predated D138 — the exact failure D139 was written to catch,
+surviving in the population most likely to hit it.
+
+The gate conflated two questions that need different evidence. *Did the bytes change?* cannot be
+answered without a recorded hash. *Is the path still there?* can, by `stat` alone. `verifyArtifact`
+now resolves the destination once (`managedDest`), stats it, and only then falls through to the hash
+gate: a vanished artifact is `missing` regardless of what the lockfile knows about its content,
+while one that is present but hashless stays `unknown`.
+
+**The first-upgrade guarantee is untouched**, which is what made the original gate defensible: no
+file that exists is ever rewritten on account of a missing hash. Restoring something that is *gone*
+is not the mass rewrite that argument protects against — it writes only where there is nothing, and
+it is what the operator already believes `sync` does.
+
+Rejected: healing `unknown` outright (reintroduces the mass rewrite), and special-casing `status` to
+surface unknowns as drift (would make every pre-D138 client exit 1 until it reconnects, and still
+leave `sync` unable to restore the missing file). `doctor` keeps aggregating the remaining unknowns
+into its one advisory line — with existence now covered, that line means what it says: content that
+cannot be compared, not artifacts that might be absent.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -133,10 +133,15 @@ Verification scope per kind, decided by what is verifiable:
 | `agent` | the single materialized file's bytes |
 | `mcp`, `instructions` | **presence only** of the managed key or marker block: the file is shared with the user, so its other content is never compared and never rewritten |
 
-Findings are `missing`, `modified`, `unregistered`, or `unknown`. `unknown` means the lockfile
-records no `materialized_hash` (written before D138): it is reported, never healed — treating it as
-drift would rewrite every artifact on every client at once on the first upgrade. A read error is a
-finding too, never a fatal: one unreadable artifact must not abort the verification of the others.
+Findings are `missing`, `modified`, `unregistered`, or `unknown`. **Existence and content are
+verified separately** ([D146](decisions/client-configurator.md#d146)), because they need different
+evidence: whether a path is still on disk needs no hash, whether its bytes changed does. So the
+destination is stat'd first, and `unknown` — the lockfile records no `materialized_hash`, having
+been written before D138 — applies only to an artifact that **is** on disk and whose content
+therefore cannot be compared. It is reported, never healed: treating it as drift would rewrite every
+artifact on every client at once on the first upgrade. A pre-D138 entry whose files are gone is
+`missing` like any other, and is healed. A read error is a finding too, never a fatal: one
+unreadable artifact must not abort the verification of the others.
 
 `cartographer sync --no-heal` reports divergence and skips the restore, for someone deliberately
 iterating on a local copy. `cartographer status` counts on-disk divergence as drift, so a locally

--- a/internal/provisioning/verify.go
+++ b/internal/provisioning/verify.go
@@ -6,6 +6,12 @@ package provisioning
 // edited by hand stayed edited forever and a deleted file was never restored
 // — while `cartographer status` reported in-sync. This is the mechanical half
 // of what D138's provenance stamp promises editorially.
+//
+// Existence and content are verified separately, because they need different
+// evidence: a recorded hash is required to tell whether bytes changed, but not
+// to tell whether a path is still there. Collapsing the two behind one gate is
+// what let entries predating D138 keep reporting in-sync after their files had
+// been deleted.
 
 import (
 	"fmt"
@@ -25,9 +31,12 @@ const (
 	// DriftUnregistered: a managed key or marker block inside a file shared
 	// with the user (mcp, instructions) is no longer there.
 	DriftUnregistered = "unregistered"
-	// DriftUnknown: no materialized hash was recorded — a lockfile written
-	// before D138. Reported but never healed: treating it as drift would
-	// rewrite every artifact on every client at once on the first upgrade.
+	// DriftUnknown: the artifact is on disk but no materialized hash was
+	// recorded — a lockfile written before D138 — so its content cannot be
+	// compared. Reported but never healed: treating it as drift would rewrite
+	// every artifact on every client at once on the first upgrade. Scoped to
+	// content: whether the path exists is checked without any hash, so a
+	// pre-D138 entry that vanished is DriftMissing, not unknown.
 	DriftUnknown = "unknown"
 	// DriftError: the artifact could not be verified (permissions, a path
 	// that became a directory). Reported, never fatal: one unreadable
@@ -98,6 +107,29 @@ func verifyArtifact(mf ManagedFile, provider configurator.Provider, baseDir stri
 		return finding, true
 	}
 
+	destRel, full, ok := managedDest(mf, provider, baseDir)
+	if !ok {
+		return DriftFinding{}, false
+	}
+	finding.Path = destRel
+
+	// Existence before content. Whether the path is on disk needs no recorded
+	// hash, so it is checked ahead of the MaterializedHash gate below: an
+	// artifact that is gone is missing whatever the lockfile knows about its
+	// bytes. Stat also comes first because the walk helper wraps a missing
+	// directory in a formatted error, and "gone" must not be reported as
+	// "unreadable".
+	if _, statErr := os.Stat(full); statErr != nil {
+		if os.IsNotExist(statErr) {
+			finding.Reason = DriftMissing
+		} else {
+			finding.Reason, finding.Detail = DriftError, statErr.Error()
+		}
+		return finding, true
+	}
+
+	// Only the content comparison needs a hash: a pre-D138 entry whose files
+	// are present stays unknown and is never rewritten.
 	if mf.MaterializedHash == "" {
 		finding.Reason = DriftUnknown
 		return finding, true
@@ -107,7 +139,6 @@ func verifyArtifact(mf ManagedFile, provider configurator.Provider, baseDir stri
 	var err error
 	switch mf.Kind {
 	case "agent":
-		full := filepath.Join(baseDir, mf.Path)
 		var data []byte
 		data, err = os.ReadFile(full)
 		if err == nil {
@@ -115,22 +146,6 @@ func verifyArtifact(mf ManagedFile, provider configurator.Provider, baseDir stri
 		}
 	default:
 		// skill/hook: a directory of its own.
-		destRel := destDir(mf.Kind, mf.Name, provider)
-		if destRel == "" {
-			return DriftFinding{}, false
-		}
-		finding.Path = destRel
-		full := filepath.Join(baseDir, destRel)
-		// Stat first: the walk helper wraps a missing directory in a formatted
-		// error, and "gone" must not be reported as "unreadable".
-		if _, statErr := os.Stat(full); statErr != nil {
-			if os.IsNotExist(statErr) {
-				finding.Reason = DriftMissing
-			} else {
-				finding.Reason, finding.Detail = DriftError, statErr.Error()
-			}
-			return finding, true
-		}
 		onDisk, err = contentHashDirOS(full, mf.Kind)
 	}
 
@@ -146,6 +161,21 @@ func verifyArtifact(mf ManagedFile, provider configurator.Provider, baseDir stri
 		return finding, true
 	}
 	return DriftFinding{}, false
+}
+
+// managedDest resolves where an artifact of this kind lives on disk, returning
+// the path relative to baseDir and the absolute one. ok is false when the
+// artifact has no destination for this provider: an unsupported kind is not
+// drift, it simply does not concern it.
+func managedDest(mf ManagedFile, provider configurator.Provider, baseDir string) (rel, full string, ok bool) {
+	rel = mf.Path
+	if mf.Kind != "agent" {
+		// skill/hook: a directory of its own.
+		if rel = destDir(mf.Kind, mf.Name, provider); rel == "" {
+			return "", "", false
+		}
+	}
+	return rel, filepath.Join(baseDir, rel), true
 }
 
 // managedEntryPresent reports whether the managed key (mcp) or marker block

--- a/internal/provisioning/verify_test.go
+++ b/internal/provisioning/verify_test.go
@@ -147,6 +147,30 @@ func TestVerifyManaged_NoMaterializedHashIsUnknown(t *testing.T) {
 	}
 }
 
+// Existence needs no recorded hash: a pre-D138 entry whose files are gone is
+// missing, not unknown, and is healable — otherwise `status` reports in-sync
+// on a skill that is not on disk and `sync` never restores it.
+func TestVerifyManaged_NoMaterializedHashStillDetectsMissing(t *testing.T) {
+	baseDir, _, applied, _ := driftKB(t)
+	lock := applied.NewLock
+	for i := range lock.Managed {
+		lock.Managed[i].MaterializedHash = ""
+	}
+	os.RemoveAll(filepath.Join(baseDir, ".claude", "skills", "runbooks"))
+	os.Remove(filepath.Join(baseDir, ".claude", "agents", "reviewer.md"))
+
+	findings := VerifyManaged(lock, configurator.ProviderClaudeCode, baseDir)
+	for _, want := range []struct{ kind, name string }{{"skill", "runbooks"}, {"agent", "reviewer"}} {
+		f, ok := findingFor(findings, want.kind, want.name)
+		if !ok || f.Reason != DriftMissing {
+			t.Errorf("%s %q: expected missing without a hash, got %+v", want.kind, want.name, f)
+		}
+		if !f.Healable() {
+			t.Errorf("%s %q: a missing artifact must be healable, got %+v", want.kind, want.name, f)
+		}
+	}
+}
+
 // mcp/instructions live inside a file shared with the user: presence only.
 func TestVerifyManaged_SharedFileEntriesArePresenceChecked(t *testing.T) {
 	kbRoot := t.TempDir()


### PR DESCRIPTION
Closes #161.

## Problem

`VerifyManaged` returned `DriftUnknown` for any lockfile entry without a `materialized_hash` — before touching the filesystem. `DriftUnknown` is not `Healable()`, and `snapshotDiverged` drops non-healable findings, so a managed artifact **deleted from disk** kept reporting `in-sync` on every client whose lockfile predated D138. `sync` never restored it either.

That is the failure D139 was written to catch, surviving in exactly the population most likely to hit it: clients upgraded from before v0.8.0.

Observed on a live v0.8.1 client — a KB-provided skill deleted by hand weeks earlier, with `status` reporting `skill 5/5 · in-sync` throughout.

## Change

Existence and content need different evidence: only the content comparison requires a recorded hash. `verifyArtifact` now resolves the destination once (new `managedDest` helper), stats it, and falls through to the hash gate only when the path is present.

- gone → `DriftMissing`, whatever the lockfile knows about its content — reported by `status`, healed by `sync`;
- present but hashless → `DriftUnknown`, exactly as before.

**The first-upgrade guarantee is unchanged**, which is what made the original gate defensible: no file that exists is ever rewritten on account of a missing hash. Restoring something that is gone writes only where there is nothing.

## Test

`TestVerifyManaged_NoMaterializedHashStillDetectsMissing` — a pre-D138 lock with the skill directory and the agent file removed. Verified to fail on the parent commit with `Reason:unknown`, pass here. The existing `TestVerifyManaged_NoMaterializedHashIsUnknown` still passes unmodified: modified-but-present content stays unknown.

`make vet && make test` green.

## Docs

`docs/sync.md` §On-disk verification, plus D146 in `docs/decisions/client-configurator.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)