### PR TITLE
fix(client): report writes that happened, not writes intended (D147)

### DIFF
--- a/cmd/cartographer/clientsync.go
+++ b/cmd/cartographer/clientsync.go
@@ -269,19 +269,33 @@ func ensureBootstrapForProviders(providers []string, targetDir string, dryRun bo
 // printApplySummary prints a one-line-per-file summary of a materialization pass.
 // dir is the base-dir the artifacts were materialized into — used to print the
 // resolved settings.json path in printHookRegistered (D57).
-func printApplySummary(dir string, results map[string]provisioning.AppliedResult) {
+//
+// dryRun is not cosmetic: Apply fills AppliedResult with what it *would* write
+// when it changes nothing, so reporting those lines in the past tense describes
+// a pass that never happened — precisely when the reader asked to see the plan
+// before committing to it (D147).
+func printApplySummary(dir string, results map[string]provisioning.AppliedResult, dryRun bool) {
 	needsApproval := false
 	needsMCPApproval := false
+	// "wrote" / "would write", chosen once so every line of the pass agrees.
+	verb := func(done, planned string) string {
+		if dryRun {
+			return planned
+		}
+		return done
+	}
 	for _, p := range sortedKeys(results) {
 		r := results[p]
 		for _, w := range r.Written {
-			fmt.Printf("[%s] wrote %s\n", p, w.Path)
-			if hookRegistrationManagedFile(p, w) {
+			fmt.Printf("[%s] %s %s\n", p, verb("wrote", "would write"), w.Path)
+			// The registration line reports a side effect on a shared file
+			// that a dry run does not perform either.
+			if !dryRun && hookRegistrationManagedFile(p, w) {
 				printHookRegistered(p, dir, w)
 			}
 		}
 		for _, pr := range r.Pruned {
-			fmt.Printf("[%s] pruned %s\n", p, pr.Path)
+			fmt.Printf("[%s] %s %s\n", p, verb("pruned", "would prune"), pr.Path)
 		}
 		// A heal means a local change was discarded (D139): say so on its own
 		// line instead of folding it into the ordinary writes above.
@@ -292,7 +306,7 @@ func printApplySummary(dir string, results map[string]provisioning.AppliedResult
 				continue
 			}
 			healedArtifacts[key] = true
-			fmt.Printf("[%s] restored %s from the server (local changes discarded)\n", p, key)
+			fmt.Printf("[%s] %s %s from the server (local changes discarded)\n", p, verb("restored", "would restore"), key)
 		}
 		for _, d := range r.Divergent {
 			fmt.Printf("[%s] diverged locally (%s): %s/%s at %s — `cartographer sync` restores it\n", p, d.Reason, d.Kind, d.Name, d.Path)

--- a/cmd/cartographer/clientsync_test.go
+++ b/cmd/cartographer/clientsync_test.go
@@ -553,3 +553,38 @@ func TestMaterializeForProviders_MissingProviderBaseDir(t *testing.T) {
 		t.Errorf("error %q does not name the variable", err)
 	}
 }
+
+// A dry run must not describe its plan in the past tense: Apply fills
+// AppliedResult with what it would write, and printing that as "wrote" reports
+// a pass that never happened (D147).
+func TestPrintApplySummary_DryRunSpeaksInTheConditional(t *testing.T) {
+	results := map[string]provisioning.AppliedResult{
+		"claude": {
+			Written: []provisioning.ManagedFile{{Kind: "skill", Name: "runbooks", Path: ".claude/skills/runbooks/SKILL.md"}},
+			Pruned:  []provisioning.ManagedFile{{Kind: "skill", Name: "old", Path: ".claude/skills/old/SKILL.md"}},
+			Healed:  []provisioning.ManagedFile{{Kind: "agent", Name: "reviewer", Path: ".claude/agents/reviewer.md"}},
+		},
+	}
+
+	dry := withStdout(t, func() { printApplySummary(t.TempDir(), results, true) })
+	for _, want := range []string{"would write", "would prune", "would restore"} {
+		if !strings.Contains(dry, want) {
+			t.Errorf("dry run output = %q, want it to contain %q", dry, want)
+		}
+	}
+	for _, unwanted := range []string{"] wrote ", "] pruned ", "] restored "} {
+		if strings.Contains(dry, unwanted) {
+			t.Errorf("dry run output = %q, must not claim %q", dry, unwanted)
+		}
+	}
+
+	real := withStdout(t, func() { printApplySummary(t.TempDir(), results, false) })
+	for _, want := range []string{"] wrote ", "] pruned ", "] restored "} {
+		if !strings.Contains(real, want) {
+			t.Errorf("real run output = %q, want it to contain %q", real, want)
+		}
+	}
+	if strings.Contains(real, "would ") {
+		t.Errorf("real run output = %q, must not be conditional", real)
+	}
+}

--- a/cmd/cartographer/connect.go
+++ b/cmd/cartographer/connect.go
@@ -422,14 +422,21 @@ func printConnectResult(dir string, providers []string, opts connectOptions, res
 	if res.Deferred {
 		fmt.Fprintf(os.Stderr, "Warning: skill sync deferred, server unreachable: %v\n", res.DeferredErr)
 	} else {
-		printApplySummary(dir, res.Applied)
+		printApplySummary(dir, res.Applied, opts.DryRun)
 	}
 
 	for _, p := range providers {
+		if opts.DryRun {
+			fmt.Printf("[dry-run] would connect: %s\n", p)
+			continue
+		}
 		fmt.Printf("connected: %s\n", p)
 	}
-	if !opts.DryRun {
-		fmt.Printf("restart the %s sessions to load the MCP tools\n", strings.Join(providers, ", "))
+	// Only providers whose MCP configuration Cartographer writes have tools to
+	// load: telling someone to restart Hermes for MCP tools it never received
+	// contradicts the warning printed above (D147).
+	if mcpProviders := providersManagingMCP(providers); !opts.DryRun && len(mcpProviders) > 0 {
+		fmt.Printf("restart the %s sessions to load the MCP tools\n", strings.Join(mcpProviders, ", "))
 	}
 	if res.Deferred {
 		fmt.Println("warning: skill sync deferred (server unreachable); run `cartographer sync` once the server is up")
@@ -564,7 +571,15 @@ func doConnect(opts connectOptions) (connectResult, error) {
 	}
 	pullCfg := &clientconfig.Config{ServerURL: opts.ServerURL, ServerName: opts.Name, Auth: opts.Auth, TokenEnv: opts.TokenEnv, KBs: pullKBs, SigningKeys: existing.SigningKeys}
 
-	res := connectResult{Providers: opts.Providers, ConfigsWritten: configsWritten, MCPEntries: entryNames(entries), Warnings: configWarnings}
+	// The MCP-entry lines report what was emitted, not what was asked for:
+	// entries is built from the client config alone, so keeping it when no
+	// selected provider has an MCP emitter announces a write into a file the
+	// output cannot even name (D147).
+	mcpEntries := entryNames(entries)
+	if len(providersManagingMCP(opts.Providers)) == 0 {
+		mcpEntries = nil
+	}
+	res := connectResult{Providers: opts.Providers, ConfigsWritten: configsWritten, MCPEntries: mcpEntries, Warnings: configWarnings}
 	if m, err := fetchMergedManifest(pullCfg); err != nil {
 		res.Deferred = true
 		res.DeferredErr = err
@@ -591,4 +606,18 @@ func doConnect(opts connectOptions) (connectResult, error) {
 	}
 
 	return res, nil
+}
+
+// providersManagingMCP filters providers down to those whose MCP configuration
+// Cartographer actually writes. A provider configured outside Cartographer
+// (D141, hermes) receives artifacts but no MCP entry, so every line that talks
+// about MCP must be scoped to this subset rather than to the whole selection.
+func providersManagingMCP(providers []string) []string {
+	out := make([]string, 0, len(providers))
+	for _, p := range providers {
+		if configurator.ManagesMCPConfig(configurator.Provider(p)) {
+			out = append(out, p)
+		}
+	}
+	return out
 }

--- a/cmd/cartographer/connect_test.go
+++ b/cmd/cartographer/connect_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -285,5 +286,64 @@ func TestInstallServiceAndWaitHealthy_UsesDefaultListenAddress(t *testing.T) {
 	}
 	if got.HTTPAddr != defaults.DefaultListenAddress {
 		t.Errorf("automatic service HTTPAddr = %q, want %q", got.HTTPAddr, defaults.DefaultListenAddress)
+	}
+}
+
+// A provider whose MCP configuration Cartographer does not write (D141, hermes)
+// must not be told an MCP entry was written for it, nor to restart its sessions
+// to load tools it never received — both contradict the warning printed
+// alongside them (D147).
+func TestPrintConnectResult_NoMCPClaimsForProvidersWithoutAnEmitter(t *testing.T) {
+	hermes := []string{"hermes"}
+	out := withStdout(t, func() {
+		printConnectResult(t.TempDir(), hermes, connectOptions{}, connectResult{Providers: hermes})
+	})
+	if strings.Contains(out, "MCP entry") {
+		t.Errorf("output = %q, must not announce an MCP entry for a provider with no emitter", out)
+	}
+	if strings.Contains(out, "load the MCP tools") {
+		t.Errorf("output = %q, must not ask to restart sessions for MCP tools never delivered", out)
+	}
+	if !strings.Contains(out, "connected: hermes") {
+		t.Errorf("output = %q, want the provider still reported as connected", out)
+	}
+
+	// A provider that does have an emitter keeps both lines.
+	claude := []string{"claude"}
+	out = withStdout(t, func() {
+		printConnectResult(t.TempDir(), claude, connectOptions{}, connectResult{Providers: claude, MCPEntries: []string{"cartographer"}})
+	})
+	if !strings.Contains(out, "wrote MCP entry cartographer") {
+		t.Errorf("output = %q, want the MCP entry reported", out)
+	}
+	if !strings.Contains(out, "restart the claude sessions") {
+		t.Errorf("output = %q, want the restart hint", out)
+	}
+}
+
+// With a mixed selection the restart hint names only the providers that
+// actually received MCP configuration.
+func TestPrintConnectResult_RestartHintNamesOnlyMCPProviders(t *testing.T) {
+	providers := []string{"claude", "hermes"}
+	out := withStdout(t, func() {
+		printConnectResult(t.TempDir(), providers, connectOptions{}, connectResult{Providers: providers, MCPEntries: []string{"cartographer"}})
+	})
+	if !strings.Contains(out, "restart the claude sessions") {
+		t.Errorf("output = %q, want only claude named in the restart hint", out)
+	}
+	if strings.Contains(out, "hermes sessions") {
+		t.Errorf("output = %q, must not tell hermes to restart for MCP tools", out)
+	}
+}
+
+// The predicate both the MCP-entry lines and the restart hint are scoped by.
+func TestProvidersManagingMCP(t *testing.T) {
+	got := providersManagingMCP([]string{"claude", "hermes", "codex"})
+	want := []string{"claude", "codex"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("providersManagingMCP() = %v, want %v", got, want)
+	}
+	if got := providersManagingMCP([]string{"hermes"}); len(got) != 0 {
+		t.Errorf("providersManagingMCP([hermes]) = %v, want empty — it has no MCP emitter", got)
 	}
 }

--- a/cmd/cartographer/sync.go
+++ b/cmd/cartographer/sync.go
@@ -135,7 +135,11 @@ func runSync(dir string, cfg *clientconfig.Config, opts syncOptions) (syncResult
 	if err != nil {
 		return syncResult{}, err
 	}
-	printApplySummary(dir, results)
+	printApplySummary(dir, results, opts.DryRun)
+	if opts.DryRun {
+		fmt.Printf("would sync to revision %s\n", m.Revision)
+		return syncResult{Revision: m.Revision}, nil
+	}
 	fmt.Printf("synced to revision %s\n", m.Revision)
 	return syncResult{Revision: m.Revision}, nil
 }

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -98,7 +98,7 @@ cartographer connect all --auto-trust --dry-run
 | `--server-url` | `http://localhost:39273/mcp` | Cartographer server URL |
 | `--auth` | `false` | Enables the Bearer header in generated configs |
 | `--token-env` | `CARTOGRAPHER_TOKENS` | Env var holding the Bearer token |
-| `--dry-run` | `false` | Prints without writing |
+| `--dry-run` | `false` | Prints what would be written, in the conditional (`would write`, `would connect`), and writes nothing ([D147](decisions/client-configurator.md#d147)) |
 | `--auto-trust` | `false` | Also treats KB skills as trusted (unsigned) |
 | `--pin-key` | *(repeatable)* | Pins `KB=PUBLIC_KEY` for Ed25519-verified provisioning artifacts; existing pins are preserved |
 
@@ -470,7 +470,9 @@ the shared base dir declares `BaseDirEnv` instead ([D141](decisions/client-confi
 configuration: Hermes' endpoint list lives in a `config.yaml` rendered by its Ansible role and
 recreated on the next playbook run, so anything written there would be lost — `connect` says so
 explicitly rather than silently doing nothing, and pointing Hermes at the server stays the
-operator's job. For the same reason Hermes is absent from the interactive connect form, which offers
+operator's job. The output is scoped to match: no MCP-entry line is printed, and the closing
+"restart the … sessions to load the MCP tools" hint names only the providers that received one
+([D147](decisions/client-configurator.md#d147)). For the same reason Hermes is absent from the interactive connect form, which offers
 the providers whose MCP configuration `connect` writes.
 
 - **`$HERMES_HOME` is required**: it is the base dir artifacts are materialized under, recorded as

--- a/docs/decisions/client-configurator.md
+++ b/docs/decisions/client-configurator.md
@@ -555,3 +555,32 @@ surface unknowns as drift (would make every pre-D138 client exit 1 until it reco
 leave `sync` unable to restore the missing file). `doctor` keeps aggregating the remaining unknowns
 into its one advisory line — with existence now covered, that line means what it says: content that
 cannot be compared, not artifacts that might be absent.
+
+## D147 — Every reported write is observed, never intended
+
+Two lines claimed work that had not happened. `connect --dry-run` printed `[kiro] wrote
+.kiro/skills/…/SKILL.md` and `connected: kiro` for files it did not write, because `Apply` fills
+`AppliedResult.Written` with what it *would* write and `printApplySummary` never received the flag —
+while `printConnectResult`, one frame above, branched on it correctly for its own two loops. And
+`connect hermes` printed `wrote MCP entry cartographer` immediately before the warning explaining
+that Hermes' MCP configuration is never written by Cartographer (D141), because the line was
+rendered from `entryNames(entries)` — the entries built from the client config, independent of which
+providers can accept them.
+
+Neither was a functional defect: the files on disk were right in both cases. The cost is
+epistemic. `connect` is the command whose output *is* its result — run once, in an unfamiliar setup,
+with nothing to compare against — and `--dry-run` exists precisely to be read before committing. A
+line saying `wrote` that corresponds to no write is worth less than no line at all, and in the
+Hermes case it argued against the warning printed to correct it, arriving first.
+
+**The rule.** A `wrote`/`pruned`/`restored`/`connected` line is emitted from the code path that
+observed the effect, never from the one that planned it. Mechanically: `printApplySummary` takes
+`dryRun` and renders the conditional (`would write`), suppressing the hook-registration line, which
+reports a side effect on a shared file that a dry run does not perform either; `sync --dry-run` ends
+with `would sync to revision`; and both the MCP-entry lines and the restart hint are scoped by
+`providersManagingMCP`, so a mixed `connect claude,hermes` names only claude in the hint.
+
+Rejected: dropping the MCP-entry line whenever `ConfigsWritten` is empty. It reads as equivalent but
+couples an MCP claim to an unrelated emptiness — a provider that writes its entry into a file
+already containing it would lose the line for the wrong reason. The predicate is "does this provider
+have an emitter", so that is what the code asks.


### PR DESCRIPTION
Closes #162.

## Problem

Two output lines claimed work that had not happened.

**`--dry-run` in the past tense.** `printApplySummary` printed `[kiro] wrote .kiro/skills/…/SKILL.md` and `connected: kiro` for files it never wrote — `Apply` populates `AppliedResult.Written` with what it *would* write, and the summary never received the flag. `printConnectResult` one frame above branches on `opts.DryRun` correctly for its own two loops; it just didn't pass it down.

**An MCP entry for a provider with no emitter.** `connect hermes` printed `wrote MCP entry cartographer` immediately before the warning explaining that Hermes' MCP configuration is never written by Cartographer (D141), then closed with `restart the hermes sessions to load the MCP tools`. The line came from `entryNames(entries)` — entries built from the client config, independent of which providers can accept them — so it announced a write and named no file it went into.

Neither is a functional defect: the files on disk were right both times. But `connect` is the command whose output *is* its result, and `--dry-run` exists to be read before committing.

## Change

- `printApplySummary` takes `dryRun` and renders the conditional (`would write` / `would prune` / `would restore`), suppressing the hook-registration line — that reports a side effect on a shared file a dry run does not perform either;
- `sync --dry-run` ends with `would sync to revision`, `connect --dry-run` with `[dry-run] would connect: <p>`;
- the MCP-entry lines and the restart hint are scoped by a new `providersManagingMCP`, so `connect claude,hermes` names only claude in the hint and `connect hermes` prints neither.

## Test

Three tests, all verified to fail on the parent commit:
- `TestPrintApplySummary_DryRunSpeaksInTheConditional` — dry run must not use the indicative, real run must not use the conditional;
- `TestPrintConnectResult_NoMCPClaimsForProvidersWithoutAnEmitter` and `TestPrintConnectResult_RestartHintNamesOnlyMCPProviders`;
- `TestProvidersManagingMCP` covers the predicate both call sites share.

`make vet && make test` green.

## Docs

`docs/configurator.md` (`--dry-run` row, §Hermes Agent) and D147 in `docs/decisions/client-configurator.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)