### PR TITLE
docs(readme): give the configurator and the team story their own sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,84 @@ any text editor.
 Cartographer offers **two complementary profiles**:
 - **Local Core** — single agent, stdio transport, local git. Captures the value of the pattern with
   minimal complexity.
-- **Server** — multi-KB, HTTP + token auth. For shared and remote
-  deployments.
+- **Server** — multi-KB, HTTP + token auth. One server holds several knowledge bases, hands each
+  client the artifacts its KBs define, and lets a team share some KBs while keeping others private.
+
+Two consequences are worth stating on their own, because they are what most of the design is for:
+the KB **configures the agents that read it** across every client you use, and it does that for a
+whole team rather than a single laptop.
+
+## One KB, every agent
+
+A knowledge base is not only what an agent reads — it is also **how that agent is set up to work**.
+Cartographer treats skills, subagents, hooks and standing instructions as content of the KB, and
+materializes them into each client's native format.
+
+The manual alternative is what most setups do today: the same skill hand-copied into
+`.claude/skills/`, `.opencode/skills/` and `.codex/skills/`, each drifting on its own, each config
+file edited by hand for every MCP endpoint. Change one thing and you change it in five places, on
+every machine, forever.
+
+```bash
+cartographer connect        # detects installed clients and configures all of them
+```
+
+That single command writes, per client and in the format that client expects:
+
+| | claude | opencode | codex | kiro | hermes |
+|---|---|---|---|---|---|
+| **MCP endpoint** | `.claude.json` | `opencode.json` | `config.toml` block | `.kiro/settings/mcp.json` | *rendered by its own deploy* |
+| **Skills** | `.claude/skills/` | `.opencode/skills/` | `.codex/skills/` | `.kiro/skills/` | delivered to its inbox |
+| **Subagents** | `.claude/agents/*.md` | `.opencode/agent/*.md` | `.codex/agents/*.toml` | — | — |
+| **Hooks** | `settings.json` | generated JS plugin | `config.toml` block | — | — |
+| **Instructions** | block in `CLAUDE.md` | block in `AGENTS.md` | block in `AGENTS.md` | `.kiro/steering/` | — |
+
+Subagents and hooks are **translated**, not copied: the same KB artifact becomes a Markdown agent
+for Claude Code, a TOML one for Codex, and a generated JavaScript plugin where a hook has no native
+equivalent. Cells that cannot exist are `unsupported` by explicit declaration, never by silent
+omission — and a cell missing from the table fails a test.
+
+What keeps it true after the first run:
+
+- **it re-syncs by itself** — a `SessionStart` hook on every client that has one, a scheduled timer
+  for those that don't;
+- **it verifies the files on disk**, not just its own bookkeeping: an artifact edited by hand or
+  deleted is restored from the server;
+- **every materialized file carries a provenance stamp** saying which KB it came from and where to
+  edit it for real;
+- **it only ever touches what it created** — pruning is limited to its own tracked paths, and
+  `--dry-run` shows the plan without writing;
+- **`doctor`** diagnoses residues and drift read-only; **`reconnect`** rebuilds a client from
+  scratch while preserving every setting.
+
+Edit a skill once in the KB, and every client of every machine converges on it.
+
+## Teams
+
+The same mechanism is what makes Cartographer work for more than one person. A server mounts
+several KBs and routes by `?kb=<name>`, so colleagues can each keep a private knowledge base while
+sharing others.
+
+- **Per-KB authorization** — bearer tokens carry `kb:<name>:r` or `kb:<name>:rw` scopes. **Roles**
+  ([`docs/transport-auth.md`](docs/transport-auth.md)) narrow that further to specific maps, journals
+  and concept types, so a teammate can be an editor of the runbooks and a reader of everything else.
+  Rules are unioned: adding a role can only widen access, never silently revoke it.
+- **Git is the sync layer** — every write is a commit, with fetch/pull-rebase before and push after,
+  so teammates running their own server against **separate clones of the same remote** converge
+  without a coordination protocol. A conflict is then not an error page but a workflow: the affected
+  concepts are flagged `degraded`, `conflicts_list` enumerates them, and a bundled skill walks an
+  agent through resolving them. (One process is the sole writer of a given working copy; pointing
+  two writers at one checkout is not a supported model — partition KBs across instances instead, see
+  [`docs/concurrency.md`](docs/concurrency.md).)
+- **Shared content stays portable** — a skill that mentions a local repository uses a
+  `{{repo:<name>}}` placeholder resolved **on each client** from its own git remotes, so the same
+  artifact works on every teammate's machine without machine-specific paths leaking into the KB. A
+  server-side lint flags the ones that do.
+- **Provenance you can verify** — a KB can sign its provisioning artifacts with Ed25519; clients pin
+  the public key out of band and refuse anything that fails verification. Distributing a skill to a
+  team is then a checkable act, not a matter of trust.
+- **Per-KB identity** — commit author and an optional tool-name prefix are configured per KB, so
+  history attributes correctly and an agent mounting several KBs never confuses their tools.
 
 ## Key features
 
@@ -61,16 +137,12 @@ Cartographer offers **two complementary profiles**:
 - 🛡️ **Governance** — deterministic `lint` (broken link, stale claim, orphan, map contracts), `commit_gate`,
   `gate_check`, `supersede`, contradiction tracking
 - 🧬 **Transactional git** — one commit per write operation; optional synchronization to a remote
-  (fetch/pull-rebase before and push after every write) — git as a sync layer across multiple
-  instances; agentic conflict handling (concepts flagged `degraded` + `conflicts_list` tool +
-  guided skill)
-- 🗂️ **Multi-KB** with `?kb=<name>` routing; bearer-token auth with scopes / RBAC
+  (fetch/pull-rebase before and push after every write), which is also what lets several instances
+  serve one KB — see [Teams](#teams)
 - 🔐 **Audit log** — append-only with hash-chain and Ed25519 signature
-- 🧩 **Domain skills** (`SKILL.md` / agentskills.io format) with provisioning and client↔server sync, including executable scripts and binary assets
+- 🧩 **Domain skills** (`SKILL.md` / agentskills.io format), including executable scripts and binary
+  assets — see [One KB, every agent](#one-kb-every-agent) for how they reach each client
 - 🔑 **Secrets via SOPS** — JSON Pointer references, scoped resolution and safe rotation; plaintext values never stored
-- ⚙️ **Multi-provider configurator** — generates MCP config for Claude Code, Codex CLI, Kiro,
-  OpenCode; Hermes Agent is supported for artifact delivery (skills are *delivered* to its inbox for
-  the agent to adopt, never installed over the ones it curates itself)
 - 📦 **OKF-compliant** — each KB is an OKF bundle and a standalone git repo, zero lock-in (just git +
   Markdown)
 
@@ -131,7 +203,7 @@ first KB, and connect an agent client to it.
 brew install beppetemp/tap/cartographer   # or curl install.sh, or `go install` (see Install above)
 cartographer service install              # generates config, installs and starts the service
 cartographer kb create <name> --remote <url>  # scaffolds a KB in the data dir, pushes it to <url>
-cartographer connect                      # connects an agent client (Claude Code, OpenCode, Codex, Kiro, Hermes)
+cartographer connect                      # configures every detected client — see One KB, every agent
 ```
 
 `--remote <url>` is an **empty** git repository that becomes the KB's `origin`: a KB is a git

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -297,7 +297,7 @@ Binds to **loopback** by default (`127.0.0.1:39273`) → auth stays in auto-off 
 
 `service status` uses systemctl-like exit codes: `0` running, `3` installed but stopped, `4` not installed — this is what lets `install.sh update` automatically restart only a running service (see §Client installation).
 
-**Data/code separation**: the cartographer repo contains no data. KBs live in the data dir (default `~/cartographer-data`); every subdirectory of it is a separate KB. For multiple users on shared KBs, see the k8s topology below — the server configuration is identical, only where it runs changes; for multiple instances on the same KB, see §Topologies (Multi-server).
+**Data/code separation**: the cartographer repo contains no data. KBs live in the data dir (default `~/cartographer-data`); every subdirectory of it is a separate KB. For multiple users on shared KBs, see the k8s topology below — the server configuration is identical, only where it runs changes; one server process is the sole writer of a given working copy, so several instances mean separate clones synchronizing through the same remote, never two writers on one checkout (`concurrency.md` §Writer boundary).
 
 Client-side convenience: if `cartographer connect` targets a loopback URL and the probe fails because the service isn't running, it directly offers to install+start the service (in the interactive flow) or suggests `cartographer service install` (in the non-interactive one).
 


### PR DESCRIPTION
## Why

The README lists twelve features and buries the two that most distinguish Cartographer.

**The configurator** was the tenth bullet — "generates MCP config for Claude Code, Codex CLI, Kiro, OpenCode" — which undersells it: `connect` also materializes skills, subagents, hooks and standing instructions, *translating* them per client, and then keeps them true with session triggers, on-disk verification, healing and provenance stamps. A reader could finish the README without learning that editing one skill in the KB updates every client on every machine.

**The team story** appeared nowhere outside `docs/`. Several KBs on one server with `?kb=` routing, per-KB scopes and roles, `{{repo:}}` placeholders that exist precisely so shared artifacts survive different machines, Ed25519-signed provisioning with client-side pinning — all of it reads as designed for one laptop unless someone says otherwise.

## What changed

- new **One KB, every agent** — the manual alternative it replaces, what one `connect` writes per client (as a matrix), that subagents and hooks are translated rather than copied, and the five mechanisms that keep it true after the first run;
- new **Teams** — private and shared KBs on one server, per-KB scopes and roles, git as the sync layer, path portability, signed artifacts, per-KB identity;
- **Key features** trimmed of the bullets those two sections now cover, with cross-links instead of duplicates;
- the two profiles under "What is it" now say what the Server profile is *for*.

Claims are limited to what the code and docs support. In particular the git bullet states the supported model explicitly — separate clones synchronizing through one remote, one writer per working copy — rather than implying multi-writer scaling, which `docs/concurrency.md` rules out.

## Drive-by

`docs/deployment.md` pointed at a `§Topologies (Multi-server)` section that does not exist (the table has only Local and Shared server). Repointed at `concurrency.md` §Writer boundary, which is the model it was describing.

Docs only — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
