### PR TITLE
fix(sync): scope sync's MCP-entry line like connect's (D147)

### DIFF
--- a/cmd/cartographer/connect.go
+++ b/cmd/cartographer/connect.go
@@ -401,13 +401,7 @@ func cmdConnect(args []string) int {
 // factored out so both the non-interactive path and the interactive retry
 // loop in cmdConnect (D64) share exactly one rendering of a successful result.
 func printConnectResult(dir string, providers []string, opts connectOptions, res connectResult) {
-	for _, entry := range res.MCPEntries {
-		if opts.DryRun {
-			fmt.Printf("[dry-run] would write MCP entry %s\n", entry)
-		} else {
-			fmt.Printf("wrote MCP entry %s\n", entry)
-		}
-	}
+	printMCPEntryLines(providers, res.MCPEntries, opts.DryRun)
 	for _, p := range res.ConfigsWritten {
 		if opts.DryRun {
 			fmt.Printf("[dry-run] would write %s\n", p)
@@ -606,6 +600,24 @@ func doConnect(opts connectOptions) (connectResult, error) {
 	}
 
 	return res, nil
+}
+
+// printMCPEntryLines reports the MCP entries emitted for providers, in the
+// conditional under dryRun. Shared by connect and sync because both derive
+// entries from the client config alone: without scoping to the providers that
+// actually have an emitter, either would announce a write into a file it does
+// not name and cannot have touched (D147).
+func printMCPEntryLines(providers, entries []string, dryRun bool) {
+	if len(providersManagingMCP(providers)) == 0 {
+		return
+	}
+	for _, entry := range entries {
+		if dryRun {
+			fmt.Printf("[dry-run] would write MCP entry %s\n", entry)
+		} else {
+			fmt.Printf("wrote MCP entry %s\n", entry)
+		}
+	}
 }
 
 // providersManagingMCP filters providers down to those whose MCP configuration

--- a/cmd/cartographer/connect_test.go
+++ b/cmd/cartographer/connect_test.go
@@ -295,8 +295,10 @@ func TestInstallServiceAndWaitHealthy_UsesDefaultListenAddress(t *testing.T) {
 // alongside them (D147).
 func TestPrintConnectResult_NoMCPClaimsForProvidersWithoutAnEmitter(t *testing.T) {
 	hermes := []string{"hermes"}
+	// MCPEntries deliberately non-empty: the guard must hold even if a caller
+	// hands over entries derived from the client config (sync does exactly that).
 	out := withStdout(t, func() {
-		printConnectResult(t.TempDir(), hermes, connectOptions{}, connectResult{Providers: hermes})
+		printConnectResult(t.TempDir(), hermes, connectOptions{}, connectResult{Providers: hermes, MCPEntries: []string{"cartographer"}})
 	})
 	if strings.Contains(out, "MCP entry") {
 		t.Errorf("output = %q, must not announce an MCP entry for a provider with no emitter", out)

--- a/cmd/cartographer/sync.go
+++ b/cmd/cartographer/sync.go
@@ -105,13 +105,7 @@ func runSync(dir string, cfg *clientconfig.Config, opts syncOptions) (syncResult
 		for _, w := range warnings {
 			fmt.Fprintf(os.Stderr, "warning: %s\n", w)
 		}
-		for _, name := range entryNames(entries) {
-			if opts.DryRun {
-				fmt.Printf("[dry-run] would write MCP entry %s\n", name)
-			} else {
-				fmt.Printf("wrote MCP entry %s\n", name)
-			}
-		}
+		printMCPEntryLines(cfg.Agents, entryNames(entries), opts.DryRun)
 		if !opts.DryRun {
 			cfg.KBs = kbs
 			if err := clientconfig.Save(dir, cfg); err != nil {

--- a/docs/decisions/client-configurator.md
+++ b/docs/decisions/client-configurator.md
@@ -580,6 +580,10 @@ reports a side effect on a shared file that a dry run does not perform either; `
 with `would sync to revision`; and both the MCP-entry lines and the restart hint are scoped by
 `providersManagingMCP`, so a mixed `connect claude,hermes` names only claude in the hint.
 
+`connect` and `sync` both build those entries from the client config, so the scoping lives in one
+`printMCPEntryLines` they share — the first cut fixed only `connect` and left `sync` announcing the
+entry on a Hermes-only client, which is the duplication that caused the defect reasserting itself.
+
 Rejected: dropping the MCP-entry line whenever `ConfigsWritten` is empty. It reads as equivalent but
 couples an MCP claim to an unrelated emptiness — a provider that writes its entry into a file
 already containing it would lose the line for the wrong reason. The predicate is "does this provider


### PR DESCRIPTION
Follow-up to #164, found while rolling out v0.8.2 to a live Hermes client.

D147 scoped the MCP-entry line to providers that actually have an emitter — but only in `connect`. `sync` builds the same line from the same config-derived entries (`sync.go`), and was left unscoped, so a Hermes-only client still logged on every timer tick:

```
wrote MCP entry cartographer
synced to revision 4948e29f…
```

immediately alongside the warning saying its MCP configuration is never written by Cartographer. Same defect as #162, same cause, one call site further along.

## Change

Both paths now go through a shared `printMCPEntryLines(providers, entries, dryRun)`. The duplication is what let the defect survive its own fix, so removing it is the fix rather than adding a second guard that can drift from the first.

`TestPrintConnectResult_NoMCPClaimsForProvidersWithoutAnEmitter` now passes a non-empty `MCPEntries` for the Hermes case, so the guard is exercised the way `sync` actually calls it — with entries present and no provider able to accept them.

`make vet && make test` green.

## Note

Verified against the released v0.8.2 binary on the affected client, which is where it surfaced. Not worth a release of its own — it will ship with whatever lands next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)