### PR TITLE
fix(mcp): name the resource in artifact and asset commit subjects

### DIFF
--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -35,6 +35,13 @@ replacement is atomic, and Cartographer creates no working branch, opens no pull
 request and never merges into `main`: repository review policy belongs to the
 remote hosting workflow.
 
+Each commit subject is `<tool_name>: <resource>`, so the history of a KB is
+readable as an audit trail. The resource is built from the arguments that
+identify what the write touched: `path` for the artifact tools, `concept_id/path`
+for the asset tools, and otherwise the first of `id`, `name`, `source_id`,
+`contradiction_id` present in the call. A tool invoked with none of them commits
+as the bare tool name.
+
 `git.profile: server` (D117) is an opt-in GitHub review boundary. It requires a
 base branch, a dedicated working branch, GitHub owner/repository/API URL and the
 name of an environment variable holding a token. On mount Cartographer fetches

--- a/internal/mcpserver/audit.go
+++ b/internal/mcpserver/audit.go
@@ -47,11 +47,14 @@ var auditResourceFields = map[string][]string{
 	"asset_list":           {"concept_id"},
 	"asset_write":          {"concept_id", "path"},
 	"asset_delete":         {"concept_id", "path"},
-	"artifact_read":        {"kind", "name"},
-	"artifact_list":        {"kind"},
-	"artifact_write":       {"kind", "name"},
-	"artifact_delete":      {"kind", "name"},
-	"service_get":          {"service_id"},
+	// The artifact tools address their target by path only (see
+	// tools_artifact.go: "required": ["path", ...]); "kind"/"name" were never
+	// arguments of theirs, so those entries recorded nothing. artifact_list
+	// takes no arguments at all, so it has no entry (silence is safe here).
+	"artifact_read":   {"path"},
+	"artifact_write":  {"path"},
+	"artifact_delete": {"path"},
+	"service_get":     {"service_id"},
 	// secret_resolve's "names" and secret_set's "key" are secret field
 	// names, not resource identifiers — deliberately excluded.
 	"secret_resolve":       {"concept_id"},

--- a/internal/mcpserver/docs_test.go
+++ b/internal/mcpserver/docs_test.go
@@ -48,6 +48,9 @@ var docsNonTools = map[string]bool{
 	"index_incomplete": true,
 	// frontmatter fields and schema keys
 	"concept_id": true, "concept_types": true, "archive_type": true,
+	// tool argument names, cited where the docs explain which argument
+	// identifies the resource a write touched (commit subjects)
+	"contradiction_id": true, "source_id": true,
 	"contradiction_kind": true, "service_ref": true, "secret_refs": true,
 	"secrets_source": true, "review_after": true, "asserted_by": true,
 	"last_indexed_commit": true, "content_hash": true, "applied_revision": true,

--- a/internal/mcpserver/gitwrap.go
+++ b/internal/mcpserver/gitwrap.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/BeppeTemp/cartographer/internal/gitx"
@@ -243,20 +244,57 @@ func handleConflictError(k *kb.KB, rce *gitx.RebaseConflictError) int {
 	return n
 }
 
+// commitSubjectFields names, per tool, the argument fields that identify the
+// resource a write touched, in the order they appear in the commit subject
+// (joined with "/"). It exists because the fallback list below is keyed on the
+// concept tools' vocabulary: the artifact tools identify their target with
+// "path" and the asset tools with "concept_id" plus "path", so without an entry
+// here every one of those writes committed as the bare tool name and the git
+// history could not distinguish them.
+//
+// Deliberately not shared with audit.go's auditResourceFields: that list is a
+// leakage allow-list answering "which arguments may be recorded at all", and
+// its artifact entries name fields those tools do not accept.
+var commitSubjectFields = map[string][]string{
+	"artifact_write":  {"path"},
+	"artifact_delete": {"path"},
+	"asset_write":     {"concept_id", "path"},
+	"asset_delete":    {"concept_id", "path"},
+}
+
+// commitSubjectFallback is the priority order used for any tool with no
+// commitSubjectFields entry: the first non-empty string field wins.
+var commitSubjectFallback = []string{"id", "name", "source_id", "contradiction_id"}
+
 // commitMessage builds a human-readable commit message from the tool name and
-// the first recognisable identifier found in the args map.
-// Priority: "id" > "name" > "source_id" > "contradiction_id".
-// Falls back to the tool name alone if none are present.
+// the arguments that identify what the write touched: the per-tool fields in
+// commitSubjectFields when the tool has an entry, otherwise the first
+// recognisable identifier in commitSubjectFallback.
+// Falls back to the tool name alone when no identifying argument is present.
 func commitMessage(toolName string, args json.RawMessage) string {
 	var m map[string]any
 	if err := json.Unmarshal(args, &m); err != nil {
 		return toolName
 	}
-	for _, key := range []string{"id", "name", "source_id", "contradiction_id"} {
-		if v, ok := m[key]; ok {
-			if s, ok := v.(string); ok && s != "" {
-				return fmt.Sprintf("%s: %s", toolName, s)
+	stringArg := func(key string) string {
+		s, _ := m[key].(string)
+		return s
+	}
+	if fields, ok := commitSubjectFields[toolName]; ok {
+		var parts []string
+		for _, key := range fields {
+			if s := stringArg(key); s != "" {
+				parts = append(parts, s)
 			}
+		}
+		if len(parts) > 0 {
+			return fmt.Sprintf("%s: %s", toolName, strings.Join(parts, "/"))
+		}
+		return toolName
+	}
+	for _, key := range commitSubjectFallback {
+		if s := stringArg(key); s != "" {
+			return fmt.Sprintf("%s: %s", toolName, s)
 		}
 	}
 	return toolName

--- a/internal/mcpserver/gitwrap_test.go
+++ b/internal/mcpserver/gitwrap_test.go
@@ -761,3 +761,109 @@ func TestFormatTiming(t *testing.T) {
 		})
 	}
 }
+
+// headSubject returns the subject line of HEAD in dir. The commit subject is
+// the audit trail of a git-backed KB, so the tests below assert on what landed
+// in the history rather than only on commitMessage's return value.
+func headSubject(t *testing.T, dir string) string {
+	t.Helper()
+	out, err := exec.Command("git", "-C", dir, "log", "-1", "--format=%s").Output()
+	if err != nil {
+		t.Fatalf("git log: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func TestCommitMessage_IdentifiesTheResourceForEveryWriteTool(t *testing.T) {
+	cases := []struct {
+		name string
+		tool string
+		args string
+		want string
+	}{
+		// Per-tool fields: these are the ones that used to commit as the bare
+		// tool name, leaving consecutive writes indistinguishable in the log.
+		{"artifact_write by path", "artifact_write", `{"path":"skills/kb-import/SKILL.md","content":"x"}`, "artifact_write: skills/kb-import/SKILL.md"},
+		{"artifact_delete by path", "artifact_delete", `{"path":"agents/dev.md","if_match":"abc"}`, "artifact_delete: agents/dev.md"},
+		{"asset_write by concept and path", "asset_write", `{"concept_id":"assets/owner","path":"evidence/check.txt","content":"x"}`, "asset_write: assets/owner/evidence/check.txt"},
+		{"asset_delete by concept and path", "asset_delete", `{"concept_id":"assets/owner","path":"evidence/check.txt"}`, "asset_delete: assets/owner/evidence/check.txt"},
+		{"asset_write with only concept_id", "asset_write", `{"concept_id":"assets/owner"}`, "asset_write: assets/owner"},
+		// Fallback vocabulary: unchanged behaviour.
+		{"concept_patch by id", "concept_patch", `{"id":"manutenzione/runbook","if_match":"abc"}`, "concept_patch: manutenzione/runbook"},
+		{"map_create by name", "map_create", `{"name":"notes","title":"Notes"}`, "map_create: notes"},
+		{"supersede by source_id", "supersede", `{"source_id":"a/b","target_id":"c/d"}`, "supersede: a/b"},
+		{"conflict_resolve by contradiction_id", "conflict_resolve", `{"contradiction_id":"x1"}`, "conflict_resolve: x1"},
+		// No identifying argument, and unparseable arguments.
+		{"no identifier", "snapshot", `{"message":"m"}`, "snapshot"},
+		{"empty identifier", "concept_patch", `{"id":""}`, "concept_patch"},
+		{"invalid json", "concept_patch", `not json`, "concept_patch"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := commitMessage(tc.tool, json.RawMessage(tc.args)); got != tc.want {
+				t.Errorf("commitMessage(%q, %s) = %q, want %q", tc.tool, tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGitWrap_ArtifactWriteCommitSubjectNamesThePath(t *testing.T) {
+	k, _ := setupGitKB(t)
+	k.AutoCommit = true
+	k.AllowArtifactWrite = true
+	s := New("test")
+	RegisterKBTools(s, k, Deps{})
+
+	write := s.Tools()["artifact_write"]
+	for _, slug := range []string{"one", "two"} {
+		path := "skills/" + slug + "/SKILL.md"
+		body := fmt.Sprintf("---\nname: %s\ndescription: Test skill %s.\n---\n# %s\n", slug, slug, slug)
+		args, err := json.Marshal(map[string]string{"path": path, "content": body})
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := write.Handler(authLocalContext(), json.RawMessage(args))
+		if err != nil || result.IsError {
+			t.Fatalf("artifact_write %s: result=%+v err=%v", path, result, err)
+		}
+		if got, want := headSubject(t, k.Root), "artifact_write: "+path; got != want {
+			t.Fatalf("commit subject = %q, want %q", got, want)
+		}
+	}
+	// The regression this guards: two consecutive artifact writes used to
+	// produce two identical subjects.
+	out, err := exec.Command("git", "-C", k.Root, "log", "-2", "--format=%s").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	subjects := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(subjects) != 2 || subjects[0] == subjects[1] {
+		t.Fatalf("last two subjects are not distinguishable: %q", subjects)
+	}
+}
+
+func TestGitWrap_AssetWriteCommitSubjectNamesConceptAndPath(t *testing.T) {
+	k, _ := setupGitKB(t)
+	fm, _ := okf.ParseFrontmatter("type: Note\ntitle: Asset owner")
+	if _, err := k.WriteConcept("assets/owner", fm, "# Owner\n", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := k.ExpandConcept("assets/owner"); err != nil {
+		t.Fatal(err)
+	}
+	k.AutoCommit = true
+	if _, err := k.CommitOp("test: set up asset owner"); err != nil {
+		t.Fatal(err)
+	}
+	s := New("test")
+	RegisterKBTools(s, k, Deps{})
+
+	write := s.Tools()["asset_write"]
+	result, err := write.Handler(authLocalContext(), json.RawMessage(`{"concept_id":"assets/owner","path":"evidence/check.txt","content":"check"}`))
+	if err != nil || result.IsError {
+		t.Fatalf("asset_write: result=%+v err=%v", result, err)
+	}
+	if got, want := headSubject(t, k.Root), "asset_write: assets/owner/evidence/check.txt"; got != want {
+		t.Fatalf("commit subject = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
`commitMessage` (`internal/mcpserver/gitwrap.go:246`) looked for `id`/`name`/`source_id`/`contradiction_id`, none of which the artifact and asset tools accept, so every one of their writes committed as the bare tool name and consecutive commits were indistinguishable in a KB's history.

- per-tool `commitSubjectFields`: `path` for `artifact_write`/`artifact_delete`, `concept_id/path` for `asset_write`/`asset_delete`. Every other tool keeps the previous four-key fallback, so no existing subject changes.
- **found while implementing, and fixed here**: `auditResourceFields` (`internal/mcpserver/audit.go`) named `kind`/`name` for the three `artifact_*` tools, which take only `path` — so the audit trail recorded nothing for them either. `artifact_list` takes no arguments at all, so its entry is removed; the map's own contract says silence is safe.
- `docs/concurrency.md` states the subject convention next to the local-profile commit behaviour.

## Tests

A table over `commitMessage` covering both vocabularies plus the empty and unparseable cases, and two end-to-end tests that read the subject back with `git log -1 --format=%s` after a real `artifact_write` and `asset_write`. Verified they fail on the pre-fix code with exactly the reported symptom (`commitMessage("artifact_write", …) = "artifact_write"`).

`internal/mcpserver/docs_test.go` gains `contradiction_id`/`source_id` to `docsNonTools`: the new documentation paragraph cites them as argument names, and the tool-name guard added in #60 would otherwise read them as unregistered tools.

## Verification

`make vet`, `make test`, `make smoke-http`, `make e2e` (12/12) and `make test-install` all green locally; `gofmt -l` clean.

Closes #185
