### PR TITLE
fix(client): share the sync-timer check between doctor and the connect/status hint

### DIFF
--- a/cmd/cartographer/connect.go
+++ b/cmd/cartographer/connect.go
@@ -438,17 +438,43 @@ func printConnectResult(dir string, providers []string, opts connectOptions, res
 	printSyncTimerHint(providers)
 }
 
-// printSyncTimerHint names the scheduled trigger once per invocation when a
-// provider being configured has no session hook (D140): without it, that
-// client only syncs when a human remembers to. The timer is never installed
-// automatically — see cmdServiceSyncTimer.
-func printSyncTimerHint(providers []string) {
+// providersNeedingSyncTimer returns the providers among those given that have
+// no session-start hook and are therefore covered by no trigger at all: nil
+// when every provider has a hook, and also nil when the scheduled timer is
+// installed, since that is what covers the hook-less ones (D140). The timer
+// status is returned alongside so a caller can name its path.
+//
+// One predicate, two callers — printSyncTimerHint below (connect, reconnect and
+// status) and doctor's checkTriggerCoverage — because two copies of it
+// disagreed: the hint never consulted the timer, so it advised installing a
+// trigger that was already installed and running, on the command an operator
+// reads last.
+func providersNeedingSyncTimer(providers []string) ([]string, service.SyncTimerStatus) {
 	var hookless []string
 	for _, p := range providers {
 		if !provisioning.SupportsSessionHook(configurator.Provider(p)) {
 			hookless = append(hookless, p)
 		}
 	}
+	if len(hookless) == 0 {
+		return nil, service.SyncTimerStatus{}
+	}
+	// A status that cannot be read is not evidence the timer is there, so the
+	// caller still warns.
+	st, err := syncTimerStatusFn()
+	if err == nil && st.Installed {
+		return nil, st
+	}
+	return hookless, st
+}
+
+// printSyncTimerHint names the scheduled trigger once per invocation when a
+// provider being configured has no session hook and the trigger is not already
+// installed (D140): without either, that client only syncs when a human
+// remembers to. The timer is never installed automatically — see
+// cmdServiceSyncTimer.
+func printSyncTimerHint(providers []string) {
+	hookless, _ := providersNeedingSyncTimer(providers)
 	if len(hookless) == 0 {
 		return
 	}

--- a/cmd/cartographer/doctor.go
+++ b/cmd/cartographer/doctor.go
@@ -528,19 +528,11 @@ func checkServer(dir string, cfg *clientconfig.Config, providers []string) []doc
 }
 
 // checkTriggerCoverage: a provider with no session hook syncs only when a human
-// remembers to, unless the scheduled trigger is installed (D140).
+// remembers to, unless the scheduled trigger is installed (D140). Shares its
+// predicate with printSyncTimerHint (connect.go) so the two cannot disagree.
 func checkTriggerCoverage(dir string, providers []string) []doctorFinding {
-	var hookless []string
-	for _, p := range providers {
-		if !provisioning.SupportsSessionHook(configurator.Provider(p)) {
-			hookless = append(hookless, p)
-		}
-	}
+	hookless, st := providersNeedingSyncTimer(providers)
 	if len(hookless) == 0 {
-		return nil
-	}
-	st, err := syncTimerStatusFn()
-	if err == nil && st.Installed {
 		return nil
 	}
 	path := st.Path

--- a/cmd/cartographer/synctimer_test.go
+++ b/cmd/cartographer/synctimer_test.go
@@ -4,6 +4,7 @@ package main
 // (D140).
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -80,21 +81,34 @@ func TestCmdServiceSyncTimer_Dispatch(t *testing.T) {
 	})
 }
 
-// The hint names the scheduled trigger once per invocation, and only for
-// providers that genuinely have no session hook.
+// The hint names the scheduled trigger once per invocation, only for providers
+// that genuinely have no session hook, and only when the trigger is not already
+// installed (a status the hint used to ignore, advising the installation of
+// something already running).
 func TestPrintSyncTimerHint(t *testing.T) {
+	installed := service.SyncTimerStatus{Installed: true, Path: "/tmp/com.cartographer.sync.plist"}
 	cases := []struct {
 		name      string
 		providers []string
+		status    func() (service.SyncTimerStatus, error)
 		want      bool
 		mentions  string
 	}{
-		{"hook-less provider", []string{"kiro"}, true, "kiro"},
-		{"hooked providers only", []string{"claude", "codex", "opencode"}, false, ""},
-		{"mixed", []string{"claude", "kiro"}, true, "kiro"},
+		{"hook-less provider", []string{"kiro"}, func() (service.SyncTimerStatus, error) { return service.SyncTimerStatus{}, nil }, true, "kiro"},
+		{"hooked providers only", []string{"claude", "codex", "opencode"}, func() (service.SyncTimerStatus, error) { return service.SyncTimerStatus{}, nil }, false, ""},
+		{"mixed", []string{"claude", "kiro"}, func() (service.SyncTimerStatus, error) { return service.SyncTimerStatus{}, nil }, true, "kiro"},
+		{"hook-less provider but timer installed", []string{"kiro"}, func() (service.SyncTimerStatus, error) { return installed, nil }, false, ""},
+		{"mixed and timer installed", []string{"claude", "kiro"}, func() (service.SyncTimerStatus, error) { return installed, nil }, false, ""},
+		{"timer status unreadable still warns", []string{"kiro"}, func() (service.SyncTimerStatus, error) {
+			return service.SyncTimerStatus{}, errors.New("launchctl unavailable")
+		}, true, "kiro"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			old := syncTimerStatusFn
+			t.Cleanup(func() { syncTimerStatusFn = old })
+			syncTimerStatusFn = tc.status
+
 			out := withStdout(t, func() { printSyncTimerHint(tc.providers) })
 			printed := strings.Contains(out, "sync-timer install")
 			if printed != tc.want {

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -59,7 +59,10 @@ Hook **`cartographer-bootstrap`** (reserved name, `provisioning.BootstrapHookNam
 install [--interval 30m]` registers a launchd agent (macOS) or a systemd user timer (Linux) that
 runs `cartographer sync` on an interval. It is **opt-in**: installing a background job on the
 user's machine during `connect` would be out of proportion, so `connect` and `status` only name the
-command when a connected provider has no session hook. The timer runs sync **without**
+command when a connected provider has no session hook **and** the timer is not already installed —
+the same predicate `doctor`'s `trigger` check uses, so the three commands cannot disagree about
+whether a trigger covers the client. A timer status that cannot be read is not evidence of coverage,
+so the hint is still printed. The timer runs sync **without**
 `--auto-trust` — an unattended job must not grant a trust the user never gave; the persisted
 `trust` setting in `.cartographer.yaml` still applies (D54). Logs: `~/Library/Logs/cartographer/sync.log`
 on macOS, the journal on Linux.


### PR DESCRIPTION
`doctor` and `connect`/`reconnect`/`status` answered the same question — is the scheduled sync trigger installed? — differently, and the one that was wrong spoke last: it advised installing a trigger already installed and running.

Two implementations of one rule. `checkTriggerCoverage` (`cmd/cartographer/doctor.go`) consulted `syncTimerStatusFn()`; `printSyncTimerHint` (`cmd/cartographer/connect.go`) never did — it only tested `provisioning.SupportsSessionHook`. The hint reaches more surfaces than the report of it suggested: it is called from the shared finish path used by `connect` and `reconnect` (`connect.go:438`) **and** from `status.go:157`.

- new `providersNeedingSyncTimer(providers)` returns the hook-less providers not covered by any trigger, plus the timer status so a caller can name its path. Both call sites use it, so they cannot drift again — that was the actual defect, not a missing condition.
- a timer status that cannot be read is not evidence of coverage, so the hint is still printed (matching `doctor`'s existing `err == nil && st.Installed`).
- `docs/sync.md` states the shared predicate next to the scheduled-trigger material.

## Tests

`TestPrintSyncTimerHint` gains the three cases that matter and, importantly, **stubs `syncTimerStatusFn` in every case**: it previously called the real one, so on a machine with a timer installed the test was reading host state. New cases: timer installed with a hook-less provider (silent), mixed providers with the timer installed (silent), unreadable status (still warns). Verified the two "installed" cases fail on the pre-fix code with the hint printed.

## Verification

`make vet`, `make test`, `make smoke-http`, `make e2e` (12/12) and `make test-install` all green locally; `gofmt -l` clean.

Closes #184
