### PR TITLE
fix(lint): resolve relative links against the file, and targets through the concept resolver

### DIFF
--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -403,6 +403,14 @@ cartographer import --source ./docs --kb ./kb-clone \
 | `--message` | `import: <source> -> <kb>` | Commit message; implies `--commit` |
 | `--dir-as-concept` | `false` | Promotes a source directory with `index.md` (or `README.md`) into an expanded concept and keeps its satellites together |
 
+**`import` rewrites markdown links.** Every `[text](path.md)` whose target is part of the same
+import is rewritten to the destination's relative form, computed from the file it lands in — the
+base lint uses since D149, so the importer's output no longer generates findings against itself.
+Worth knowing before building a preprocessing step in front of it: if the caller has already
+rewritten links into ID space, this pass either undoes that or leaves them unmapped. The workable
+arrangement is to stage the corpus with its final map names and run `import` with identity
+mappings, so the rewriting is a no-op. Wiki-links `[[id]]` are never touched.
+
 For every file: if it already has YAML frontmatter it's preserved, only adding missing fields;
 otherwise it synthesizes the minimum — `title` from the body's first H1 (fallback: file name), `type: Note` if absent
 (`WriteConcept` always requires it — a deviation from the original spec, see

--- a/docs/data-plane.md
+++ b/docs/data-plane.md
@@ -134,6 +134,9 @@ review_after: 2026-09-25
 Concept ID = path relative to the bundle without `.md`. File names are `kebab-case`. In journals, concepts are dated (`YYYY-MM-DD-slug`); in maps they have durable thematic names. A ConceptID never changes with expansion: `map/name` resolves to `map/name.md` or, once expanded, to `map/name/index.md`.
 
 **Links between concepts** (both syntaxes are seen by the graph, lint, and `concept_move`'s backlink-rewrite, D72 WP0): wiki-links `[[id]]` / `[[id#section]]` with **root-relative** IDs (path from the KB root without `.md`, e.g. `[[smart-home/otbr]]`); markdown links `[text](rel/path.md)` **relative to the file** containing them. The alias form `[[id|text]]` is not supported.
+**One base, and it is the file** (D149). A relative markdown link resolves against the file that contains it, exactly as a markdown viewer resolves it — so from an expanded concept's `index.md` a satellite is `[s](s.md)`, not `[s](c/s.md)`. The graph and lint use that same base; lint's existence check goes through the same resolver `concept_read` uses, so a link to the canonical ID of an expanded concept (`[c](c.md)` where `map/c/index.md` holds it) is valid rather than broken. A wiki-link `[[id]]` is root-relative and therefore base-independent, which is why it is the safe choice when in doubt.
+
+**In a curated index, both forms are accepted** for an expanded concept: `[c](c.md)` and `[c](c/index.md)` both satisfy `require_index_entry`. The two used to be inverses of each other — one valid between concepts, the other in an index — with nothing to tell them apart.
 
 ## Extended concept types
 

--- a/docs/decisions/control-plane.md
+++ b/docs/decisions/control-plane.md
@@ -562,3 +562,66 @@ with a thoroughness switch removes the choice; resolving the classification towa
 write-scoped is the honest reading, and a read-only client rewriting the server's index was
 never intended.
 
+
+## D149 — One link base and one concept resolver for lint
+
+**Status: implemented (2026-08-28).** Closes #170.
+
+**Context.** For the `index.md` of an expanded concept, no relative link form satisfied both
+`lint` and the backlink graph, because the two resolved relative links against different
+bases. `lint` derived it from the **ID** (`okf.IDToPath(id)`, which is just `id + ".md"`);
+`buildLinkAdjacency` derived it from the **file** (`walkConceptPaths`'s `physicalPath`). For a
+plain concept they coincide; for an expanded concept the ID is `map/c` (base `map/`) while the
+body lives in `map/c/index.md` (base `map/c/`).
+
+The consequence, measured on a KB with 52 expanded concepts: writing `[s](s.md)` produced
+~300 false `broken_link`; writing `[s](c/s.md)` produced 54 falsely orphaned satellites. The
+only escape was the wiki-link, which is root-relative and correct on both sides — at the cost
+of the label.
+
+A second, independent disagreement sat three lines below: the existence check was
+`ReadRaw(okf.IDToPath(target))`, a plain `os.ReadFile` with no fallback, so a link to the
+**canonical ID of an expanded concept** — the exact ID `concept_read` accepts — was reported
+broken. `resolveConceptRelPath` already existed and its own doc comment already said every
+read/write caller must resolve through it; `checkCuratedIndex` obeyed that (it calls
+`ReadConcept`), the general pass did not.
+
+Third: in a curated index, an expanded concept had to be linked `c.md`, because `c/index.md`
+extracts as the ID `map/c/index`, which is not the candidate `map/c`. That is the **inverse**
+of the inter-concept rule, with nothing to tell the two apart — 58 false `index_incomplete`
+in the field.
+
+**Decision.** `lint` resolves a body's relative links against the **physical path of the file
+that contains them**, obtained from the KB via a new exported `kb.ConceptRelPath`.
+
+The field report proposed the opposite alignment — making the graph use `IDToPath`. That is
+rejected: it would make both sides agree on `c/s.md`, a link that inside `map/c/index.md`
+points on disk at `map/c/c/s.md`, so the KB would stop rendering in GitHub, Obsidian or any
+plain-markdown viewer. **A relative link must resolve the way the filesystem resolves it.**
+The codebase already agreed in two of its three call sites: `expanded_as_category` and
+`checkCuratedIndex` both pass the physical path, and the latter's comment says so explicitly.
+Only the `broken_link` pass disagreed, with itself.
+
+Also decided:
+
+- **`Finding.Path` keeps its ID-derived value.** It is what every caller displays and sorts
+  on; the physical path is a separate local variable used only as the extraction base.
+- The existence check goes through `ReadConcept`, so `lint` and `concept_read` can no longer
+  disagree about what a valid target is. The message text is unchanged, so only the *set* of
+  targets considered present moves.
+- A curated index accepts **both** forms, by inserting the parent ID of any `.../index`
+  target into the comparison set. Deliberately not canonicalised in `ExtractLinks`: stripping
+  a trailing `/index` there would silently rewrite graph edges and break
+  `expanded_ambiguous`. A satellite literally named `index` cannot exist —
+  `walkConceptPaths` treats `map/c/index.md` as the expanded concept's own body.
+
+**Consequences.** `cartographer import` needed **no change**: it already computes the new
+link base from `path.Dir(destPath)`, i.e. the physical base, so it stops generating findings
+against its own output for free — under the report's proposal it would have needed one. That
+closes the code half of the report's A4; its documentation half is a note in
+`docs/configurator.md` §`cartographer import` saying the command rewrites links, because a
+preprocessor otherwise fights it silently.
+
+Behaviour change in lint output: a KB that adopted the `concept/satellite.md` workaround —
+correct for the old lint, wrong on disk — will see new `broken_link` findings and must move
+those links up one level or switch them to wiki-links.

--- a/internal/kb/kb.go
+++ b/internal/kb/kb.go
@@ -647,6 +647,23 @@ func (kb *KB) ReadConcept(id okf.ConceptID) (*ConceptData, error) {
 	}, nil
 }
 
+// ConceptRelPath returns the data-root-relative path of the file that actually
+// holds id, honouring the expanded-concept fallback, plus whether that concept
+// is expanded. A concept whose path cannot be resolved yields the direct form
+// okf.IDToPath(id) and false, so a caller never has to branch on an error.
+//
+// It exists for lint (D149), which must resolve a body's relative links against
+// the file that contains them: for an expanded concept the ID is "map/concept"
+// but the body lives in "map/concept/index.md", and those two bases differ by
+// one level.
+func (kb *KB) ConceptRelPath(id okf.ConceptID) (relPath string, expanded bool) {
+	rel, exp, err := kb.resolveConceptRelPath(id, false)
+	if err != nil {
+		return okf.IDToPath(id), false
+	}
+	return rel, exp
+}
+
 // resolveConceptRelPath resolves id to the relative path (from the data root)
 // of the file that actually holds it, honouring the expanded-concept
 // fallback (D77 WP2): a concept born as "<id>.md" can be expanded (see

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -170,6 +170,11 @@ func Run(k *kb.KB, scope string, scopeNeighbors bool) ([]Finding, error) {
 
 	for id, content := range toCheck {
 		relPath := okf.IDToPath(id)
+		// Relative links resolve against the file that contains them, which for
+		// an expanded concept is "<id>/index.md", not "<id>.md" (D149). relPath
+		// stays ID-derived: it is what Finding.Path reports and what callers
+		// sort on. The two coincide for a plain concept.
+		linkBase, _ := k.ConceptRelPath(id)
 		fmRaw, body, hasFM := okf.SplitFrontmatter(content)
 		parts := strings.Split(string(id), "/")
 		var allowPrefixes []string
@@ -178,9 +183,12 @@ func Run(k *kb.KB, scope string, scopeNeighbors bool) ([]Finding, error) {
 		}
 
 		// --- broken_link (warning) ---
-		for _, target := range kb.ExtractLinks(body, relPath) {
+		for _, target := range kb.ExtractLinks(body, linkBase) {
 			targetPath := okf.IDToPath(target)
-			_, readErr := k.ReadRaw(targetPath)
+			// ReadConcept honours the expanded-concept fallback, so a link to
+			// the canonical ID of an expanded concept is not broken — lint and
+			// concept_read now agree on what a valid target is (D149).
+			_, readErr := k.ReadConcept(target)
 			if readErr != nil && errors.Is(readErr, okf.ErrNotFound) {
 				findings = append(findings, Finding{
 					Path:     relPath,
@@ -588,6 +596,14 @@ func checkCuratedIndex(k *kb.KB, folder, indexPath string, candidates []okf.Conc
 	targets := map[okf.ConceptID]bool{}
 	for _, target := range kb.ExtractLinks(body, indexPath) {
 		targets[target] = true
+		// An expanded concept can be linked as "<c>/index.md", which extracts
+		// as "<map>/<c>/index" — resolvable and correct, but not the candidate
+		// ID "<map>/<c>", so the entry counted as missing. Accept both forms
+		// here rather than canonicalising in ExtractLinks, which would silently
+		// rewrite graph edges and break expanded_ambiguous (D149).
+		if parent, ok := strings.CutSuffix(string(target), "/index"); ok && parent != "" {
+			targets[okf.ConceptID(parent)] = true
+		}
 		if validateLinks {
 			if _, readErr := k.ReadConcept(target); errors.Is(readErr, okf.ErrNotFound) {
 				*findings = append(*findings, Finding{

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -923,3 +923,119 @@ func TestRun_ScopeNeighbors(t *testing.T) {
 		t.Errorf("expected broken_link for concept-b with scopeNeighbors, got: %v", findings)
 	}
 }
+
+// --- D149: one link base, one concept resolver ---
+
+// The natural form inside an expanded concept's index.md is a bare sibling
+// filename, and it is the form that resolves correctly on disk and in any
+// markdown viewer. lint used to resolve it against the ID's base and report a
+// broken link; the graph resolved it against the file and was right. This test
+// pins the direction of the alignment: making the graph use the ID base instead
+// would make this KB stop rendering, and the satellite would go orphan.
+func TestLint_ExpandedIndexRelativeLinkToSatellite(t *testing.T) {
+	k := tempKB(t)
+	writeFile(t, k.DataRoot(), "m/_map.md", "---\ntype: Map\nkind: map\ntitle: M\n---\n# M\n")
+	writeFile(t, k.DataRoot(), "m/index.md", "---\ntype: Index\ntitle: M\n---\n- [c](c.md)\n")
+	writeFile(t, k.DataRoot(), "m/c/index.md", "---\ntype: Note\ntitle: C\n---\n- [s](s.md)\n")
+	writeFile(t, k.DataRoot(), "m/c/s.md", "---\ntype: Note\ntitle: S\n---\n# S\n")
+
+	findings, err := Run(k, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range findings {
+		if f.Check == "broken_link" {
+			t.Errorf("unexpected broken_link: %s — %s", f.Path, f.Message)
+		}
+		if f.Check == "orphan" && strings.Contains(f.Path, "m/c/s") {
+			t.Errorf("satellite falsely orphaned: %s — %s", f.Path, f.Message)
+		}
+	}
+}
+
+// The mirror image, kept as an explicit test so the behaviour change cannot be
+// reverted by accident: the previously-accepted form now resolves one level too
+// deep, which is what it always did on disk.
+func TestLint_ExpandedIndexPrefixedLinkIsNowBroken(t *testing.T) {
+	k := tempKB(t)
+	writeFile(t, k.DataRoot(), "m/_map.md", "---\ntype: Map\nkind: map\ntitle: M\n---\n# M\n")
+	writeFile(t, k.DataRoot(), "m/index.md", "---\ntype: Index\ntitle: M\n---\n- [c](c.md)\n")
+	writeFile(t, k.DataRoot(), "m/c/index.md", "---\ntype: Note\ntitle: C\n---\n- [s](c/s.md)\n")
+	writeFile(t, k.DataRoot(), "m/c/s.md", "---\ntype: Note\ntitle: S\n---\n# S\n")
+
+	findings, err := Run(k, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, f := range findings {
+		if f.Check == "broken_link" && strings.Contains(f.Message, "m/c/c/s.md") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want a broken_link naming m/c/c/s.md, got %+v", findings)
+	}
+}
+
+// lint's existence check now goes through the same resolver concept_read uses,
+// so a link to the canonical ID of an expanded concept is not broken.
+func TestLint_LinkToExpandedConceptCanonicalIDIsNotBroken(t *testing.T) {
+	k := tempKB(t)
+	writeFile(t, k.DataRoot(), "m/_map.md", "---\ntype: Map\nkind: map\ntitle: M\n---\n# M\n")
+	writeFile(t, k.DataRoot(), "m/index.md", "---\ntype: Index\ntitle: M\n---\n- [a](a.md)\n- [c](c.md)\n")
+	writeFile(t, k.DataRoot(), "m/a.md", "---\ntype: Note\ntitle: A\n---\n- [c](c.md)\n")
+	writeFile(t, k.DataRoot(), "m/c/index.md", "---\ntype: Note\ntitle: C\n---\n# C\n")
+
+	findings, err := Run(k, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range findings {
+		if f.Check == "broken_link" {
+			t.Errorf("unexpected broken_link: %s — %s", f.Path, f.Message)
+		}
+	}
+}
+
+func TestLint_LinkToMissingConceptStillBroken(t *testing.T) {
+	k := tempKB(t)
+	writeFile(t, k.DataRoot(), "m/_map.md", "---\ntype: Map\nkind: map\ntitle: M\n---\n# M\n")
+	writeFile(t, k.DataRoot(), "m/a.md", "---\ntype: Note\ntitle: A\n---\n- [gone](gone.md)\n")
+
+	findings, err := Run(k, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, f := range findings {
+		if f.Check == "broken_link" && strings.Contains(f.Message, "m/gone.md") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want broken_link to m/gone.md, got %+v", findings)
+	}
+}
+
+// In a curated index an expanded concept may be linked either way. The
+// index.md form is the inverse of the inter-concept one, and requiring exactly
+// one of them produced 58 false index_incomplete findings in the field.
+func TestLint_CuratedIndexAcceptsBothExpandedForms(t *testing.T) {
+	for _, link := range []string{"- [c](c.md)\n", "- [c](c/index.md)\n"} {
+		k := tempKB(t)
+		writeFile(t, k.DataRoot(), "m/_map.md", "---\ntype: Map\nkind: map\ntitle: M\nrequire_index_entry: true\n---\n# M\n")
+		writeFile(t, k.DataRoot(), "m/index.md", "---\ntype: Index\ntitle: M\n---\n"+link)
+		writeFile(t, k.DataRoot(), "m/c/index.md", "---\ntype: Note\ntitle: C\n---\n# C\n")
+
+		findings, err := Run(k, "", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, f := range findings {
+			if f.Check == "index_incomplete" {
+				t.Errorf("link %q: unexpected index_incomplete: %s — %s", strings.TrimSpace(link), f.Path, f.Message)
+			}
+		}
+	}
+}


### PR DESCRIPTION
For the `index.md` of an expanded concept, **no relative link form satisfied both `lint` and the backlink graph**, because the two resolved relative links against different bases: `lint` from the ID (`okf.IDToPath(id)`, just `id + ".md"`), the graph from the file (`walkConceptPaths`'s `physicalPath`). The ID is `map/c` (base `map/`), the body lives in `map/c/index.md` (base `map/c/`) — they differ by one level.

Measured on a KB with 52 expanded concepts: `[s](s.md)` gave ~300 false `broken_link`; `[s](c/s.md)` gave 54 falsely orphaned satellites.

## The report's proposed fix is the wrong way round, and this inverts it

The field report proposed aligning `buildLinkAdjacency` to `IDToPath`. That makes both sides agree on `c/s.md` — a link that inside `map/c/index.md` points **on disk** at `map/c/c/s.md`, so the KB stops rendering in GitHub, Obsidian or any plain-markdown viewer. `lint` is the side that was wrong, and the codebase already agreed in two of its three call sites: `expanded_as_category` (`lint.go:411`) and `checkCuratedIndex` (`:589`, whose comment says *"indexPath is the exact physical base … so relative Markdown links resolve from the right directory"*) both pass the physical path. Only the `broken_link` pass disagreed — with itself.

## What changed

- **WP1** — new exported `kb.ConceptRelPath(id)` (delegating to the existing `resolveConceptRelPath`); `lint` extracts links against it. `Finding.Path` keeps its ID-derived value: it is what callers display and sort on.
- **WP2** — the existence check goes from `ReadRaw(IDToPath(target))` to `ReadConcept(target)`, so a link to the canonical ID of an expanded concept is valid. `lint` and `concept_read` can no longer disagree about what a valid target is. Message text unchanged.
- **WP3** — a curated index accepts **both** `c.md` and `c/index.md`, by inserting the parent ID of any `.../index` target into the comparison set. Deliberately *not* canonicalised in `ExtractLinks`: stripping a trailing `/index` there would silently rewrite graph edges and break `expanded_ambiguous`.
- **`cartographer import` needed no change.** It already computes the new base from `path.Dir(destPath)`, i.e. the physical base, so it stops generating findings against its own output for free — under the report's proposal it would have needed one. That closes the code half of report item A4.

## Tests and regression evidence

Five new tests, and on the pre-fix `lint.go` they fail with exactly the four symptoms from the report:

```
TestLint_ExpandedIndexRelativeLinkToSatellite   broken link to m/s.md
TestLint_ExpandedIndexPrefixedLinkIsNowBroken   m/c/s.md orphan: no incoming links
TestLint_LinkToExpandedConceptCanonicalIDIsNotBroken   broken link to m/c.md
TestLint_CuratedIndexAcceptsBothExpandedForms   missing curated index entry for m/c
```

`TestLint_ExpandedIndexPrefixedLinkIsNowBroken` exists so the deliberate behaviour change cannot be reverted by accident, and `TestLint_LinkToMissingConceptStillBroken` guards the message text.

## Docs

`docs/data-plane.md`: one rule — a relative link resolves against the file that contains it — plus the both-forms-accepted note for curated indexes. `docs/configurator.md` §`cartographer import`: the command rewrites markdown links, which a preprocessing step otherwise fights silently. `D149` in `docs/decisions/control-plane.md`, including why the report's direction was rejected.

## Release impact

Behaviour change in lint output: a KB that adopted the `concept/satellite.md` workaround — correct for the old lint, wrong on disk — will see new `broken_link` findings, and the remedy is to move those links up one level or switch them to wiki-links.

## Verification

`make vet`, `make test` (23 packages), `make smoke-http`, `make e2e` (12/12) and `make test-install` all green locally; `gofmt -l` clean.

Closes #170
