### PR TITLE
fix(secrets): match type Service case-insensitively and redact secret_resolve by default

### DIFF
--- a/docs/decisions/skills-services-secrets.md
+++ b/docs/decisions/skills-services-secrets.md
@@ -68,3 +68,53 @@ root `.sops.yaml` creation-rules file.
 references provide least privilege without widening the intentionally small
 frontmatter grammar. Creation rules and recipient selection remain operator
 work, while encrypted `*.sops.yaml` files are safely writable by the server.
+
+## D158 — `Service` is matched case-insensitively, and `secret_resolve` redacts by default
+
+**Status: implemented (2026-08-28).** Closes #179.
+
+**Context.** Two defects on the secrets path, one making the feature silently inert and one
+putting credentials in a transcript.
+
+`service_list` and `service_get` compared `fm.Type() != "Service"` exactly — the only two
+occurrences of the literal in non-test code. A KB whose type vocabulary is lowercase (the
+likely outcome when types come from an imported corpus, or from a non-English domain
+vocabulary) declared `type: service`, both tools returned **zero services**, secret
+resolution was unusable, and nothing reported why. In the field this cost a source-code read
+*after* 17 SOPS bundles had already been converted. Nothing in the docs said the type string
+was reserved or that its capitalisation was load-bearing.
+
+`secret_resolve` had no redacted mode: the handler already built a sorted key list and then
+interpolated the value. Verifying that resolution works therefore meant printing a
+credential into the agent transcript, and from there into whatever logs it. It happened. The
+audit layer was already careful about exactly this distinction — `auditResourceFields`
+records `secret_resolve`'s `concept_id` and deliberately excludes its `names` as "secret
+field names, not resource identifiers" — so the tool's own output was the one place that
+leaked.
+
+**Decision.**
+
+- The comparison becomes `strings.EqualFold`, **not** "any type accepted": `Service` stays
+  the reserved role, only the spelling stops mattering. That is the smallest change that
+  removes a silent failure without widening what counts as a service descriptor — a
+  near-miss like `services` is still not one.
+- The reserved type is documented, and lint reports `secrets_on_non_service` (warning) when a
+  concept declares `secrets_source` or `secret_refs` under another type, so the mistake
+  surfaces from the KB rather than from reading Go.
+- **`secret_resolve` redacts by default**, rather than offering an opt-in `keys_only`. The
+  safe behaviour has to be the default one: the unsafe default already leaked a credential
+  once, and an agent choosing the safe flag requires the agent to know the flag exists.
+  `reveal: true` returns the values.
+- `reveal` **is** recorded in the audit trail (added to `auditResourceFields`): the argument
+  name is not secret, and the decision to print a credential is exactly what an audit trail
+  is for.
+- `service_get(resolve_secrets: true)` is **unchanged**. It returns a descriptor with
+  resolved values by design and its callers are the skill-execution path, not an agent
+  transcript; changing it is a separate decision with different consequences.
+
+**Consequences.** `secret_resolve`'s default output changes, so any caller parsing
+`key=value` from it must pass `reveal: true` — the one breaking edge of this entry. The
+case-insensitive match is strictly additive: KBs that worked keep working, KBs that silently
+returned nothing start working. The regression test asserts the **absence** of the plaintext
+rather than only the presence of the placeholder, so a future change that reintroduces the
+leak fails the build.

--- a/docs/skills-services-secrets.md
+++ b/docs/skills-services-secrets.md
@@ -37,7 +37,16 @@ where appropriate and never store plaintext credentials in skill files.
 ## Service concepts
 
 Service descriptors are regular concepts under `services/` with
-`type: Service`. Frontmatter supports Cartographer's scalar/list subset, so a
+`type: Service`. **`Service` is a reserved type**, and `service_list`/`service_get`
+match it **case-insensitively** (D158): a KB whose type vocabulary is lowercase —
+a likely outcome of an import, or of a non-English domain vocabulary — used to
+get zero services and unusable secret resolution with no error anywhere. A
+near-miss such as `services` is still not a service. Lint reports
+`secrets_on_non_service` when a concept declares `secrets_source` or
+`secret_refs` under any other type, so the mistake surfaces from the KB instead
+of from a source read.
+
+Frontmatter supports Cartographer's scalar/list subset, so a
 descriptor intended for `service_get` should stay flat:
 
 ```yaml
@@ -57,7 +66,13 @@ schema beyond the normal concept and strict-map type rules.
 `service_list` inventories Service concepts. `service_get` returns one
 descriptor; with `resolve_secrets: true` it resolves declared `secret_refs`.
 Any concept may own secret references and `secret_resolve` exposes them for
-task- and dossier-scoped credentials.
+task- and dossier-scoped credentials. **It redacts by default** (D158): the
+output is the sorted key names with `<redacted>` values, which is what verifying
+that resolution works actually needs. `reveal: true` returns the values, and is
+recorded in the audit trail — printing a credential is a decision, and the
+transcript (and any log that captures it) keeps it. `names` filters the keys and
+composes with redaction, so a caller can confirm *which* of several keys resolve
+without printing any of them.
 
 ## SOPS files
 

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -254,6 +254,23 @@ func Run(k *kb.KB, scope string, scopeNeighbors bool) ([]Finding, error) {
 						})
 					}
 				}
+
+				// --- secrets_on_non_service (warning, D158) ---
+				// service_list/service_get match type Service (case-insensitively
+				// since D158): a concept declaring secrets under any other type has
+				// them unresolvable, and nothing else reported why.
+				if !strings.EqualFold(parsed.Type(), "Service") {
+					for _, field := range []string{"secrets_source", "secret_refs"} {
+						if v, ok := parsed.Get(field); ok && !emptyFrontmatterValue(v) {
+							findings = append(findings, Finding{
+								Path:     relPath,
+								Check:    "secrets_on_non_service",
+								Severity: SevWarning,
+								Message:  fmt.Sprintf("declares %s but type is %q — service_list/service_get only match type Service, so these secrets are unresolvable", field, parsed.Type()),
+							})
+						}
+					}
+				}
 			}
 		}
 		if len(parts) > 1 && archiveSet[parts[0]] {

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -1039,3 +1039,40 @@ func TestLint_CuratedIndexAcceptsBothExpandedForms(t *testing.T) {
 		}
 	}
 }
+
+// --- D158: secrets on a concept the service tools cannot see ---
+
+func TestLint_SecretsOnNonServiceConcept(t *testing.T) {
+	cases := []struct {
+		name      string
+		frontmat  string
+		wantCheck bool
+	}{
+		{"lowercase service type is fine", "type: service\ntitle: S\nsecrets_source: secrets/x.sops.yaml\n", false},
+		{"canonical Service type is fine", "type: Service\ntitle: S\nsecrets_source: secrets/x.sops.yaml\n", false},
+		{"other type with secrets_source is flagged", "type: functional\ntitle: F\nsecrets_source: secrets/x.sops.yaml\n", true},
+		{"other type with secret_refs is flagged", "type: functional\ntitle: F\nsecret_refs: [TOKEN=secrets/x.sops.yaml#/t]\n", true},
+		{"other type with no secrets is fine", "type: functional\ntitle: F\n", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			k := tempKB(t)
+			writeFile(t, k.DataRoot(), "m/_map.md", "---\ntype: Map\nkind: map\ntitle: M\n---\n# M\n")
+			writeFile(t, k.DataRoot(), "m/c.md", "---\n"+tc.frontmat+"---\n# C\n")
+
+			findings, err := Run(k, "", false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var got bool
+			for _, f := range findings {
+				if f.Check == "secrets_on_non_service" {
+					got = true
+				}
+			}
+			if got != tc.wantCheck {
+				t.Errorf("secrets_on_non_service = %v, want %v (findings %+v)", got, tc.wantCheck, findings)
+			}
+		})
+	}
+}

--- a/internal/mcpserver/audit.go
+++ b/internal/mcpserver/audit.go
@@ -57,7 +57,9 @@ var auditResourceFields = map[string][]string{
 	"service_get":     {"service_id"},
 	// secret_resolve's "names" and secret_set's "key" are secret field
 	// names, not resource identifiers — deliberately excluded.
-	"secret_resolve":       {"concept_id"},
+	// "reveal" is recorded: the argument name is not secret, and the decision
+	// to print a credential is exactly what an audit trail is for (D158).
+	"secret_resolve":       {"concept_id", "reveal"},
 	"secret_set":           {"path"},
 	"skill_install":        {"name"},
 	"conflict_resolve":     {"contradiction_id"},

--- a/internal/mcpserver/tools_secret_security_test.go
+++ b/internal/mcpserver/tools_secret_security_test.go
@@ -56,10 +56,17 @@ func TestServiceAndSecretResolveScopeDeclaredRefs(t *testing.T) {
 		t.Fatalf("unexpected refs output: %s", text)
 	}
 	writeSecretConcept(t, k.Root, "dossier", "type: Dossier\nsecret_refs:\n  - TOKEN=secrets/test.sops.yaml#/allowed\n")
+	// Redacted by default (D158): the scoping is still observable through the
+	// key names, which is what verifying resolution actually needs.
 	args, _ := json.Marshal(map[string]any{"concept_id": "dossier", "names": []string{"TOKEN"}})
 	got, _ := toolSecretResolve(k).Handler(authLocalContext(), args)
-	if got.IsError || got.Content[0].Text != "TOKEN=only-this" {
+	if got.IsError || got.Content[0].Text != "TOKEN=<redacted>" {
 		t.Fatalf("resolve=%#v", got)
+	}
+	args, _ = json.Marshal(map[string]any{"concept_id": "dossier", "names": []string{"TOKEN"}, "reveal": true})
+	got, _ = toolSecretResolve(k).Handler(authLocalContext(), args)
+	if got.IsError || got.Content[0].Text != "TOKEN=only-this" {
+		t.Fatalf("resolve with reveal=%#v", got)
 	}
 	args, _ = json.Marshal(map[string]any{"concept_id": "dossier", "names": []string{"UNKNOWN"}})
 	got, _ = toolSecretResolve(k).Handler(authLocalContext(), args)
@@ -109,5 +116,70 @@ func TestSecretSetSafetyAndRegistration(t *testing.T) {
 	}
 	if !advancedToolNames["secret_resolve"] || !advancedToolNames["secret_set"] || !ToolRequiresWrite("secret_resolve") || !ToolRequiresWrite("secret_set") {
 		t.Fatal("secret tool profile incorrect")
+	}
+}
+
+// --- D158 ---
+
+// "Service" is reserved and was compared exactly, so a KB whose type vocabulary
+// is lowercase — a likely outcome of an import, or of a non-English domain
+// vocabulary — got zero services and unusable secret resolution, with no error
+// anywhere.
+func TestServiceTools_MatchTypeCaseInsensitively(t *testing.T) {
+	for _, typ := range []string{"Service", "service", "SERVICE"} {
+		t.Run(typ, func(t *testing.T) {
+			k := setupServiceTestKB(t, "")
+			writeSecretConcept(t, k.Root, "svc", "type: "+typ+"\ntitle: Svc\n")
+			res := callServiceGet(t, k, "svc", false)
+			if res.IsError {
+				t.Fatalf("service_get with type %q = %+v, want success", typ, res.Content)
+			}
+		})
+	}
+
+	t.Run("a near-miss type is still not a service", func(t *testing.T) {
+		k := setupServiceTestKB(t, "")
+		writeSecretConcept(t, k.Root, "svc", "type: services\ntitle: Svc\n")
+		if res := callServiceGet(t, k, "svc", false); !res.IsError {
+			t.Errorf("service_get with type \"services\" = %+v, want an error", res.Content)
+		}
+	})
+}
+
+// Verifying that resolution works must not require printing a credential into
+// the transcript, so the values are redacted unless explicitly revealed.
+func TestSecretResolve_RedactsByDefault(t *testing.T) {
+	fakeSecretSOPS(t)
+	k := setupServiceTestKB(t, "/age/key")
+	writeSecretConcept(t, k.Root, "dossier", "type: Dossier\nsecret_refs:\n  - TOKEN=secrets/test.sops.yaml#/allowed\n")
+
+	args, _ := json.Marshal(map[string]any{"concept_id": "dossier"})
+	got, _ := toolSecretResolve(k).Handler(authLocalContext(), args)
+	if got.IsError {
+		t.Fatalf("secret_resolve = %+v", got.Content)
+	}
+	text := got.Content[0].Text
+	// The absence assertion is the one that makes a future regression fail the
+	// build instead of leaking.
+	if strings.Contains(text, "only-this") {
+		t.Errorf("the plaintext value leaked into the default output: %q", text)
+	}
+	if !strings.Contains(text, "TOKEN=<redacted>") {
+		t.Errorf("output = %q, want the key name with a redacted value", text)
+	}
+
+	args, _ = json.Marshal(map[string]any{"concept_id": "dossier", "reveal": true})
+	got, _ = toolSecretResolve(k).Handler(authLocalContext(), args)
+	if got.IsError || !strings.Contains(got.Content[0].Text, "TOKEN=only-this") {
+		t.Errorf("reveal:true = %+v, want the value", got.Content)
+	}
+}
+
+func TestSecretResolve_DescriptionNamesTheRedaction(t *testing.T) {
+	desc := toolSecretResolve(nil).Description
+	for _, want := range []string{"redacted", "reveal"} {
+		if !strings.Contains(desc, want) {
+			t.Errorf("description does not mention %q: %s", want, desc)
+		}
 	}
 }

--- a/internal/mcpserver/tools_skill.go
+++ b/internal/mcpserver/tools_skill.go
@@ -100,7 +100,12 @@ func toolServiceGet(k *kb.KB) Tool {
 				return errorResult(fmt.Sprintf("service_get: parse frontmatter: %v", err)), nil
 			}
 
-			if fm.Type() != "Service" {
+			// "Service" is a reserved type, matched case-insensitively: a KB whose
+			// type vocabulary is lowercase (a very likely outcome of an import, or
+			// of a non-English domain vocabulary) declared "service" and the
+			// service tools silently returned nothing, leaving secret resolution
+			// unusable with no error anywhere (D158).
+			if !strings.EqualFold(fm.Type(), "Service") {
 				return errorResult(fmt.Sprintf("service_get: %q has type %q, expected Service", params.ServiceID, fm.Type())), nil
 			}
 
@@ -200,10 +205,11 @@ func resolveFrontmatterSecrets(k *kb.KB, fm *okf.Frontmatter) (map[string]string
 }
 
 func toolSecretResolve(k *kb.KB) Tool {
-	return Tool{Name: "secret_resolve", Description: "Resolves declared SOPS secret_refs for any concept (requires rw scope).", InputSchema: json.RawMessage(`{"type":"object","required":["concept_id"],"properties":{"concept_id":{"type":"string"},"names":{"type":"array","items":{"type":"string"}}}}`), Handler: func(ctx requestContext, args json.RawMessage) (ToolResult, error) {
+	return Tool{Name: "secret_resolve", Description: "Resolves declared SOPS secret_refs for any concept (requires rw scope). Returns the key names with values redacted; pass reveal: true to return the values, which then appear in the transcript and in any log that captures it.", InputSchema: json.RawMessage(`{"type":"object","required":["concept_id"],"properties":{"concept_id":{"type":"string"},"names":{"type":"array","items":{"type":"string"}},"reveal":{"type":"boolean","description":"Return the secret values instead of <redacted>; they will appear in the transcript"}}}`), Handler: func(ctx requestContext, args json.RawMessage) (ToolResult, error) {
 		var p struct {
 			ConceptID string   `json:"concept_id"`
 			Names     []string `json:"names"`
+			Reveal    bool     `json:"reveal"`
 		}
 		if err := json.Unmarshal(args, &p); err != nil {
 			return errorResult("invalid params: " + err.Error()), nil
@@ -232,8 +238,15 @@ func toolSecretResolve(k *kb.KB) Tool {
 			}
 		}
 		sort.Strings(keys)
+		// Redacted by default (D158): verifying that resolution works must not
+		// require printing a credential into an agent transcript, and a safe
+		// behaviour that has to be opted into is not the safe default.
 		for _, n := range keys {
-			sb.WriteString(n + "=" + values[n] + "\n")
+			if p.Reveal {
+				sb.WriteString(n + "=" + values[n] + "\n")
+				continue
+			}
+			sb.WriteString(n + "=<redacted>\n")
 		}
 		return textResult(strings.TrimSuffix(sb.String(), "\n")), nil
 	}}
@@ -287,7 +300,7 @@ func toolServiceList(k *kb.KB) Tool {
 				if err != nil {
 					return nil
 				}
-				if fm.Type() != "Service" {
+				if !strings.EqualFold(fm.Type(), "Service") {
 					return nil
 				}
 				e := svcEntry{ID: string(id)}


### PR DESCRIPTION
Two defects on the secrets path: one made the feature silently inert, the other put credentials in a transcript.

## `type: Service` was reserved, case-sensitive, and documented as neither

`service_list` and `service_get` compared `fm.Type() != "Service"` exactly — the only two occurrences of the literal in non-test code. A KB whose type vocabulary is lowercase (the likely outcome of an imported corpus, or a non-English domain vocabulary) declared `type: service`, both tools returned **zero services**, secret resolution was unusable, and nothing reported why. In the field this cost a source read *after* 17 SOPS bundles had been converted.

- `strings.EqualFold`, **not** "any type accepted": `Service` stays the reserved role and only the spelling stops mattering. A near-miss like `services` is still not a service, and there is a test for that.
- new lint check `secrets_on_non_service` (warning) when a concept declares `secrets_source` or `secret_refs` under another type, so the mistake surfaces from the KB rather than from reading Go.

## `secret_resolve` printed values in clear

Verifying that resolution works meant printing a credential into the transcript, and from there into whatever logs it. The audit layer was already careful about exactly this distinction (`auditResourceFields` excludes `secret_resolve`'s `names` as "secret field names, not resource identifiers"); the tool's own output was the one place that leaked.

- **redacted by default**, not an opt-in `keys_only`: the safe behaviour has to be the default, since an agent choosing the safe flag requires the agent to know the flag exists. `reveal: true` returns the values.
- `reveal` is added to `auditResourceFields`: the argument name is not secret, and the decision to print a credential is exactly what an audit trail is for.
- `names` filtering composes with redaction, so a caller can confirm *which* keys resolve without printing any of them.
- `service_get(resolve_secrets: true)` is deliberately **unchanged**: it returns resolved values by design and its callers are the skill-execution path, not an agent transcript.

## Tests and regression evidence

`TestServiceTools_MatchTypeCaseInsensitively` (three spellings plus the near-miss), `TestLint_SecretsOnNonServiceConcept` (five cases), `TestSecretResolve_RedactsByDefault`, `TestSecretResolve_DescriptionNamesTheRedaction`. On the pre-fix code:

```
TestServiceTools_MatchTypeCaseInsensitively/service   FAIL
TestServiceTools_MatchTypeCaseInsensitively/SERVICE   FAIL
TestSecretResolve_RedactsByDefault  the plaintext value leaked into the default output: "TOKEN=only-this"
```

The redaction test asserts the **absence** of the plaintext, not just the presence of the placeholder, so a future change that reintroduces the leak fails the build. `TestServiceAndSecretResolveScopeDeclaredRefs` was asserting the old plaintext output and is updated to cover both the redacted default and `reveal: true`.

## Docs

`docs/skills-services-secrets.md`: `Service` is reserved and matched case-insensitively, with the lint check named; `secret_resolve` redacts by default and what `reveal` costs. `D158` in `docs/decisions/skills-services-secrets.md`.

## Release impact

**`secret_resolve`'s default output changes**: a caller parsing `key=value` from it must pass `reveal: true`. The case-insensitive match is strictly additive — KBs that worked keep working, KBs that silently returned nothing start working.

## Verification

`make vet`, `make test` (23 packages), `make smoke-http`, `make e2e` (12/12) and `make test-install` all green locally; `gofmt -l` clean.

Closes #179
