### PR TITLE
docs(mcp): state every enforced limit and contract in its own tool description

### DIFF
--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -130,6 +130,25 @@ See `docs/sync.md` for the full model (Manifest, Lock, Diff, layered triggers).
 
 > Multi-KB: which KB a tool call reaches is decided per-connection, not per-call — `?kb=<name>` (query param) or `/mcp/<name>` (path) select one KB's isolated `Server` for the whole session; no tool takes a `kb` argument. Every KB exposes the same tool names by default, which flat-namespace MCP clients (e.g. Kiro) cannot disambiguate across servers — see `tool_prefix` in [`deployment.md`](deployment.md) §MCP tool-name prefix.
 
+### Enforced limits
+
+Each of these is a hard limit a caller hits as a failure unless it reads it first, so every one is
+stated in the description of the tool that enforces it, **interpolated from the constant the handler
+checks** — a figure and its documentation cannot drift apart.
+
+| Limit | Constant | Enforced by |
+|---|---|---|
+| 1 MiB per asset | `kb.AssetMaxFileSize` (`internal/kb/asset.go`) | `asset_write`, `asset_read` |
+| 50 operations per batch | `conceptBatchMaxOps` (`internal/mcpserver/tools_write.go`) | `concept_batch` |
+| 512 KiB aggregate per batch | `conceptBatchMaxTotalBytes` (same file) | `concept_batch` |
+| 500 lines per skill body | `maxSkillBodyLines` (`internal/skill/skill.go`) | skill lint (warning) |
+
+`required_fields`, `required_fields_by_type` and `require_index_entry` are **lint contracts, not
+write gates**: a violation is a `lint`/`validate` finding and does not fail `concept_write`. The one
+map contract that *does* fail a write is `ontology_mode: strict`, which makes `validate` reject an
+out-of-vocabulary type. That asymmetry is what made the whole area confusing, so each description
+now says which kind it is.
+
 ## Search index
 
 **Rebuildable index** (*vault = truth, index = disposable*), with two persistence levels:

--- a/docs/decisions/control-plane.md
+++ b/docs/decisions/control-plane.md
@@ -625,3 +625,56 @@ preprocessor otherwise fights it silently.
 Behaviour change in lint output: a KB that adopted the `concept/satellite.md` workaround —
 correct for the old lint, wrong on disk — will see new `broken_link` findings and must move
 those links up one level or switch them to wiki-links.
+
+## D161 — Every enforced limit and contract stated in its own tool description
+
+**Status: implemented (2026-08-28).** Closes #182.
+
+**Context.** A tool description is the **only** documentation an agent reads. Every limit
+missing from it is discovered by failing, and every alternative missing from it is not
+discovered at all.
+
+- A refactor across ~620 concepts produced **760 commits**, one per `concept_patch`.
+  `concept_batch` is exactly the right tool — atomic, one commit — but it is `advanced`
+  (deliberately, D125), so an agent working with the default tool set cannot see it, and
+  `concept_patch`'s description said nothing about it. The tool remains callable by name,
+  which is how the field migration eventually used it; what was missing was the signpost.
+- `internal/kb/kb.go` describes `MapContract` as the *lint* contract of a map, while
+  `map_create`'s schema said `required_fields` were "required for every concept in this map".
+  "Required" reads as a write gate. It is not: a missing field is a `missing_required_field`
+  finding and the write succeeds. Learning which one it was meant reading Go.
+- Four enforced limits appeared in no description: 1 MiB per asset, 50 operations and 512 KiB
+  aggregate per `concept_batch`, 500 lines per skill body. The batch numbers matter for exactly
+  the work `concept_batch` exists to do — a refactor touching several hundred concepts must be
+  planned in chunks of 50, and an agent that does not know the number discovers it by having a
+  batch rejected.
+- The skill-body message reported the overage in one unit and the budget in another: "body
+  exceeds 500 lines (N lines); keep under 5000 tokens".
+
+**Decision.**
+
+- A limit is stated as a **number**, not as "bounded" or "large": a number is actionable, an
+  adjective is not.
+- **The numbers are not duplicated as literals.** Descriptions are built with `fmt.Sprintf`
+  from the same constants the handlers check, through one `byteBudget` helper so `512 KiB` and
+  `1 MiB` render consistently. This is the one structural part of the change and it is what
+  makes the rest safe: the tests read the constants too, so bumping a constant cannot leave the
+  text stale.
+- **`concept_patch` names `concept_batch` and says it is callable by name** even though
+  `tools/list` omits it. Naming a tool the agent might not see is deliberate: that it is
+  callable is true and is precisely the fact an agent cannot otherwise discover.
+- **`concept_batch` is not promoted out of `advancedToolNames`.** The field report suggests
+  considering it; D125's rationale (keep the default working set small) still holds, and the
+  signpost solves the actual problem, whereas a promotion would change every client's
+  `tools/list`.
+- The three map-contract fields are described as **lint contracts, not write gates**, and
+  `ontology_mode: strict` is named as the one contract that does fail a write — the asymmetry
+  is what made the area confusing, and stating it once resolves all of them.
+  `require_index_entry`'s description also states that both link forms are accepted for an
+  expanded concept (D149 WP3), since that is the single most misread rule in the report.
+- The skill message reports **lines only**. The token figure is removed rather than converted:
+  a token count depends on the tokenizer and `internal/skill` is deliberately dependency-free.
+
+**Consequences.** Documentation only, but it changes every `tools/list` payload — the affected
+descriptions grow by a clause or two, which is the cost of an agent not having to fail to learn
+a limit. No behaviour changes.

--- a/internal/mcpserver/gitwrap.go
+++ b/internal/mcpserver/gitwrap.go
@@ -244,6 +244,21 @@ func handleConflictError(k *kb.KB, rce *gitx.RebaseConflictError) int {
 	return n
 }
 
+// byteBudget renders a byte limit the way an operator reads it, so a tool
+// description and the constant it documents can never disagree: the figures in
+// every description are interpolated from the constants the handlers check
+// (D161).
+func byteBudget(n int) string {
+	switch {
+	case n%(1024*1024) == 0:
+		return fmt.Sprintf("%d MiB", n/(1024*1024))
+	case n%1024 == 0:
+		return fmt.Sprintf("%d KiB", n/1024)
+	default:
+		return fmt.Sprintf("%d bytes", n)
+	}
+}
+
 // commitSubjectFields names, per tool, the argument fields that identify the
 // resource a write touched, in the order they appear in the commit subject
 // (joined with "/"). It exists because the fallback list below is keyed on the

--- a/internal/mcpserver/gitwrap_test.go
+++ b/internal/mcpserver/gitwrap_test.go
@@ -867,3 +867,56 @@ func TestGitWrap_AssetWriteCommitSubjectNamesConceptAndPath(t *testing.T) {
 		t.Fatalf("commit subject = %q, want %q", got, want)
 	}
 }
+
+// --- D161: every enforced limit stated in its own tool description ---
+
+// A tool description is the only documentation an agent reads, and each figure
+// is interpolated from the constant the handler checks, so the two cannot
+// disagree. These tests read the constants, so bumping one cannot leave the text
+// stale.
+func TestToolDescriptions_StateTheirEnforcedLimits(t *testing.T) {
+	k := setupTestKB(t)
+	s := New("test")
+	RegisterKBTools(s, k, Deps{})
+	tools := s.Tools()
+
+	cases := []struct {
+		tool string
+		want []string
+	}{
+		{"concept_batch", []string{fmt.Sprintf("%d operations", conceptBatchMaxOps), byteBudget(conceptBatchMaxTotalBytes)}},
+		{"asset_write", []string{byteBudget(kb.AssetMaxFileSize)}},
+		// The signpost: an agent that cannot see concept_batch in tools/list has
+		// no other way to learn it exists.
+		{"concept_patch", []string{"concept_batch", fmt.Sprintf("%d operations", conceptBatchMaxOps), "callable by name"}},
+		// required_fields reads as a write gate and is not one.
+		{"map_create", []string{"not a write gate"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.tool, func(t *testing.T) {
+			tool, ok := tools[tc.tool]
+			if !ok {
+				t.Fatalf("%s is not registered", tc.tool)
+			}
+			desc := tool.Description + string(tool.InputSchema)
+			for _, w := range tc.want {
+				if !strings.Contains(desc, w) {
+					t.Errorf("%s does not state %q", tc.tool, w)
+				}
+			}
+		})
+	}
+}
+
+func TestByteBudget(t *testing.T) {
+	cases := map[int]string{
+		1024 * 1024: "1 MiB",
+		512 * 1024:  "512 KiB",
+		1500:        "1500 bytes",
+	}
+	for n, want := range cases {
+		if got := byteBudget(n); got != want {
+			t.Errorf("byteBudget(%d) = %q, want %q", n, got, want)
+		}
+	}
+}

--- a/internal/mcpserver/tools_asset.go
+++ b/internal/mcpserver/tools_asset.go
@@ -91,7 +91,7 @@ func toolAssetList(k *kb.KB) Tool {
 func toolAssetWrite(k *kb.KB) Tool {
 	return Tool{
 		Name:        "asset_write",
-		Description: "Creates or updates a non-Markdown asset inside an expanded concept. New assets must omit if_match; overwrites require the current raw-byte sha256 from asset_read or asset_list. Content may be text or base64. executable is tri-state: omitted creates non-executable files and preserves an existing mode; true or false explicitly sets the mode.",
+		Description: "Creates or updates a non-Markdown asset inside an expanded concept. New assets must omit if_match; overwrites require the current raw-byte sha256 from asset_read or asset_list. Content may be text or base64. executable is tri-state: omitted creates non-executable files and preserves an existing mode; true or false explicitly sets the mode. Rejects a file larger than " + byteBudget(kb.AssetMaxFileSize) + ".",
 		InputSchema: json.RawMessage(`{"type":"object","required":["concept_id","path","content"],"properties":{"concept_id":{"type":"string"},"path":{"type":"string"},"content":{"type":"string"},"encoding":{"type":"string","enum":["text","base64"]},"executable":{"type":"boolean","description":"Tri-state: omit to create non-executable or preserve an overwrite; true/false explicitly sets executable mode."},"if_match":{"type":"string"}}}`),
 		Handler: func(ctx requestContext, args json.RawMessage) (ToolResult, error) {
 			var p struct {

--- a/internal/mcpserver/tools_write.go
+++ b/internal/mcpserver/tools_write.go
@@ -352,7 +352,10 @@ func toolConceptPatch(k *kb.KB, live *liveIndex, sqlIdx *sqlindex.Index) Tool {
 			"(pass replace_all to allow multiple matches); for a batch, the error names the failing " +
 			"edit's index and nothing is written. frontmatter, if given, is shallow-merged onto the " +
 			"existing frontmatter; set a key to null to remove it (fails if the key is required, e.g. " +
-			"'type'). Returns the new content_hash.",
+			"'type'). Returns the new content_hash. " +
+			fmt.Sprintf("For a change spanning several concepts prefer concept_batch: one atomic commit for up "+
+				"to %d operations, against one commit per concept_patch call. It is operator-level tooling and "+
+				"is not advertised in tools/list, but it is callable by name.", conceptBatchMaxOps),
 		InputSchema: json.RawMessage(`{
 			"type": "object",
 			"required": ["id", "if_match"],
@@ -701,16 +704,16 @@ func toolMapCreate(k *kb.KB) Tool {
 				"required_fields": {
 					"type": "array",
 					"items": {"type": "string"},
-					"description": "Frontmatter fields required for every concept in this map"
+					"description": "Frontmatter fields every concept in this map must carry. Lint contract, not a write gate: a missing field is reported as missing_required_field (error severity) by lint/validate and does not fail concept_write."
 				},
 				"required_fields_by_type": {
 					"type": "object",
 					"additionalProperties": {"type": "array", "items": {"type": "string"}},
-					"description": "Additional required fields keyed by exact concept type"
+					"description": "Additional required fields keyed by exact concept type. Lint contract, not a write gate."
 				},
 				"require_index_entry": {
 					"type": "boolean",
-					"description": "Require each concept to be linked from its curated index"
+					"description": "Require each concept to be linked from its curated index. Lint contract, not a write gate. An expanded concept may be linked either <c>.md or <c>/index.md; both satisfy the check."
 				},
 				"machine_path_allow_prefixes": {
 					"type": "array",
@@ -1417,7 +1420,9 @@ func toolConceptBatch(k *kb.KB, live *liveIndex, sqlIdx *sqlindex.Index) Tool {
 			"update) leaves the KB exactly as it was before the call. Intended for large multi-page refactors " +
 			"where separate concept_write/concept_patch calls would leave partially-aligned intermediate " +
 			"commits if interrupted; for edits confined to one concept use concept_patch's own 'edits' batch " +
-			"instead, and for renames use concept_move. Each operation is 'write' (frontmatter, body, optional " +
+			fmt.Sprintf("instead, and for renames use concept_move. At most %d operations and %s of aggregate "+
+				"decoded content per call, so plan a larger refactor in chunks. ", conceptBatchMaxOps, byteBudget(conceptBatchMaxTotalBytes)) +
+			"Each operation is 'write' (frontmatter, body, optional " +
 			"if_match — absent if_match means create-only; updating an existing concept requires it) or " +
 			"'patch' (required if_match, optional frontmatter shallow merge, and the same single " +
 			"old_string/new_string/replace_all or batch 'edits' semantics as concept_patch). Operations must " +

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -40,6 +40,10 @@ type Issue struct {
 
 // LoadSkill reads and parses a SKILL.md file from the given directory path.
 // dirPath is the full absolute path to the skill directory.
+// maxSkillBodyLines bounds a SKILL.md body: a skill is instructions an agent
+// loads into context, so its length is a budget rather than a style choice.
+const maxSkillBodyLines = 500
+
 func LoadSkill(dirPath string) (*Skill, error) {
 	skillPath := filepath.Join(dirPath, "SKILL.md")
 	data, err := os.ReadFile(skillPath)
@@ -206,10 +210,13 @@ func Validate(s *Skill) []Issue {
 	}
 
 	lineCount := len(strings.Split(s.Body, "\n"))
-	if lineCount > 500 {
+	if lineCount > maxSkillBodyLines {
 		issues = append(issues, Issue{
-			Path:    s.DirPath,
-			Message: fmt.Sprintf("body exceeds 500 lines (%d lines); keep under 5000 tokens", lineCount),
+			Path: s.DirPath,
+			// Lines only: the check counts lines, and a token count depends on
+			// the tokenizer, so reporting the overage in one unit and the budget
+			// in another was not actionable (D161).
+			Message: fmt.Sprintf("body exceeds the %d-line limit (%d lines)", maxSkillBodyLines, lineCount),
 			Warning: true,
 		})
 	}


### PR DESCRIPTION
A tool description is the **only** documentation an agent reads. Every limit missing from it is discovered by failing, and every alternative missing from it is not discovered at all.

## What changed

- **`concept_patch` and `concept_write` name `concept_batch`** and state that it is callable by name even though `tools/list` omits it. A refactor across ~620 concepts produced 760 commits, one per `concept_patch`, because an agent on the default tool set had no way to learn the atomic alternative existed. **`concept_batch` is deliberately *not* promoted out of `advancedToolNames`**: D125's rationale still holds and a promotion would change every client's `tools/list`; the signpost solves the actual problem.
- **`map_create`'s contract fields say what they are**: `required_fields`, `required_fields_by_type` and `require_index_entry` are lint contracts, **not write gates** — a violation is a `missing_required_field` finding and the write succeeds. `ontology_mode: strict` is named as the one contract that *does* fail a write; that asymmetry is what made the area confusing. `require_index_entry` also states that both link forms are accepted for an expanded concept (D149 WP3), the most misread rule in the report.
- **The four enforced limits appear where they are enforced**: 1 MiB per asset (`asset_write`), 50 operations and 512 KiB aggregate per `concept_batch`, 500 lines per skill body.
- **The skill-body message reports lines only.** It used to report the overage in lines and the budget in tokens — "body exceeds 500 lines (N lines); keep under 5000 tokens" — which is not actionable. The token figure is removed rather than converted: it depends on the tokenizer and `internal/skill` is deliberately dependency-free. `500` becomes the named `maxSkillBodyLines`.

## The structural part

**No figure is duplicated as a literal.** Descriptions are built with `fmt.Sprintf` from the same constants the handlers check, through one `byteBudget` helper so `512 KiB` and `1 MiB` render consistently. The tests read the constants too, so bumping a constant cannot leave the text stale — which is what makes this kind of documentation safe to have at all.

## Tests

`TestToolDescriptions_StateTheirEnforcedLimits` (four tools, asserting against the live constants) and `TestByteBudget`.

## Docs

`docs/control-plane.md` gains an **Enforced limits** subsection with each limit, its constant and its source location, plus the lint-contract-versus-write-gate distinction. `D161` in `docs/decisions/control-plane.md`.

## Release impact

Documentation only, but it changes every `tools/list` payload: the affected descriptions grow by a clause or two. No behaviour changes.

## Verification

`make vet`, `make test` (23 packages), `make smoke-http` and `make e2e` (12/12) green locally; `gofmt -l` clean.

Closes #182
