### PR TITLE
fix(mcp): enforce tool-prefix uniqueness and align the client warning with the server

### DIFF
--- a/cmd/cartographer/connect.go
+++ b/cmd/cartographer/connect.go
@@ -572,7 +572,7 @@ func doConnect(opts connectOptions) (connectResult, error) {
 	if err != nil {
 		return connectResult{}, err
 	}
-	if w := kiroFlatNamespaceWarning(opts.Providers, entries); w != "" {
+	if w := kiroFlatNamespaceWarning(opts.Providers, entries, effectiveToolPrefixes(facts, healthErr), healthErr); w != "" {
 		configWarnings = append(configWarnings, w)
 	}
 

--- a/cmd/cartographer/multikb.go
+++ b/cmd/cartographer/multikb.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -17,6 +18,10 @@ import (
 type mcpEntry struct {
 	Name string
 	URL  string
+	// KBName is the KB this entry selects, empty for the single-KB entry that
+	// reaches the server's default endpoint. Carried so a client-side check can
+	// pair an entry with the KB facts /health reports for it (D152).
+	KBName string
 }
 
 // kbTarget is one resolved remote-KB target for a top-level administrative
@@ -154,31 +159,81 @@ func enumerateKBs(serverURL string, auth bool, tokenEnv string) (serverFacts, er
 	return facts, nil
 }
 
-// kiroFlatNamespaceWarning returns a non-empty warning when providers
-// includes kiro and entries has 2 or more entries (a multi-KB connection):
-// Kiro's MCP tool namespace is flat across servers — unlike Claude Code,
-// Codex and OpenCode, which namespace tools per server (verified empirically,
-// see the D102 issue thread) — so without a server-side tool_prefix on the
-// extra KBs, only one of them stays reachable in a Kiro session, silently.
-// enumerateKBs returns names only, so the client cannot tell whether the
-// server mounted those KBs with prefixes; making this warning prefix-aware
-// would mean plumbing GET /health's KBInfo.ToolPrefix through it to avoid one
-// stderr line of false positive. It stays unconditional on the precondition:
-// the server itself warns from what it actually mounted (D144,
-// flatNamespaceMountWarning).
-func kiroFlatNamespaceWarning(providers []string, entries []mcpEntry) string {
+// effectiveToolPrefixes turns the /health facts a caller already fetched into a
+// KB name -> effective prefix map (D120). Returns nil when the server was
+// unreachable or advertises no KB list, so a caller can tell "verified" from
+// "unknown" instead of assuming (D152). Pure: no extra round trip.
+func effectiveToolPrefixes(facts serverFacts, healthErr error) map[string]string {
+	if healthErr != nil || !facts.Listed {
+		return nil
+	}
+	out := make(map[string]string, len(facts.KBs))
+	for _, kb := range facts.KBs {
+		out[kb.Name] = kb.ToolPrefix
+	}
+	return out
+}
+
+// kiroFlatNamespaceWarning returns a non-empty warning when a provider with a
+// flat MCP tool namespace would receive two or more KBs that register their tools
+// **unprefixed**. Kiro's namespace is flat across servers — unlike Claude Code,
+// Codex and OpenCode, which namespace per server (verified empirically, see the
+// D102 issue thread) — so unprefixed KBs collide there and only one stays
+// reachable, silently.
+//
+// It adopts the server-side predicate (>= 2 unprefixed) and reads the effective
+// prefixes from GET /health, which advertises them per KB since D120. The old
+// comment here recorded that the client "cannot tell whether the server mounted
+// those KBs with prefixes" and that plumbing them through would cost "one stderr
+// line of false positive": the reasoning was sound but the premise no longer
+// holds, and the unconditional version fired on every sync of a deployment where
+// nothing was wrong — sending a maintenance session after a non-problem, on the
+// warning an operator actually reads (D152).
+//
+// prefixes maps KB name -> effective prefix. When it is nil — an unreachable
+// server, or one too old to advertise them — the warning stays unconditional and
+// says the prefixes could not be verified: a missing signal is not evidence that
+// everything is fine.
+func kiroFlatNamespaceWarning(providers []string, entries []mcpEntry, prefixes map[string]string, prefixErr error) string {
 	if len(entries) < 2 {
 		return ""
 	}
+	var flat *configurator.Descriptor
 	for _, p := range providers {
 		if d, ok := configurator.Lookup(configurator.Provider(p)); ok && d.FlatToolNamespace {
-			return fmt.Sprintf("%s has a flat MCP tool namespace across servers: writing %d MCP entries "+
-				"means only one KB's tools will be reachable in a %s session unless the server mounts the "+
-				"others with a tool_prefix (see docs/deployment.md §MCP tool-name prefix)",
-				d.Provider, len(entries), d.DisplayName)
+			flat = &d
+			break
 		}
 	}
-	return ""
+	if flat == nil {
+		return ""
+	}
+	remedies := "set kbs[].tool_prefix on them or mcp.tool_prefix_mode: kb-name (see docs/deployment.md §MCP tool-name prefix)"
+
+	if prefixes == nil {
+		reason := "the server did not advertise them"
+		if prefixErr != nil {
+			reason = prefixErr.Error()
+		}
+		return fmt.Sprintf("%s has a flat MCP tool namespace across servers: writing %d MCP entries "+
+			"means only one KB's tools will be reachable in a %s session unless the server mounts the "+
+			"others with a tool_prefix — could not read the server's effective prefixes (%s), so "+
+			"%s", flat.Provider, len(entries), flat.DisplayName, reason, remedies)
+	}
+
+	var unprefixed []string
+	for _, e := range entries {
+		if prefixes[e.KBName] == "" {
+			unprefixed = append(unprefixed, e.KBName)
+		}
+	}
+	if len(unprefixed) < 2 {
+		return ""
+	}
+	sort.Strings(unprefixed)
+	return fmt.Sprintf("%s has a flat MCP tool namespace across servers and KBs %s register identical tool "+
+		"names: only one of them stays reachable in a %s session, answering from the wrong KB — %s",
+		flat.Provider, strings.Join(quoteAll(unprefixed), ", "), flat.DisplayName, remedies)
 }
 
 // flatNamespaceMountWarning returns a non-empty warning when this server
@@ -235,7 +290,7 @@ func entriesForKBs(baseName, serverURL string, kbs []string) ([]mcpEntry, error)
 		q := entryURL.Query()
 		q.Set("kb", kb)
 		entryURL.RawQuery = q.Encode()
-		entries = append(entries, mcpEntry{Name: baseName + "-" + kb, URL: entryURL.String()})
+		entries = append(entries, mcpEntry{Name: baseName + "-" + kb, URL: entryURL.String(), KBName: kb})
 	}
 	return entries, nil
 }

--- a/cmd/cartographer/multikb_test.go
+++ b/cmd/cartographer/multikb_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -93,26 +94,69 @@ func TestDoConnect_PerKBEntries_AllProviders(t *testing.T) {
 	}
 }
 
-// TestKiroFlatNamespaceWarning covers the D102 client-side follow-up: a
-// warning fires unconditionally whenever kiro is among the target providers
-// and >=2 MCP entries are about to be written (multi-KB), and stays silent
-// otherwise (single entry, or no kiro provider).
+// TestKiroFlatNamespaceWarning covers the D152 rework: the warning fires only
+// when a flat-namespace provider would receive >=2 KBs that register their tools
+// **unprefixed**, reading the effective prefixes /health advertises (D120). The
+// pre-D152 version was unconditional on >=2 entries and fired on every sync of a
+// deployment where nothing was wrong.
 func TestKiroFlatNamespaceWarning(t *testing.T) {
-	twoEntries := []mcpEntry{{Name: "cartographer-alpha"}, {Name: "cartographer-beta"}}
-	oneEntry := []mcpEntry{{Name: "cartographer"}}
+	twoEntries := []mcpEntry{{Name: "cartographer-alpha", KBName: "alpha"}, {Name: "cartographer-beta", KBName: "beta"}}
+	threeEntries := append(append([]mcpEntry{}, twoEntries...), mcpEntry{Name: "cartographer-gamma", KBName: "gamma"})
+	oneEntry := []mcpEntry{{Name: "cartographer", KBName: "alpha"}}
+	bothUnprefixed := map[string]string{"alpha": "", "beta": ""}
+	bothPrefixed := map[string]string{"alpha": "a", "beta": "b"}
+	// Three KBs, only one unprefixed: safe, and the case that produced the
+	// reported false positive on every sync.
+	oneUnprefixed := map[string]string{"alpha": "", "beta": "b", "gamma": "g"}
 
-	if w := kiroFlatNamespaceWarning([]string{"kiro"}, twoEntries); w == "" {
-		t.Error("expected a warning: kiro provider + 2 entries")
-	}
-	if w := kiroFlatNamespaceWarning([]string{"claude", "kiro", "codex"}, twoEntries); w == "" {
-		t.Error("expected a warning: kiro among several providers + 2 entries")
-	}
-	if w := kiroFlatNamespaceWarning([]string{"kiro"}, oneEntry); w != "" {
-		t.Errorf("expected no warning for a single entry, got %q", w)
-	}
-	if w := kiroFlatNamespaceWarning([]string{"claude", "codex", "opencode"}, twoEntries); w != "" {
-		t.Errorf("expected no warning without kiro among the providers, got %q", w)
-	}
+	t.Run("two unprefixed KBs warn and are named", func(t *testing.T) {
+		w := kiroFlatNamespaceWarning([]string{"kiro"}, twoEntries, bothUnprefixed, nil)
+		if w == "" {
+			t.Fatal("expected a warning")
+		}
+		for _, name := range []string{"alpha", "beta"} {
+			if !strings.Contains(w, name) {
+				t.Errorf("warning %q does not name %q", w, name)
+			}
+		}
+		if !strings.Contains(w, "tool_prefix_mode: kb-name") {
+			t.Errorf("warning %q does not offer the global remedy", w)
+		}
+	})
+
+	t.Run("a single unprefixed KB is safe", func(t *testing.T) {
+		if w := kiroFlatNamespaceWarning([]string{"kiro"}, threeEntries, oneUnprefixed, nil); w != "" {
+			t.Errorf("expected silence with one unprefixed KB, got %q", w)
+		}
+	})
+
+	t.Run("all prefixed is silent", func(t *testing.T) {
+		if w := kiroFlatNamespaceWarning([]string{"kiro"}, twoEntries, bothPrefixed, nil); w != "" {
+			t.Errorf("expected silence, got %q", w)
+		}
+	})
+
+	t.Run("unverifiable prefixes still warn, and say why", func(t *testing.T) {
+		w := kiroFlatNamespaceWarning([]string{"kiro"}, twoEntries, nil, errors.New("connection refused"))
+		if w == "" {
+			t.Fatal("expected a warning when the prefixes cannot be read")
+		}
+		if !strings.Contains(w, "connection refused") {
+			t.Errorf("warning %q does not say why the prefixes are unknown", w)
+		}
+	})
+
+	t.Run("a single entry is silent", func(t *testing.T) {
+		if w := kiroFlatNamespaceWarning([]string{"kiro"}, oneEntry, bothUnprefixed, nil); w != "" {
+			t.Errorf("expected no warning for a single entry, got %q", w)
+		}
+	})
+
+	t.Run("no flat-namespace provider is silent", func(t *testing.T) {
+		if w := kiroFlatNamespaceWarning([]string{"claude", "codex", "opencode"}, twoEntries, bothUnprefixed, nil); w != "" {
+			t.Errorf("expected no warning without a flat-namespace provider, got %q", w)
+		}
+	})
 }
 
 // TestDoConnect_Kiro_MultiKB_WarnsFlatNamespace exercises the warning through

--- a/cmd/cartographer/serve.go
+++ b/cmd/cartographer/serve.go
@@ -256,6 +256,7 @@ func runServe(cfg *config.Config) {
 	}
 
 	seenNames := make(map[string]string) // name → first path seen
+	seenPrefixes := map[string]string{}  // resolved tool prefix -> KB name (D152)
 	var kbs []*kb.KB
 	var kbNames []string                                   // index-aligned with kbs
 	var kbToolPrefixes []string                            // index-aligned with kbs (D102, "" = unprefixed)
@@ -313,6 +314,21 @@ func runServe(cfg *config.Config) {
 		toolPrefix, err := config.ResolveToolPrefix(m.Spec, cfg.MCP.ToolPrefixMode, name)
 		if err != nil {
 			log.Fatal(err)
+		}
+		// Fail fast on a duplicate, before anything is appended: two KBs whose
+		// prefixes collide advertise identical tool names, and on a flat-namespace
+		// client one silently answers for the other (D152). Same shape as the KB
+		// name collision above, but fatal: a name clash has a safe fallback
+		// (skip the duplicate), an ambiguous prefix does not.
+		rawPrefix := m.Spec.ToolPrefix
+		if rawPrefix == "" {
+			rawPrefix = name
+		}
+		if err := config.ValidateToolPrefixUniqueness(seenPrefixes, name, toolPrefix, rawPrefix); err != nil {
+			log.Fatal(err)
+		}
+		if toolPrefix != "" {
+			seenPrefixes[toolPrefix] = name
 		}
 		k.ToolPrefix = toolPrefix
 		seenNames[name] = m.Path

--- a/cmd/cartographer/sync.go
+++ b/cmd/cartographer/sync.go
@@ -99,7 +99,7 @@ func runSync(dir string, cfg *clientconfig.Config, opts syncOptions) (syncResult
 		if err != nil {
 			return syncResult{}, err
 		}
-		if w := kiroFlatNamespaceWarning(cfg.Agents, entries); w != "" {
+		if w := kiroFlatNamespaceWarning(cfg.Agents, entries, effectiveToolPrefixes(facts, healthErr), healthErr); w != "" {
 			warnings = append(warnings, w)
 		}
 		for _, w := range warnings {

--- a/docs/decisions/transport-auth.md
+++ b/docs/decisions/transport-auth.md
@@ -419,3 +419,63 @@ without touching the protocol shape of the other tools. The report's alternative
 set with a `kb` argument per call — is a separate design that re-opens per-connection auth
 scoping (D118) and is deliberately not adopted here.
 
+
+## D152 — Tool-prefix uniqueness is enforced, and the client warning reads the prefixes
+
+**Status: implemented (2026-08-28).** Amends [D102](#d102), [D120](#d120) and [D144](#d144).
+Closes #173.
+
+**Context.** Two independent defects, both cheap, and one of them meant a deployment that had done
+everything right could still be silently ambiguous.
+
+**"Prefixed" did not imply "unambiguous".** `ResolveToolPrefix` resolved one KB's prefix in
+isolation and there was **no uniqueness check anywhere in the resolution path**. Two mechanisms
+made collisions reachable: an explicit `kbs[].tool_prefix` was never compared against the other
+KBs', and the derived form is **lossy by design** — `SanitizeToolPrefix` lowercases and collapses
+every run outside `[a-z0-9_]`, so `my-kb`, `my_kb` and `My KB` all yield `my_kb`; its own doc
+comment already showed two inputs mapping to one output. `ValidateToolPrefixShape` only checked
+non-empty and not-digit-initial. On a flat-namespace client the result is a question about KB A
+answered from KB B, with no error at call time and nothing in the logs.
+
+**Two warnings implemented one check, and the wrong one was the loud one.** The server-side
+`flatNamespaceMountWarning` fires only when **two or more** KBs actually registered unprefixed
+tools, names them, and offers both remedies — it works from what the server really mounted, so it
+is authoritative. The client-side `kiroFlatNamespaceWarning` fired whenever a flat-namespace
+client had **two or more MCP entries**, regardless of prefixes, named no KB and mentioned only the
+per-KB flag. On a deployment with three KBs and one of them unprefixed the situation was *safe* — a
+single unprefixed KB cannot collide with anything — the authoritative warning was correctly silent,
+and the client one fired on every sync. It is the one an operator reads, and it sent a maintenance
+session after a problem that did not exist.
+
+The source documented the trade-off deliberately: *"enumerateKBs returns names only, so the client
+cannot tell whether the server mounted those KBs with prefixes; making this warning prefix-aware
+would mean plumbing GET /health's KBInfo.ToolPrefix through it to avoid one stderr line of false
+positive."* The reasoning was sound and **the premise no longer held**: `/health` has advertised
+each KB's effective prefix since D120.
+
+**Decision.**
+
+- **Uniqueness is validated on the sanitised result**, since that is what creates the collisions,
+  and a duplicate is **fatal at startup** rather than a warning: it is a configuration error with
+  no safe interpretation, and `serve.go` already fails fast one branch away for a shape error. The
+  message names both KBs, the colliding prefix, and the raw input when it differs. The check runs
+  before the KB is appended, so a fatal leaves nothing half-mounted. The predicate lives in
+  `internal/config` so it is unit-testable without a server.
+- **Unprefixed KBs are exempt.** An empty prefix is the absence of one; two unprefixed KBs are the
+  case `flatNamespaceMountWarning` covers deliberately as a warning, because a
+  per-server-namespaced deployment must keep working untouched (D102). Turning that into a failure
+  is D153's decision, not this one's.
+- **The client warning adopts the server's predicate** (`>= 2` unprefixed), evaluated on `/health`
+  data the caller already fetched — `effectiveToolPrefixes` is pure, so there is no extra round
+  trip. It names the colliding KBs, as the server-side message does, and adds
+  `mcp.tool_prefix_mode: kb-name` to its remedies: mentioning only the per-KB flag is what led the
+  reporting deployment to add per-KB flags by hand instead of one global line.
+- **The client-side copy is kept rather than deleted.** It is the only warning printed at
+  `connect`/`sync` time, which is when the operator is actually looking.
+- **When `/health` cannot be read, the warning stays unconditional** and says why. A missing signal
+  must not silently become "all good" — the same rule the sync-timer check follows.
+
+**Consequences.** A previously-starting server can now fail to start, but only when two mounted KBs
+resolve to the same prefix — which was already broken, silently. `mcpEntry` gained a `KBName` field
+so an entry can be paired with the KB facts `/health` reports for it. The client warning becomes
+quieter on correct deployments, which is the point.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -197,6 +197,21 @@ KB's tools as `<prefix>__<tool>` instead of `<tool>`. Precedence: `kbs[].tool_pr
 `mcp.tool_prefix_mode`/env (global default) > off. It is off by default so that Claude
 Code/Codex/OpenCode deployments, unaffected by the problem, never see a tool rename.
 
+**Uniqueness is enforced at startup** (D152). Two mounted KBs whose **resolved, sanitised**
+prefixes are equal make the server fail fast, naming both KBs and the colliding prefix. The check
+is on the sanitised result because sanitisation is what creates collisions: `SanitizeToolPrefix` is
+lossy by design, so `my-kb`, `my_kb` and `My KB` all derive `my_kb`, and two explicit
+`kbs[].tool_prefix` values were previously never compared against each other at all. Unprefixed
+KBs are exempt — an empty prefix is the absence of one, and two unprefixed KBs remain the warning
+case below, not a failure, so a per-server-namespaced deployment keeps working untouched.
+
+The client-side warning printed by `connect`/`sync` uses the same predicate as the server's:
+it fires only when a flat-namespace provider would receive **two or more** KBs that are actually
+unprefixed, reading each KB's effective prefix from `/health` (which advertises it since D120)
+rather than guessing. When those prefixes cannot be read — an unreachable server, or one too old
+to advertise them — it still warns and says why: a missing signal is not evidence that everything
+is fine.
+
 The raw prefix is sanitized before use: lowercased, every run of characters outside `[a-z0-9_]`
 collapsed to a single `_`, leading/trailing `_` stripped. The server fails fast at startup (not at
 first tool call) if, after sanitisation, the result is empty, starts with a digit, or the resulting

--- a/internal/config/toolprefix.go
+++ b/internal/config/toolprefix.go
@@ -45,6 +45,34 @@ func ValidateToolPrefixShape(sanitized string) error {
 	return nil
 }
 
+// ValidateToolPrefixUniqueness reports an error when prefix is already taken by
+// another mounted KB. Unprefixed KBs are skipped: an empty prefix is the absence
+// of one, and two unprefixed KBs are the case flatNamespaceMountWarning covers
+// deliberately as a warning, because a per-server-namespaced client must keep
+// working untouched (D102).
+//
+// The comparison is on the **sanitised** result, because sanitisation is what
+// creates the collisions: SanitizeToolPrefix is lossy by design, so "my-kb",
+// "my_kb" and "My KB" all derive the same prefix, and two explicit
+// kbs[].tool_prefix values were never compared against each other at all. There
+// was no uniqueness check anywhere in the resolution path, so a deployment that
+// had done everything right could still be silently ambiguous (D152).
+func ValidateToolPrefixUniqueness(takenBy map[string]string, kbName, prefix, rawPrefix string) error {
+	if prefix == "" {
+		return nil
+	}
+	other, taken := takenBy[prefix]
+	if !taken {
+		return nil
+	}
+	detail := ""
+	if rawPrefix != prefix {
+		detail = fmt.Sprintf(" (derived from %q)", rawPrefix)
+	}
+	return fmt.Errorf("KB %q and KB %q resolve to the same MCP tool prefix %q%s: their tools would be indistinguishable — set a different kbs[].tool_prefix on one of them",
+		other, kbName, prefix, detail)
+}
+
 // ResolveToolPrefix determines the tool-name prefix for one KB:
 // spec.ToolPrefix (explicit, per-KB) wins over mode; mode == "kb-name"
 // derives the prefix from kbName; anything else ("off" or unset) leaves the

--- a/internal/config/toolprefix_test.go
+++ b/internal/config/toolprefix_test.go
@@ -1,6 +1,9 @@
 package config
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestSanitizeToolPrefix(t *testing.T) {
 	cases := map[string]string{
@@ -62,4 +65,65 @@ func TestResolveToolPrefix(t *testing.T) {
 			}
 		})
 	}
+}
+
+// A deployment that had done everything right could still be silently
+// ambiguous: SanitizeToolPrefix is lossy, so distinct valid KB names derive one
+// prefix, and two explicit tool_prefix values were never compared at all (D152).
+func TestValidateToolPrefixUniqueness(t *testing.T) {
+	t.Run("distinct names that sanitise to one prefix collide", func(t *testing.T) {
+		taken := map[string]string{}
+		first, err := ResolveToolPrefix(KBSpec{}, "kb-name", "ai-team")
+		if err != nil {
+			t.Fatal(err)
+		}
+		taken[first] = "ai-team"
+		second, err := ResolveToolPrefix(KBSpec{}, "kb-name", "AI Team")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if first != second {
+			t.Fatalf("expected both to sanitise to the same prefix, got %q and %q", first, second)
+		}
+		err = ValidateToolPrefixUniqueness(taken, "AI Team", second, "AI Team")
+		if err == nil {
+			t.Fatal("expected a collision error")
+		}
+		for _, want := range []string{"ai-team", "AI Team", second} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q does not name %q", err, want)
+			}
+		}
+	})
+
+	t.Run("two identical explicit prefixes collide", func(t *testing.T) {
+		taken := map[string]string{"shared": "alpha"}
+		if err := ValidateToolPrefixUniqueness(taken, "beta", "shared", "shared"); err == nil {
+			t.Error("expected a collision error for two identical explicit prefixes")
+		}
+	})
+
+	t.Run("prefixed and unprefixed do not collide", func(t *testing.T) {
+		taken := map[string]string{"alpha": "alpha"}
+		if err := ValidateToolPrefixUniqueness(taken, "beta", "", ""); err != nil {
+			t.Errorf("unprefixed KB reported a collision: %v", err)
+		}
+	})
+
+	t.Run("two unprefixed KBs do not collide", func(t *testing.T) {
+		taken := map[string]string{}
+		if err := ValidateToolPrefixUniqueness(taken, "alpha", "", ""); err != nil {
+			t.Fatal(err)
+		}
+		if err := ValidateToolPrefixUniqueness(taken, "beta", "", ""); err != nil {
+			t.Errorf("two unprefixed KBs reported a collision: %v", err)
+		}
+	})
+
+	t.Run("distinct prefixes are accepted", func(t *testing.T) {
+		taken := map[string]string{"alpha": "alpha"}
+		if err := ValidateToolPrefixUniqueness(taken, "beta", "beta", "beta"); err != nil {
+			t.Errorf("distinct prefixes reported a collision: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
Two independent defects on the tool-prefix path. Both cheap, both worth fixing regardless of whether the default ever changes, and one of them meant **a deployment that had done everything right could still be silently ambiguous**.

## 1. "Prefixed" did not imply "unambiguous"

`ResolveToolPrefix` resolved one KB's prefix in isolation, and there was **no uniqueness check anywhere in the resolution path**. An explicit `kbs[].tool_prefix` was never compared against the other KBs', and the derived form is lossy by design: `SanitizeToolPrefix` collapses every run outside `[a-z0-9_]`, so `my-kb`, `my_kb` and `My KB` all yield `my_kb` — its own doc comment already showed two inputs mapping to one output. On a flat-namespace client the result is a question about KB A answered from KB B, with no error at call time and nothing in the logs.

New `config.ValidateToolPrefixUniqueness`, consulted in the mount loop before the KB is appended: a duplicate is **fatal at startup**, naming both KBs, the colliding prefix and the raw input when it differs. Fatal rather than a warning because it is a configuration error with no safe interpretation, and `serve.go` already fails fast one branch away for a shape error. The comparison is on the **sanitised** result, since that is what creates the collisions.

**Unprefixed KBs are exempt**: an empty prefix is the absence of one, and two unprefixed KBs remain the warning case below, so a per-server-namespaced deployment (D102) keeps working untouched. Making *that* fatal is D153's decision, not this one's.

## 2. Two warnings for one check, and the wrong one was the loud one

The server-side `flatNamespaceMountWarning` fires only on **≥2 actually-unprefixed** KBs, names them, and offers both remedies. The client-side `kiroFlatNamespaceWarning` fired on **≥2 MCP entries**, regardless of prefixes, named no KB, and mentioned only the per-KB flag. On a deployment with three KBs and one unprefixed the situation was *safe*, the authoritative warning was correctly silent, and the client one fired on every sync — and it is the one an operator reads.

The old comment recorded the trade-off deliberately: the client "cannot tell whether the server mounted those KBs with prefixes", and plumbing them through would cost "one stderr line of false positive". Sound reasoning, but **the premise no longer holds**: `/health` has advertised each KB's effective prefix since D120. The client now reads it, adopts the server's `≥2 unprefixed` predicate, names the colliding KBs, and adds `mcp.tool_prefix_mode: kb-name` to its remedies — mentioning only the per-KB flag is what led the reporting deployment to add per-KB flags by hand instead of one global line.

`effectiveToolPrefixes` is **pure**: both callers already had the `/health` facts, so there is no extra round trip. When those prefixes cannot be read the warning stays unconditional and says why — a missing signal must not become "all good", the same rule the sync-timer check follows.

## Tests

`TestValidateToolPrefixUniqueness`: two names that sanitise to one prefix collide (built through `ResolveToolPrefix`, so the test proves the lossiness rather than assuming it), two identical explicit prefixes collide, prefixed+unprefixed do not, two unprefixed do not, distinct are accepted.

`TestKiroFlatNamespaceWarning` rewritten: **three KBs with one unprefixed is now silent** — the reported false positive — while two unprefixed warn and are named, all-prefixed is silent, and unverifiable prefixes still warn with the reason. The old unconditional assertions were the pre-fix behaviour.

## Docs

`docs/deployment.md` §MCP tool-name prefix: uniqueness enforced at startup, why the check is on the sanitised value, why unprefixed KBs are exempt, and what the client warning now means. `D152` in `docs/decisions/transport-auth.md`.

## Release impact

**A previously-starting server can now fail to start** — only when two mounted KBs resolve to the same prefix, which was already broken silently. `mcpEntry` gained a `KBName` field so an entry can be paired with its KB's `/health` facts.

## Verification

`make vet`, `make test` (23 packages), `make smoke-http` and `make e2e` (12/12) green locally; `gofmt -l` clean.

Closes #173
