### PR TITLE
feat(mcp)!: derive a tool prefix for every mounted KB by default

### DIFF
--- a/cmd/cartographer/serve.go
+++ b/cmd/cartographer/serve.go
@@ -311,7 +311,15 @@ func runServe(cfg *config.Config) {
 			log.Printf("warning: KB name collision %q (first: %s, duplicate: %s) — skipping duplicate", name, prev, m.Path)
 			continue
 		}
-		toolPrefix, err := config.ResolveToolPrefix(m.Spec, cfg.MCP.ToolPrefixMode, name)
+		// With one KB mounted a prefix is pure noise, so derivation is reserved
+		// for the second mount onward (D153). An explicit kbs[].tool_prefix still
+		// applies: only derivation is suppressed, which ResolveToolPrefix's own
+		// precedence gives for free once the mode is the thing we override.
+		prefixMode := cfg.MCP.ToolPrefixMode
+		if len(mounts) == 1 {
+			prefixMode = "off"
+		}
+		toolPrefix, err := config.ResolveToolPrefix(m.Spec, prefixMode, name)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -351,6 +359,11 @@ func runServe(cfg *config.Config) {
 		kbToolPrefixes = append(kbToolPrefixes, toolPrefix)
 		kbArtifactSigners = append(kbArtifactSigners, artifactSigner)
 		kbMCPAllowlists = append(kbMCPAllowlists, m.Spec.MCPAllowlist)
+		if toolPrefix != "" && m.Spec.ToolPrefix == "" {
+			// Derived, not written down by the operator: adding a second KB renames
+			// the first one's tools, and that must be loud rather than silent (D153).
+			log.Printf("KB %q mounts its tools as %s__<tool> (derived from the KB name; set mcp.tool_prefix_mode: off to keep bare names)", name, toolPrefix)
+		}
 		if m.Discovered {
 			// A discovered KB works — it serves tools, answers reads, commits
 			// writes — and looks identical to a configured one from every client

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -50,10 +50,17 @@ kbs:
                                    # mcp.tool_prefix_mode below. See docs/deployment.md
                                    # §MCP tool-name prefix.
 mcp:
-  # tool_prefix_mode: "off"        # (D102) off (default) | kb-name — global default
-                                   # applied to every KB above that doesn't set its own
-                                   # tool_prefix; kb-name derives the prefix from the
-                                   # KB's own name.
+  # tool_prefix_mode: "kb-name"    # (D102, default flipped in D153) kb-name (default) | off
+                                   # global default applied to every KB above that doesn't
+                                   # set its own tool_prefix; kb-name derives the prefix
+                                   # from the KB's own name. With one KB mounted no prefix
+                                   # is derived — it would be pure noise — so tools keep
+                                   # their bare names until a second KB appears, and that
+                                   # rename is announced at startup.
+                                   # off keeps bare names on every KB: the documented
+                                   # opt-out for a deployment that cannot absorb the
+                                   # rename, at the cost of silent wrong answers on a
+                                   # client with a flat tool namespace.
   # allowed_origins:               # (D128) browser origins allowed to reach /mcp, scheme
   #   - "https://app.example.com"  # and port included. Empty (default) accepts only an
                                    # Origin matching the request's own Host; "*" accepts

--- a/docs/decisions/transport-auth.md
+++ b/docs/decisions/transport-auth.md
@@ -479,3 +479,63 @@ each KB's effective prefix since D120.
 resolve to the same prefix — which was already broken, silently. `mcpEntry` gained a `KBName` field
 so an entry can be paired with the KB facts `/health` reports for it. The client warning becomes
 quieter on correct deployments, which is the point.
+
+## D153 — A tool prefix is the default for every mounted KB
+
+**Status: implemented (2026-08-28).** Supersedes [D102](#d102)'s default; requires
+[D152](#d152). Closes #174.
+
+**Context.** Prefixing was opt-in and its absence was silent. `mcp.tool_prefix_mode` defaulted to
+`off`, so with two or more KBs mounted every KB registered the same tool names. On a client with a
+flat tool namespace one of them wins and the others become unreachable — a question about KB A
+answered from KB B, with **no error at call time and nothing in the logs**, only a startup warning
+the operator may never read. Silent wrong answers from a plausible-looking source are the worst
+failure class a knowledge base can have, and that was the default configuration's behaviour.
+
+The portability argument is the one that bit in daily use. Because the prefix was an optional,
+server-side choice, **a tool name was not a stable identifier for a KB's capability**: the same KB
+is `concept_read` on one deployment and `<x>__concept_read` on another. That contradicts the rest of
+the model, where a concept ID is stable and portable by construction. The product already knew it —
+`generateKBInstructions` takes a `toolPrefix` and qualifies every tool name it imprints, precisely
+"so a prefixed KB does not imprint tools the agent cannot call" — but skill **bodies** get no such
+treatment: turning on a prefix for one KB forced rewriting **25 tool citations inside skill bodies
+across two KBs**, because every naked `concept_write` in a skill had silently become wrong.
+
+D102's objection was that keeping the mode off lets deployments on per-server-namespacing clients
+work untouched. That optimises for not renaming existing tools, at the price of making correctness
+depend on which client happens to connect. **A KB's identity in the tool namespace is a property of
+the KB, not of the consumer** — and the consumer that gets it wrong fails silently.
+
+**Decision.**
+
+- `Default()` returns `ToolPrefixMode: "kb-name"`. An explicit `kbs[].tool_prefix` still wins,
+  unchanged: nothing an operator wrote down is overridden.
+- **`off` is retained**, explicitly and documented, as the opt-out for single-KB deployments and
+  for anyone who cannot absorb the rename in this release. It is not deprecated here.
+- **The single-KB case is reserved.** With exactly one KB mounted a prefix is pure noise, so no
+  prefix is derived and tools keep bare names. Implemented by overriding the *mode* for that case
+  rather than by changing `ResolveToolPrefix`, which stays a pure function of (spec, mode, name) —
+  the reservation is a deployment-shape decision, not a resolution rule, and routing it through the
+  mode is what keeps an explicit `tool_prefix` working on a single-KB mount for free.
+- **A derived prefix is announced at startup**, once per KB, only when it was derived rather than
+  configured: an operator who wrote the prefix does not need telling, but adding a second KB to a
+  previously-single-KB deployment renames the first one's tools and that must be loud.
+- **Not in scope: making skill bodies prefix-independent.** A placeholder expanded at
+  materialization time (the way `{{repo:...}}` already is) would be the fix, and coupling a config
+  default to the provisioning expander in one change is how both get broken. Recorded here as
+  follow-up work rather than attempted.
+
+**Consequences.** Breaking for multi-KB deployments: tool names change on first start, so the PR
+title is a `feat:` and release-please computes a **minor** bump. The generated steering block
+follows automatically; hand-written tool citations in skill bodies do not, which the release note
+must say.
+
+A name that sanitises to empty or starts with a digit now fails fast for a KB that previously
+mounted fine, so the message names the derivation and `mcp.tool_prefix_mode: off` as the escape.
+
+Three e2e scenarios asserted on bare tool names with two KBs mounted: `10_scoped_tokens` and
+`14_rbac_visibility` pin `off` (they assert on RBAC, not on naming) and `16_prefixed_multikb` pins it
+for its mixed prefixed/unprefixed phases, then gains a fourth phase that exercises the new default
+end to end — derived prefixes on both KBs, the announcement in the log, `/health` advertising them,
+and the bare name no longer resolving. Pinning the old mode in a test is also exactly the migration
+path a real deployment takes, so the suite documents it.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -190,12 +190,26 @@ server — Claude Code, Codex, OpenCode — are unaffected by the collision. Kir
 flat tool namespace across every configured MCP server: mounting two KBs there means only one of
 them keeps its tools reachable, silently.
 
-The fix is an **opt-in, default-off** per-KB tool-name prefix: `kbs[].tool_prefix` (or the global
+Since D153 a prefix is the **default**, not an opt-in: `mcp.tool_prefix_mode` defaults to
+`kb-name`, so every KB registers its tools as `<prefix>__<tool>` derived from its own name unless
+it sets an explicit `kbs[].tool_prefix`. **With one KB mounted no prefix is derived** — it would be
+pure noise — so a single-KB deployment keeps bare tool names; adding a second KB then renames the
+first one's tools, and that rename is announced at startup rather than happening silently.
+`mcp.tool_prefix_mode: off` is retained as the documented opt-out.
+
+*Upgrading from 0.8.x:* a multi-KB deployment will see tool names change on first start. The
+generated steering block follows automatically (it is rendered with each KB's effective prefix), but
+**hand-written tool citations inside skill bodies are not rewritten** and must be updated — the
+concrete cost measured in the field was 25 citations across two KBs. Set
+`mcp.tool_prefix_mode: off` to defer the rename.
+
+The mechanism is a per-KB tool-name prefix: `kbs[].tool_prefix` (or the global
 `mcp.tool_prefix_mode: kb-name`/`CARTOGRAPHER_MCP_TOOL_PREFIX_MODE=kb-name`, which derives the
 prefix from the KB's own name for every KB that doesn't set its own `tool_prefix`) registers that
 KB's tools as `<prefix>__<tool>` instead of `<tool>`. Precedence: `kbs[].tool_prefix` (explicit) >
-`mcp.tool_prefix_mode`/env (global default) > off. It is off by default so that Claude
-Code/Codex/OpenCode deployments, unaffected by the problem, never see a tool rename.
+`mcp.tool_prefix_mode`/env (global default) > off. Before D153 it was off by default, so that Claude Code/Codex/OpenCode deployments — unaffected by
+the collision — would never see a tool rename; that optimised for not renaming tools at the price of
+making correctness depend on which client happened to connect.
 
 **Uniqueness is enforced at startup** (D152). Two mounted KBs whose **resolved, sanitised**
 prefixes are equal make the server fail fast, naming both KBs and the colliding prefix. The check

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -264,7 +264,12 @@ func Default() *Config {
 			SyncOutDebounce: 3 * time.Second,
 		},
 		ToolsProfile: "agent",
-		MCP:          MCPConfig{ToolPrefixMode: "off"},
+		// kb-name since D153: with prefixing opt-in and its absence silent, two
+		// unprefixed KBs on a flat-namespace client answered for each other with
+		// no error at call time — silent wrong answers from a plausible source,
+		// as the default configuration's behaviour. "off" is retained as an
+		// explicit, documented opt-out.
+		MCP: MCPConfig{ToolPrefixMode: "kb-name"},
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -146,7 +146,8 @@ func TestLoadFullYAML(t *testing.T) {
 		Audit:        AuditConfig{Log: "/data/audit.log", KeySeed: "deadbeef"},
 		Sops:         SopsConfig{AgeKeyFile: "/etc/cartographer/age.key", AgeKeyDir: "/etc/kb-sops-keys"},
 		ToolsProfile: "full",
-		MCP:          MCPConfig{ToolPrefixMode: "off"},
+		// The YAML sets no mcp.tool_prefix_mode, so the default applies (kb-name since D153).
+		MCP: MCPConfig{ToolPrefixMode: "kb-name"},
 	}
 
 	if !reflect.DeepEqual(cfg, want) {

--- a/test/e2e/lib/server.sh
+++ b/test/e2e/lib/server.sh
@@ -39,8 +39,12 @@ server_start() {
 		args=(serve --config "$E2E_CONFIG")
 	fi
 
+	# E2E_TOOL_PREFIX_MODE lets a scenario pin tool naming: since D153 the default
+	# is kb-name, so a multi-KB scenario asserting on bare tool names must opt out
+	# explicitly — which is also the migration path a real deployment takes.
 	CARTOGRAPHER_AUTH="${auth}" \
 	CARTOGRAPHER_TOKENS="${tokens}" \
+	CARTOGRAPHER_MCP_TOOL_PREFIX_MODE="${E2E_TOOL_PREFIX_MODE:-}" \
 		"$bin" "${args[@]}" \
         >"${E2E_TMP_DIR:-/tmp}/cartographer_e2e.log" 2>&1 &
 

--- a/test/e2e/scenarios/10_scoped_tokens.sh
+++ b/test/e2e/scenarios/10_scoped_tokens.sh
@@ -54,7 +54,10 @@ kb_make "$KB_B_DIR"
 # admin (no scope) + rw on kbA + r on kbA. Nobody has scope on kbB except admin.
 TOKENS="${ADMIN_TOKEN}, ${RW_TOKEN}|kb:${KB_A_NAME}:rw, ${R_TOKEN}|kb:${KB_A_NAME}:r"
 
-E2E_AUTH=true E2E_TOKENS="$TOKENS" \
+# This scenario asserts on RBAC, not on tool naming: pin the pre-D153 bare names
+# so a denial reads as "forbidden" rather than "tool not found". Prefixing has its
+# own coverage in 16_prefixed_multikb.sh.
+E2E_AUTH=true E2E_TOKENS="$TOKENS" E2E_TOOL_PREFIX_MODE=off \
     server_start "${KB_A_DIR},${KB_B_DIR}"
 server_wait_health 20
 

--- a/test/e2e/scenarios/14_rbac_visibility.sh
+++ b/test/e2e/scenarios/14_rbac_visibility.sh
@@ -62,7 +62,10 @@ kb_make "$KB_B_DIR"
 # to kbA only — no rule at all on kbB.
 TOKENS="${ADMIN_TOKEN}, ${A_TOKEN}|kb:${KB_A_NAME}:r"
 
-E2E_AUTH=true E2E_TOKENS="$TOKENS" \
+# This scenario asserts on RBAC, not on tool naming: pin the pre-D153 bare names
+# so a denial reads as "forbidden" rather than "tool not found". Prefixing has its
+# own coverage in 16_prefixed_multikb.sh.
+E2E_AUTH=true E2E_TOKENS="$TOKENS" E2E_TOOL_PREFIX_MODE=off \
     server_start "${KB_A_DIR},${KB_B_DIR}"
 server_wait_health 20
 

--- a/test/e2e/scenarios/16_prefixed_multikb.sh
+++ b/test/e2e/scenarios/16_prefixed_multikb.sh
@@ -60,7 +60,11 @@ kbs:
     tool_prefix: "${PREFIX}"
 YAML
 
-E2E_CONFIG="$CONFIG" server_start "${KB_PLAIN_DIR},${KB_PREFIXED_DIR}"
+# Phases 1-3 assert on the mixed prefixed/unprefixed shape, so they pin the
+# pre-D153 mode: with the kb-name default both KBs would be prefixed and there
+# would be no bare name and no collision to observe. The new default has its own
+# phase at the end.
+E2E_TOOL_PREFIX_MODE=off E2E_CONFIG="$CONFIG" server_start "${KB_PLAIN_DIR},${KB_PREFIXED_DIR}"
 server_wait_health 20
 trap 'server_stop' EXIT
 
@@ -159,7 +163,7 @@ kbs:
   - path: ${KB_PREFIXED_DIR}
     name: ${KB_PREFIXED}
 YAML
-E2E_CONFIG="$CONFIG_PLAIN" server_start "${KB_PLAIN_DIR},${KB_PREFIXED_DIR}"
+E2E_TOOL_PREFIX_MODE=off E2E_CONFIG="$CONFIG_PLAIN" server_start "${KB_PLAIN_DIR},${KB_PREFIXED_DIR}"
 server_wait_health 20
 
 assert_file_contains "$SERVER_LOG" "$COLLISION_MARKER"
@@ -171,6 +175,38 @@ assert_mcp_ok "unprefixed mount: ${KB_PLAIN} answers on the bare tool name" \
     "$(mcp_call "$BASE" "$KB_PLAIN" "" "$(call_body atlas_overview)")"
 assert_mcp_ok "unprefixed mount: ${KB_PREFIXED} answers on the bare tool name" \
     "$(mcp_call "$BASE" "$KB_PREFIXED" "" "$(call_body atlas_overview)")"
+
+echo ""
+echo "--- Phase 4: the kb-name default prefixes every KB, and says so (D153) ---"
+
+# Same two KBs, no mcp.tool_prefix_mode anywhere: the default applies.
+server_stop
+E2E_CONFIG="$CONFIG_PLAIN" server_start "${KB_PLAIN_DIR},${KB_PREFIXED_DIR}"
+server_wait_health 20
+
+DERIVED_PLAIN="$(printf '%s' "$KB_PLAIN" | tr 'A-Z' 'a-z' | tr -c 'a-z0-9_' '_' | sed 's/__*/_/g; s/^_//; s/_$//')"
+DERIVED_PREFIXED="$(printf '%s' "$KB_PREFIXED" | tr 'A-Z' 'a-z' | tr -c 'a-z0-9_' '_' | sed 's/__*/_/g; s/^_//; s/_$//')"
+
+# No collision to warn about any more: both KBs are prefixed.
+assert_file_not_contains "$SERVER_LOG" "$COLLISION_MARKER"
+# A derived prefix is announced, because adding a KB renames the others' tools.
+assert_file_contains "$SERVER_LOG" "derived from the KB name"
+
+HEALTH_DEFAULT="${DIR}/health-default.json"
+curl -s "http://127.0.0.1:${E2E_HTTP_PORT}/health" -o "$HEALTH_DEFAULT"
+assert_file_contains "$HEALTH_DEFAULT" '"tool_prefix":"'"${DERIVED_PLAIN}"'"'
+
+assert_mcp_ok "kb-name default: ${KB_PLAIN} answers on its derived prefixed name" \
+    "$(mcp_call "$BASE" "$KB_PLAIN" "" "$(call_body "${DERIVED_PLAIN}__atlas_overview")")"
+assert_mcp_ok "kb-name default: ${KB_PREFIXED} answers on its derived prefixed name" \
+    "$(mcp_call "$BASE" "$KB_PREFIXED" "" "$(call_body "${DERIVED_PREFIXED}__atlas_overview")")"
+
+BARE_UNDER_DEFAULT="$(mcp_call "$BASE" "$KB_PLAIN" "" "$(call_body atlas_overview)")"
+if grep -q "tool not found" <<< "$BARE_UNDER_DEFAULT"; then
+    _assert_pass "kb-name default: the bare tool name no longer resolves"
+else
+    _assert_fail "kb-name default: bare tool name unexpectedly resolved: ${BARE_UNDER_DEFAULT}"
+fi
 
 echo ""
 if [[ "${E2E_FAILURES}" -eq 0 ]]; then


### PR DESCRIPTION
**Breaking for multi-KB deployments: tool names change on first start.** `feat:` so release-please computes a minor bump.

## Why

Prefixing was opt-in and its absence was silent. With `mcp.tool_prefix_mode: off` (the default) and two or more KBs mounted, every KB registered the same tool names. On a client with a flat tool namespace one wins and the others become unreachable — a question about KB A answered from KB B, with **no error at call time and nothing in the logs**, only a startup warning the operator may never read. Silent wrong answers from a plausible-looking source are the worst failure class a knowledge base can have, and that was the default's behaviour.

The portability argument is the one that bit daily: because the prefix was a server-side choice, **a tool name was not a stable identifier for a KB's capability**. The product already knew it — `generateKBInstructions` qualifies every tool name it imprints, "so a prefixed KB does not imprint tools the agent cannot call" — but skill *bodies* get no such treatment, so turning on a prefix for one KB forced rewriting **25 tool citations inside skill bodies across two KBs**.

D102 kept the mode off so per-server-namespacing clients would see no rename. That optimises for not renaming tools at the price of making correctness depend on which client happens to connect. **A KB's identity in the tool namespace is a property of the KB, not of the consumer.**

## What changed

- `Default()` returns `ToolPrefixMode: "kb-name"`. An explicit `kbs[].tool_prefix` still wins.
- **`off` is retained** as the documented opt-out, not deprecated.
- **The single-KB case is reserved**: with one KB mounted no prefix is derived, since it would be pure noise. Implemented by overriding the *mode* for that case rather than changing `ResolveToolPrefix`, which stays a pure function of (spec, mode, name) — that also keeps an explicit `tool_prefix` working on a single-KB mount for free.
- **A derived prefix is announced at startup**, only when derived rather than configured: adding a second KB renames the first one's tools, and that must be loud.

**Deliberately not in scope:** making skill bodies prefix-independent (a placeholder expanded at materialization time, as `{{repo:...}}` already is). Coupling a config default to the provisioning expander in one change is how both get broken; it is recorded as follow-up in the D entry.

## Tests

Three e2e scenarios asserted on bare tool names with two KBs mounted, so they broke — which is the breaking change proving itself. `10_scoped_tokens` and `14_rbac_visibility` now pin `E2E_TOOL_PREFIX_MODE=off`: they assert on RBAC, not on naming, and a denial must read as `forbidden` rather than `tool not found`. `16_prefixed_multikb` pins it for its mixed prefixed/unprefixed phases and **gains a fourth phase exercising the new default end to end**: derived prefixes on both KBs, the announcement in the server log, `/health` advertising them, and the bare name no longer resolving.

Pinning the old mode in a test is also exactly the migration path a real deployment takes, so the suite documents it. New `E2E_TOOL_PREFIX_MODE` knob in `test/e2e/lib/server.sh`. `TestLoadFullYAML` asserted the old default and is updated.

## Docs

`config.example.yaml` and `docs/deployment.md` §MCP tool-name prefix: the new default, the single-KB reservation, the `off` opt-out, and an **upgrading from 0.8.x** paragraph naming the one thing that is *not* rewritten for you — hand-written tool citations in skill bodies. `D153` in `docs/decisions/transport-auth.md`.

## Verification

`make vet`, `make test` (23 packages), `make smoke-http`, `make e2e` (12/12, including the new phase) and `make test-install` all green locally; `gofmt -l` clean.

Closes #174
