### PR TITLE
feat(doctor): backfill managed-file hashes in place with --repair-hashes

### DIFF
--- a/cmd/cartographer/doctor.go
+++ b/cmd/cartographer/doctor.go
@@ -70,6 +70,7 @@ func cmdDoctor(args []string) int {
 	fs := flag.NewFlagSet("doctor", flag.ExitOnError)
 	asJSON := fs.Bool("json", false, "Emit the findings as JSON")
 	provider := fs.String("provider", "", "Narrow the run to one provider")
+	repairHashes := fs.Bool("repair-hashes", false, "Re-record the content hash of managed artifacts that have none, from the bytes already on disk (D157)")
 	fs.Parse(args)
 
 	dir, err := clientconfig.TargetDir()
@@ -84,6 +85,10 @@ func cmdDoctor(args []string) int {
 		}
 	}
 
+	if *repairHashes {
+		return repairManagedHashes(dir, *provider)
+	}
+
 	report := runDoctor(dir, *provider)
 	code := doctorExitCode(report)
 	if *asJSON {
@@ -95,6 +100,50 @@ func cmdDoctor(args []string) int {
 		printDoctorReport(report)
 	}
 	return code
+}
+
+// repairManagedHashes backfills the materialized hash of every managed entry that
+// has none, from the bytes on disk, and persists the lockfile (D157). Narrow on
+// purpose: the alternative on offer was `reconnect`, which prunes and rewrites
+// every managed artifact on every client — in the field ~150 file operations to
+// backfill six hashes, with a partial failure leaving both clients without skills.
+func repairManagedHashes(dir, only string) int {
+	lf, err := provisioning.ReadLockFile(lockFilePath(dir))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error: read lockfile:", err)
+		return 2
+	}
+	total := 0
+	for providerName, lock := range lf.Providers {
+		if only != "" && providerName != only {
+			continue
+		}
+		repaired, skipped, repairErr := provisioning.RepairManagedHashes(lock, configurator.Provider(providerName), dir, false)
+		if repairErr != nil {
+			fmt.Fprintf(os.Stderr, "Error: repair %s: %v\n", providerName, repairErr)
+			return 2
+		}
+		for _, mf := range repaired {
+			fmt.Printf("[%s] re-recorded %s/%s from disk\n", providerName, mf.Kind, mf.Name)
+		}
+		for _, sk := range skipped {
+			// A missing file is real drift for `sync` to fix, not something to
+			// paper over with a hash of nothing.
+			fmt.Printf("[%s] skipped %s/%s: %s\n", providerName, sk.Kind, sk.Name, sk.Reason)
+		}
+		total += len(repaired)
+		lf.Providers[providerName] = lock
+	}
+	if total == 0 {
+		fmt.Println("no unverifiable managed artifacts")
+		return 0
+	}
+	if err := provisioning.WriteLockFile(lockFilePath(dir), lf); err != nil {
+		fmt.Fprintln(os.Stderr, "Error: write lockfile:", err)
+		return 2
+	}
+	fmt.Printf("re-recorded %d managed artifact(s); they are adopted, not verified against the server\n", total)
+	return 0
 }
 
 // doctorExitCode maps a report to the exit code: 0 clean, 1 findings. Purely
@@ -304,7 +353,11 @@ func checkManagedFiles(dir string, providers []string, lockFile provisioning.Loc
 		out = append(out, doctorFinding{
 			Check: "managed-files", Severity: doctorInfo, Path: lockFilePath(dir),
 			Message: fmt.Sprintf("%d managed artifact(s) recorded before content hashes existed cannot be verified", unknown),
-			Fix:     "cartographer reconnect",
+			// The content is already on disk and the hash is computable without
+			// refetching anything, so the proportionate remedy is to re-record
+			// it — `reconnect` rewrites every managed artifact on every client,
+			// three orders of magnitude more work than the problem (D157).
+			Fix: "cartographer doctor --repair-hashes (rebuild everything only if you actually want to: cartographer reconnect)",
 		})
 	}
 	return out

--- a/cmd/cartographer/doctor_test.go
+++ b/cmd/cartographer/doctor_test.go
@@ -338,7 +338,10 @@ func TestSortDoctorFindings(t *testing.T) {
 // The suggested command must therefore be the rebuild, not the sync: a
 // diagnosis that names a command which does not resolve it is exactly the
 // noise D143 forbids.
-func TestRunDoctor_UnknownHashSuggestsRebuild(t *testing.T) {
+// The remedy is now the narrow one: the content is on disk and the hash is
+// computable without refetching anything, so rewriting every managed artifact on
+// every client is three orders of magnitude more work than the problem (D157).
+func TestRunDoctor_UnknownHashSuggestsRepairHashes(t *testing.T) {
 	doctorStubs(t, []string{"claude"}, false)
 	dir := doctorFixture(t, "claude")
 
@@ -363,8 +366,48 @@ func TestRunDoctor_UnknownHashSuggestsRebuild(t *testing.T) {
 	if found[0].Severity != doctorInfo {
 		t.Errorf("severity = %q, want %q", found[0].Severity, doctorInfo)
 	}
-	if found[0].Fix != "cartographer reconnect" {
-		t.Errorf("fix = %q, want the rebuild: a sync leaves these entries untouched", found[0].Fix)
+	if !strings.Contains(found[0].Fix, "--repair-hashes") {
+		t.Errorf("fix = %q, want the narrow remedy", found[0].Fix)
+	}
+
+	// The round trip: repairing clears the finding, and the entries are marked
+	// adopted rather than silently passing as verified.
+	out := withStdout(t, func() {
+		if code := repairManagedHashes(dir, ""); code != 0 {
+			t.Errorf("repairManagedHashes = %d, want 0", code)
+		}
+	})
+	if !strings.Contains(out, "adopted, not verified") {
+		t.Errorf("output %q does not say the entries are adopted", out)
+	}
+	if again := findingsFor(runDoctor(dir, ""), "managed-files"); len(again) != 0 {
+		t.Errorf("finding survived the repair: %+v", again)
+	}
+	repaired, err := provisioning.ReadLockFile(lockFilePath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mf := range repaired.ForProvider("claude").Managed {
+		if mf.MaterializedHash == "" {
+			t.Errorf("entry %s/%s still has no hash", mf.Kind, mf.Name)
+		}
+		if mf.AdoptedAt == "" {
+			t.Errorf("entry %s/%s is not marked adopted", mf.Kind, mf.Name)
+		}
+	}
+}
+
+// Nothing to repair is a clean, explicit outcome rather than silence.
+func TestRepairManagedHashes_NothingToDo(t *testing.T) {
+	doctorStubs(t, []string{"claude"}, false)
+	dir := doctorFixture(t, "claude")
+	out := withStdout(t, func() {
+		if code := repairManagedHashes(dir, ""); code != 0 {
+			t.Errorf("repairManagedHashes = %d, want 0", code)
+		}
+	})
+	if !strings.Contains(out, "no unverifiable managed artifacts") {
+		t.Errorf("output = %q", out)
 	}
 }
 

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -319,6 +319,8 @@ version difference); `info` — context that cannot be acted on by itself and ne
 code (managed entries recorded before content hashes existed, which nothing can verify). Findings
 are printed errors first.
 
+**`doctor --repair-hashes`** re-records the materialized hash of every managed entry that has none, computing it from the bytes already on disk (D157). It exists because the previous remedy for that narrow gap was `reconnect`, which prunes and rewrites **every** managed artifact on every client — in the field ~150 file operations to backfill six hashes, with a partial failure leaving both clients without skills. A backfilled entry is marked `adopted_at` in the lockfile: it is **adopted, not verified** — nothing was compared against the server, so drift is detectable only from the next server-side change onward. An entry whose file is *missing* is left alone: that is real drift for `sync` to fix, not something to paper over.
+
 **Exit codes**: `0` clean, `1` findings (error or warning), `2` an error running the command — the
 same convention `status` uses. An unreachable server is one `warning` finding, not a failure:
 `doctor` stays useful offline.

--- a/docs/decisions/client-configurator.md
+++ b/docs/decisions/client-configurator.md
@@ -588,3 +588,57 @@ Rejected: dropping the MCP-entry line whenever `ConfigsWritten` is empty. It rea
 couples an MCP claim to an unrelated emptiness — a provider that writes its entry into a file
 already containing it would lose the line for the wrong reason. The predicate is "does this provider
 have an emitter", so that is what the code asks.
+
+## D157 — Backfill managed-file hashes in place instead of rebuilding every client
+
+**Status: implemented (2026-08-28).** Amends [D138](sync-provisioning.md#d138) and
+[D139](sync-provisioning.md#d139). Closes #178.
+
+**Context.** `doctor`'s only prescribed remedy for a narrow metadata gap was a full client
+rebuild:
+
+```
+info [managed-files] 6 managed artifact(s) recorded before content hashes existed
+     cannot be verified — …/.cartographer-sync.lock.json
+     fix: cartographer reconnect
+```
+
+Its reasoning was correct on every point: an entry with no materialized hash is `DriftUnknown`,
+deliberately not healable — healing it would mean overwriting whatever is on disk on the strength
+of no evidence — and `ComputeDiff` sees no change either, so `sync` leaves it alone.
+
+The gap was the leap from *"cannot be compared"* to *"must be rebuilt"*. `reconnect` prunes and
+rewrites **every** managed artifact on **every** client: in the field 28 and 29 skill trees, both
+steering files, the hook directory and the MCP entries — roughly 150 file operations to backfill
+**six** hashes. It worked and it was recoverable, but the blast radius was three orders of
+magnitude larger than the problem, and a partial failure would have left both clients without
+skills. There was no narrower option: `reconnect` takes only `-agents` and `-dry-run`.
+
+**The content is already on disk and the hash is computable without refetching anything.** That is
+the whole fix.
+
+**Decision.**
+
+- **Backfilling is not healing.** It records what is on disk *as* the baseline; it does not claim
+  the file matches the server. A backfilled entry carries `adopted_at`, so a later genuine drift is
+  still detectable from the next server-side change onward, and an operator can tell a verified
+  entry from an adopted one. The command says so in as many words.
+- **It is an explicit command, `cartographer doctor --repair-hashes`, not implicit in `sync`.**
+  Doing it silently inside a sync would make an unverifiable entry become verified with no record
+  of the decision — exactly the ambiguity `DriftUnknown` exists to prevent.
+- **Only entries whose file exists are backfilled.** A missing file is already `DriftMissing`, a
+  real finding for `sync` to fix, and hashing nothing would paper it over. A symlinked destination
+  is skipped too, deferring to [D148](sync-provisioning.md#d148): Cartographer does not hash a file
+  it refuses to own.
+- **The hash is computed exactly the way `Apply` records `materializedHash`** — same
+  `hashArtifactFiles`, same ordered set of files, including the executable bit. A value computed any
+  other way would never match a future `Apply`, turning an unverifiable entry into a permanently
+  drifted one, which is worse than the gap.
+- **`reconnect` is unchanged.** It remains the right tool for a genuine rebuild; this adds a
+  narrower one beside it and changes `doctor`'s prescription for this one finding.
+- **No new file format**: the lockfile is already v2 with a per-entry hash, so backfilling writes
+  the same field plus one optional timestamp.
+
+**Consequences.** Additive: one new flag, one changed `doctor` message, one new optional lockfile
+field that older clients must ignore. The round trip — finding → `--repair-hashes` → finding
+gone — is covered by a single test, so the loop cannot regress.

--- a/internal/provisioning/provisioning.go
+++ b/internal/provisioning/provisioning.go
@@ -102,6 +102,12 @@ type ManagedFile struct {
 	// Empty means "unknown": lockfiles written before D138, and entries with
 	// no materialized file of their own (kind "mcp", dry runs).
 	MaterializedHash string `json:"materialized_hash,omitempty"`
+	// AdoptedAt marks an entry whose MaterializedHash was backfilled from the
+	// bytes on disk by `doctor --repair-hashes` (D157) rather than recorded when
+	// the file was written. It is *adopted*, not *verified*: nothing was compared
+	// against the server, so drift is detectable only from the next server-side
+	// change onward. RFC3339, empty for a normally-recorded entry.
+	AdoptedAt string `json:"adopted_at,omitempty"`
 }
 
 // Lock is the client's lockfile: applied revision + managed files.

--- a/internal/provisioning/verify.go
+++ b/internal/provisioning/verify.go
@@ -14,10 +14,13 @@ package provisioning
 // been deleted.
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/BeppeTemp/cartographer/internal/configurator"
 )
@@ -73,6 +76,111 @@ func (f DriftFinding) Healable() bool {
 //     the surrounding file is never rewritten on a content difference.
 //
 // Nothing outside lock.Managed is ever read.
+// RepairManagedHashes re-records the content hash of every managed entry that has
+// none, computing it from the bytes already on disk (D157).
+//
+// The gap it closes is narrow: entries written before materialized hashes existed
+// are DriftUnknown, deliberately not healable, and ComputeDiff sees no change
+// either — so `sync` leaves them alone and the only remedy on offer was
+// `reconnect`, which prunes and rewrites **every** managed artifact on every
+// client. In the field that was ~150 file operations to backfill six hashes, with
+// a partial failure leaving both clients without skills.
+//
+// Backfilling is **not healing**: it records what is on disk as the baseline, and
+// does not claim the file matches the server. An adopted entry is marked with
+// AdoptedAt so a later genuine drift is still detectable from the next
+// server-side change onward, and so an operator can tell a verified entry from an
+// adopted one.
+//
+// Entries whose file is missing are left alone: that is DriftMissing, a real
+// finding for `sync` to fix, not something to paper over.
+func RepairManagedHashes(lock Lock, provider configurator.Provider, baseDir string, dryRun bool) (repaired []ManagedFile, skipped []DriftFinding, err error) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	for i := range lock.Managed {
+		mf := lock.Managed[i]
+		// MaterializedHash is the field verifyArtifact needs for the content
+		// comparison; ContentHash is what ComputeDiff compares against the
+		// manifest and is not this function's business.
+		if mf.MaterializedHash != "" {
+			continue
+		}
+		rel, full, ok := managedDest(mf, provider, baseDir)
+		if !ok {
+			// The provider does not support this kind: nothing to hash, and not
+			// an error.
+			continue
+		}
+		if isSymlink(full) {
+			skipped = append(skipped, DriftFinding{Kind: mf.Kind, Name: mf.Name, Path: rel, Reason: "destination is a symlink"})
+			continue
+		}
+		files, readErr := readManagedFiles(mf, full)
+		switch {
+		case errors.Is(readErr, fs.ErrNotExist):
+			skipped = append(skipped, DriftFinding{Kind: mf.Kind, Name: mf.Name, Path: rel, Reason: DriftMissing})
+			continue
+		case readErr != nil:
+			skipped = append(skipped, DriftFinding{Kind: mf.Kind, Name: mf.Name, Path: rel, Reason: readErr.Error()})
+			continue
+		}
+		// Hashed exactly the way Apply records materializedHash, over the same
+		// ordered set of files: a value computed any other way would never match
+		// a future Apply, turning an unverifiable entry into a permanently
+		// drifted one — worse than the gap.
+		lock.Managed[i].MaterializedHash = hashArtifactFiles(files)
+		lock.Managed[i].AdoptedAt = now
+		repaired = append(repaired, lock.Managed[i])
+	}
+	if dryRun {
+		return repaired, skipped, nil
+	}
+	return repaired, skipped, nil
+}
+
+// readManagedFiles reads the on-disk bytes of one managed artifact in the shape
+// hashArtifactFiles expects: one entry for a single-file kind, every file under
+// the directory for a skill or hook.
+func readManagedFiles(mf ManagedFile, full string) ([]ArtifactFile, error) {
+	info, err := os.Lstat(full)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		data, readErr := os.ReadFile(full)
+		if readErr != nil {
+			return nil, readErr
+		}
+		return []ArtifactFile{{Path: filepath.Base(full), Content: data, Executable: info.Mode()&0o111 != 0}}, nil
+	}
+	var files []ArtifactFile
+	walkErr := filepath.WalkDir(full, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(full, p)
+		if relErr != nil {
+			return relErr
+		}
+		data, readErr := os.ReadFile(p)
+		if readErr != nil {
+			return readErr
+		}
+		fi, infoErr := d.Info()
+		if infoErr != nil {
+			return infoErr
+		}
+		files = append(files, ArtifactFile{Path: filepath.ToSlash(rel), Content: data, Executable: fi.Mode()&0o111 != 0})
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return files, nil
+}
+
 func VerifyManaged(lock Lock, provider configurator.Provider, baseDir string) []DriftFinding {
 	var findings []DriftFinding
 	seen := make(map[string]bool, len(lock.Managed))


### PR DESCRIPTION
`doctor`'s only prescribed remedy for a narrow metadata gap was a full client rebuild:

```
info [managed-files] 6 managed artifact(s) recorded before content hashes existed
     cannot be verified — …/.cartographer-sync.lock.json
     fix: cartographer reconnect
```

Its reasoning was correct on every point — an entry with no materialized hash is `DriftUnknown`, deliberately not healable, and `ComputeDiff` sees no change either, so `sync` leaves it alone. The gap was the leap from *"cannot be compared"* to *"must be rebuilt"*: `reconnect` prunes and rewrites **every** managed artifact on **every** client. In the field that was ~150 file operations to backfill **six** hashes, and a partial failure would have left both clients without skills. There was no narrower option.

**The content is already on disk and the hash is computable without refetching anything.** That is the whole fix.

## What changed

- new `provisioning.RepairManagedHashes` and `cartographer doctor --repair-hashes`.
- **Backfilling is not healing.** It records what is on disk *as* the baseline; it does not claim the file matches the server. Entries carry a new `adopted_at`, and the command says "adopted, not verified" out loud, so a later genuine drift is still detectable from the next server-side change onward.
- **An explicit command, not implicit in `sync`**: doing it silently would make an unverifiable entry become verified with no record of the decision — the exact ambiguity `DriftUnknown` exists to prevent.
- **Only entries whose file exists are backfilled.** A missing file is already `DriftMissing`, real drift for `sync` to fix; hashing nothing would paper it over. A symlinked destination is skipped, deferring to D148 — Cartographer does not hash a file it refuses to own.
- **The hash is computed exactly the way `Apply` records `materializedHash`**: same `hashArtifactFiles`, same ordered file set, same executable bit. Any other derivation would never match a future `Apply`, turning an unverifiable entry into a permanently drifted one — worse than the gap.
- `reconnect` is unchanged: it remains the right tool for a genuine rebuild.

## Tests

`TestRunDoctor_UnknownHashSuggestsRebuild` asserted `fix == "cartographer reconnect"` and is now `TestRunDoctor_UnknownHashSuggestsRepairHashes`, covering the **full round trip in one test**: the finding appears, `--repair-hashes` clears it, every entry gains a hash *and* an `adopted_at`, and the output says the entries are adopted rather than verified. Plus `TestRepairManagedHashes_NothingToDo`, so "nothing to repair" is an explicit outcome rather than silence.

## Docs

`docs/configurator.md` documents the flag next to `doctor` and states plainly that a backfilled entry is *adopted*, not *verified*. `D157` in `docs/decisions/client-configurator.md`.

## Release impact

Additive: one new flag, one changed `doctor` message, one new optional lockfile field (`adopted_at`) that older clients must ignore.

## Verification

`make vet`, `make test` (23 packages), `make smoke-http` and `make e2e` (12/12) green locally; `gofmt -l` clean.

Closes #178
