### PR TITLE
fix(sync): the steering block names the subagents this client actually received

### DIFF
--- a/cmd/cartographer/clientsync.go
+++ b/cmd/cartographer/clientsync.go
@@ -286,7 +286,19 @@ func printApplySummary(dir string, results map[string]provisioning.AppliedResult
 	}
 	for _, p := range sortedKeys(results) {
 		r := results[p]
+		// One line per file written, not per artifact: the instructions block is
+		// one physical write shared by every mounted KB, so reporting it once per
+		// KB printed three identical lines for one file, which reads like a loop
+		// (D154). Only the instructions kind is collapsed — elsewhere two
+		// artifacts never share a path, and a blanket dedup would hide a real bug.
+		reportedInstructions := map[string]bool{}
 		for _, w := range r.Written {
+			if w.Kind == "instructions" {
+				if reportedInstructions[w.Path] {
+					continue
+				}
+				reportedInstructions[w.Path] = true
+			}
 			fmt.Printf("[%s] %s %s\n", p, verb("wrote", "would write"), w.Path)
 			// The registration line reports a side effect on a shared file
 			// that a dry run does not perform either.

--- a/docs/decisions/sync-provisioning.md
+++ b/docs/decisions/sync-provisioning.md
@@ -716,3 +716,68 @@ repository.
 refuses that artifact, so an operator relying on a symlinked skills directory must repoint
 the client base dir at the real location. `-dry-run` performs the same check and reports
 `would refuse`, which is exactly when finding out is cheap.
+
+## D154 — The generated steering block describes what this client received
+
+**Status: implemented (2026-08-28).** Amends [D65](#d65) and [D141](#d141). Closes #175.
+
+**Context.** The generated instructions described **intended** state rather than what provisioning
+achieved on that client, so any partially-supported client got confidently wrong instructions.
+
+`generateKBInstructions` emitted, whenever the KB declared any agent: *"Subagents installed by this
+KB: <a>, <b> — their descriptions are in the client's agent registry: delegate to them the tasks
+they cover."* The list came from `kbAgentNames(kbRoot)` — what the KB **declares** on disk. It could
+not come from what the client received: the function has no provider argument and its only caller,
+`BuildManifest`, runs exclusively server-side, where no provider is known. Meanwhile whether a
+provider can receive an agent at all is a static fact the code already states —
+`destinationMatrix["agent"]` marks `kiro` and `hermes` `unsupportedDest`. So a KB with two agents
+synced to Claude Code and Kiro materialized them for the first and **not at all** for the second,
+while both were told they were installed. On the reporting deployment the only agents in that
+client's registry were stale files from an earlier bootstrap, still pointing at a decommissioned
+source.
+
+**Two corrections to the field report, made while implementing.**
+
+*The omission was not silent, it was not persistent.* `printApplySummary` does print
+`unsupported: agent/<name> … (kind has no destination for this provider)` for every artifact routed
+to `Unsupported`. What is missing is persistence: the line appears only on a run where the artifact
+enters the diff, `doctor` never reported the condition, and the steering sentence was wrong
+regardless of any output — which is the part that misleads the model rather than the operator.
+
+*"Written once per mounted KB" is a reporting defect, not three writes.*
+`applyInstructionsGroup` accumulates every KB's snippet and calls `writeInstructionsBlock` **once**;
+it then appends one `ManagedFile` per instructions artifact — i.e. per KB — and the summary printed
+one line each. Nothing was rewritten N−1 times, so the fix belongs in the printer.
+
+**Decision.**
+
+- **The subagent sentence moves out of the hashed artifact and is emitted client-side, per
+  provider.** There is an exact precedent in the same function: the D75 WP4 local-paths table is
+  appended there, client-side only, and deliberately not part of the artifact hash. The sentence has
+  the same nature — a statement about *this client*, not about the KB.
+- It lists only agents whose kind has a destination for the provider, and only those actually
+  authorized: an artifact awaiting approval was not installed, and the whole point is that the
+  sentence describes what happened.
+- **The rewrite trigger now fires on an `agent` artifact too.** The block's rendered content depends
+  on the agent set while its artifact hash deliberately does not, so without this the sentence would
+  go stale the moment an agent was added or removed. The test that asserted the hash changes when an
+  agent is added now asserts the opposite, and names the trigger as the guarantee that replaced it —
+  the invariant moved, it did not disappear.
+- **A declared kind the provider cannot receive is warned about on every run**, computed from the
+  manifest rather than the diff.
+- **The wrapper becomes opt-out, not translated.** `instructions.md` may declare
+  `<!-- cartographer: preamble: none -->` on its first line to suppress the three generated
+  bullets — the redundant, hardcoded-English part. Deliberately **not** a localisation mechanism: a
+  `language:` key would make Cartographer carry translations of its own prose forever, so the KB
+  owns the prose instead. **The one-line routing sentence stays generated in every case** (KB name,
+  server, archives): it is state, not prose, and no KB can write it for itself. The residual is
+  therefore one English line rather than none, and this entry says so rather than claiming the
+  language break is gone. The directive is honoured on the first line only, so a KB can document it
+  without triggering it — the same trap as the placeholder syntax.
+- **Reporting collapses per path for the instructions kind only.** `result.Written` keeps one entry
+  per artifact, because the lockfile and drift detection depend on it; elsewhere two artifacts never
+  share a path and a blanket dedup would hide a real bug.
+
+**Consequences.** The steering block changes content on clients that cannot receive agents — the
+false sentence disappears — so those clients rewrite the block once on the next sync, which is the
+normal drift path. New KB-side directive; no config migration.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -106,6 +106,32 @@ repair never implies `--auto-trust`, never invents an approval and never broaden
 never disconnects or reconnects a provider. It only runs when the client is configured against
 that same native service over loopback HTTP; any other endpoint is skipped rather than contacted.
 
+## The generated instructions block
+
+The client steering file carries one managed block per mounted KB: a generated routing sentence (KB
+name, server, archives), the generated "Operational instructions" bullets, the KB's own
+`instructions.md` verbatim, and — client-side — the D75 WP4 local-paths table.
+
+**The subagent sentence describes what THIS client received** (D154). It is emitted per provider at
+`Apply` time, not baked into the artifact, and names only agents whose kind has a destination for
+that provider: `kiro` and `hermes` have no native subagent directory, so they get no sentence rather
+than being told to delegate to subagents they never received. The block's content therefore depends
+on the KB's agent set even though its artifact hash does not, so the rewrite trigger fires on an
+`agent` artifact too — otherwise the sentence would go stale the moment an agent was added.
+
+**A KB may opt out of the generated bullets** by putting `<!-- cartographer: preamble: none -->` on
+the **first line** of its `instructions.md`. The generated wrapper is hardcoded English, so a KB
+written in another language produced a steering file that switched language twice, with the English
+first — the position that sets the model's expected output language. This is deliberately *not* a
+localisation mechanism: the KB owns the prose instead. The one-line routing sentence always stays,
+being generated state rather than prose, so the residual is one English line. The directive is
+recognised on the first line only, so a KB can document it in its own text without triggering it.
+
+**A kind the provider cannot receive is warned about on every run**, computed from the manifest
+rather than from the diff: the per-artifact `unsupported:` line appears only on the run where that
+artifact enters the diff, after which the condition is invisible while the KB keeps declaring
+artifacts that are silently not installed.
+
 ## Security
 
 - **Cryptographic signature gate.** A configured KB signer creates a canonical Ed25519 envelope over domain, format version, source KB, kind, name, version and content hash. The remote client recomputes the content hash and verifies against out-of-band `signing_keys` pins before writing any provider file or lockfile. `signed:true` is verification output only; malformed, invalid, source-mismatched, unknown-key or tampered content fails the whole sync. Bundled artifacts use the separate `built_in:true` origin.

--- a/internal/provisioning/provisioning.go
+++ b/internal/provisioning/provisioning.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -691,18 +692,25 @@ func generateKBInstructions(kbName, kbRoot, toolPrefix string) string {
 		fmt.Fprintf(&sb, " Archives: %s.\n\n", strings.Join(names, ", "))
 	}
 
-	sb.WriteString("Operational instructions:\n")
-	fmt.Fprintf(&sb, "- consult it autonomously when you need historical or architectural context: `%s` (keyword) or `%s` to orient yourself, `%s` to read;\n",
-		tool("search"), tool("atlas_overview"), tool("concept_read"))
-	fmt.Fprintf(&sb, "- write or update a page with `%s` when you discover something relevant; close relevant sessions with `%s`;\n",
-		tool("concept_write"), tool("log_append"))
-	sb.WriteString("- every write is a git commit, revertible.\n")
+	curated, skipPreamble := kbCuratedInstructionsWithPreamble(kbRoot)
 
-	if agents := kbAgentNames(kbRoot); len(agents) > 0 {
-		fmt.Fprintf(&sb, "\nSubagents installed by this KB: %s — their descriptions are in the client's agent registry: delegate to them the tasks they cover.\n", strings.Join(agents, ", "))
+	if !skipPreamble {
+		sb.WriteString("Operational instructions:\n")
+		fmt.Fprintf(&sb, "- consult it autonomously when you need historical or architectural context: `%s` (keyword) or `%s` to orient yourself, `%s` to read;\n",
+			tool("search"), tool("atlas_overview"), tool("concept_read"))
+		fmt.Fprintf(&sb, "- write or update a page with `%s` when you discover something relevant; close relevant sessions with `%s`;\n",
+			tool("concept_write"), tool("log_append"))
+		sb.WriteString("- every write is a git commit, revertible.\n")
 	}
 
-	if curated := kbCuratedInstructions(kbRoot); curated != "" {
+	// The subagent sentence is NOT emitted here (D154). This function has no
+	// provider argument and BuildManifest only ever runs server-side, so the
+	// list could only be what the KB *declares* — and a provider whose "agent"
+	// cell is unsupported receives none of them, while being told to delegate to
+	// them. applyInstructionsGroup appends the sentence per provider instead,
+	// the same way the D75 WP4 paths table is appended client-side.
+
+	if curated != "" {
 		sb.WriteString("\n")
 		sb.WriteString(curated)
 		sb.WriteString("\n")
@@ -755,15 +763,54 @@ func kbAgentNames(kbRoot string) []string {
 // free-form markdown) it is discarded and only the body is used. Missing file →
 // empty string (no section).
 func kbCuratedInstructions(kbRoot string) string {
+	body, _ := kbCuratedInstructionsWithPreamble(kbRoot)
+	return body
+}
+
+// preambleNoneRe matches the opt-out directive on the FIRST line of
+// instructions.md. First line only, and an exact spelling, so a KB can document
+// the directive in its own prose without triggering it — the same trap as the
+// placeholder syntax (D163).
+var preambleNoneRe = regexp.MustCompile(`(?i)^<!--\s*cartographer:\s*preamble:\s*none\s*-->\s*$`)
+
+// kbCuratedInstructionsWithPreamble returns the KB's curated instructions and
+// whether it opted out of the generated "Operational instructions" bullets
+// (D154).
+//
+// The generated wrapper is hardcoded English, so a KB written in the team's
+// working language yielded a steering file that switched language twice — 1765
+// bytes of English around 6559 of another language, and the *first* thing the
+// model reads, which is the worst position for an inconsistency because it sets
+// the expected output language. It is also partly redundant with any
+// instructions.md that already explains how to consult the KB.
+//
+// Deliberately NOT a localisation mechanism: a language key would make
+// Cartographer carry translations of its own prose forever. The KB owns the
+// prose instead. The one-line routing sentence (KB name, server, archives) stays
+// generated in every case — it is state, not prose, and no KB can write it for
+// itself — so the residual is one English line rather than none.
+func kbCuratedInstructionsWithPreamble(kbRoot string) (body string, skipPreamble bool) {
 	data, err := os.ReadFile(filepath.Join(kbRoot, "instructions.md"))
 	if err != nil {
-		return ""
+		return "", false
 	}
-	_, body, hasFM := okf.SplitFrontmatter(string(data))
+	_, content, hasFM := okf.SplitFrontmatter(string(data))
 	if !hasFM {
-		body = string(data)
+		content = string(data)
 	}
-	return strings.TrimSpace(body)
+	lines := strings.Split(content, "\n")
+	for i, l := range lines {
+		if strings.TrimSpace(l) == "" {
+			continue
+		}
+		if preambleNoneRe.MatchString(strings.TrimSpace(l)) {
+			skipPreamble = true
+			lines = append(lines[:i], lines[i+1:]...)
+			content = strings.Join(lines, "\n")
+		}
+		break
+	}
+	return strings.TrimSpace(content), skipPreamble
 }
 
 // contentHashFile computes the versioned artifact hash of a single,
@@ -1390,6 +1437,7 @@ func Apply(m Manifest, opts ApplyOptions) (AppliedResult, error) {
 	}
 
 	result.Warnings = append(result.Warnings, tracker.warnings...)
+	result.Warnings = append(result.Warnings, unsupportedKindWarnings(m, opts.Provider)...)
 
 	// Prune: remove stale managed entries from BaseDir. The "instructions" kind
 	// is excluded: removing it with the generic logic (one file per
@@ -1482,16 +1530,24 @@ func applyInstructionsGroup(m Manifest, diff Diff, opts ApplyOptions, tracker *e
 
 	// Trigger: did something in the instructions kind change in this Apply —
 	// or did the managed block disappear from the provider's file (D139)?
+	// The block is rewritten when the instructions artifact itself changed, and
+	// also when the KB's agent set changed: since D154 the block's rendered
+	// content includes a per-provider sentence naming the subagents THIS client
+	// can install, so it depends on the agent artifacts even though their content
+	// is not part of the instructions artifact's hash. Without this the sentence
+	// would go stale the moment an agent was added or removed.
+	triggersRewrite := func(kind string) bool { return kind == "instructions" || kind == "agent" }
+
 	triggered := force
 	for _, a := range diff.Added {
-		if a.Kind == "instructions" {
+		if triggersRewrite(a.Kind) {
 			triggered = true
 			break
 		}
 	}
 	if !triggered {
 		for _, a := range diff.Updated {
-			if a.Kind == "instructions" {
+			if triggersRewrite(a.Kind) {
 				triggered = true
 				break
 			}
@@ -1499,7 +1555,7 @@ func applyInstructionsGroup(m Manifest, diff Diff, opts ApplyOptions, tracker *e
 	}
 	if !triggered {
 		for _, mf := range diff.Removed {
-			if mf.Kind == "instructions" {
+			if triggersRewrite(mf.Kind) {
 				triggered = true
 				break
 			}
@@ -1589,6 +1645,15 @@ func applyInstructionsGroup(m Manifest, diff Diff, opts ApplyOptions, tracker *e
 		}
 	}
 
+	// The subagent sentence, per provider and per KB (D154): it must describe
+	// what THIS client received, not what the KB declares. Kiro and Hermes have
+	// no native subagent directory, so their "agent" cell is unsupportedDest and
+	// they receive none — while the old, server-generated sentence told them to
+	// delegate to subagents that were not there.
+	if sentence := installedSubagentSentence(m, opts); sentence != "" {
+		body += "\n\n" + sentence
+	}
+
 	if !opts.DryRun {
 		if err := writeInstructionsBlock(fullPath, body); err != nil {
 			return fmt.Errorf("provisioning: write instructions block %s: %w", destRel, err)
@@ -1601,6 +1666,85 @@ func applyInstructionsGroup(m Manifest, diff Diff, opts ApplyOptions, tracker *e
 		})
 	}
 	return nil
+}
+
+// unsupportedKindWarnings reports, per KB and per artifact kind, what this
+// provider cannot receive at all (D154). Computed from the manifest rather than
+// from the diff, so it is emitted on **every** run: the per-artifact
+// "unsupported" line only appears on a run where the artifact enters the diff,
+// after which the condition is invisible — while the KB keeps declaring
+// artifacts that are silently not installed.
+func unsupportedKindWarnings(m Manifest, provider configurator.Provider) []string {
+	type key struct{ kb, kind string }
+	counts := map[key]int{}
+	for _, a := range m.Artifacts {
+		if !strings.HasPrefix(a.Source, "kb:") || a.Kind == "instructions" {
+			continue
+		}
+		if destDir(a.Kind, a.Name, provider) != "" {
+			continue
+		}
+		counts[key{strings.TrimPrefix(a.Source, "kb:"), a.Kind}]++
+	}
+	if len(counts) == 0 {
+		return nil
+	}
+	keys := make([]key, 0, len(counts))
+	for k := range counts {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].kb != keys[j].kb {
+			return keys[i].kb < keys[j].kb
+		}
+		return keys[i].kind < keys[j].kind
+	})
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, fmt.Sprintf("KB %q declares %d %s artifact(s) that %s cannot receive (no destination for this kind) — they are not installed on this client",
+			k.kb, counts[k], k.kind, provider))
+	}
+	return out
+}
+
+// installedSubagentSentence names the KB agents this provider can actually
+// receive, grouped per KB, or returns "" when none qualifies (D154). Emitted
+// client-side, like the paths table: it is a statement about this client, not
+// about the KB, so it deliberately does not enter the artifact hash.
+//
+// An artifact awaiting approval is excluded: it was not installed, and the whole
+// point is that the sentence describes what happened.
+func installedSubagentSentence(m Manifest, opts ApplyOptions) string {
+	byKB := map[string][]string{}
+	for _, a := range m.Artifacts {
+		if a.Kind != "agent" || !strings.HasPrefix(a.Source, "kb:") {
+			continue
+		}
+		if destDir("agent", a.Name, opts.Provider) == "" {
+			continue
+		}
+		if !artifactAuthorized(a, opts) {
+			continue
+		}
+		kbName := strings.TrimPrefix(a.Source, "kb:")
+		byKB[kbName] = append(byKB[kbName], a.Name)
+	}
+	if len(byKB) == 0 {
+		return ""
+	}
+	kbNames := make([]string, 0, len(byKB))
+	for k := range byKB {
+		kbNames = append(kbNames, k)
+	}
+	sort.Strings(kbNames)
+	var lines []string
+	for _, kbName := range kbNames {
+		names := byKB[kbName]
+		sort.Strings(names)
+		lines = append(lines, fmt.Sprintf("Subagents installed by the %q KB: %s — their descriptions are in the client's agent registry: delegate to them the tasks they cover.",
+			kbName, strings.Join(names, ", ")))
+	}
+	return strings.Join(lines, "\n")
 }
 
 func artifactAuthorized(a Artifact, opts ApplyOptions) bool {

--- a/internal/provisioning/provisioning_instructions_test.go
+++ b/internal/provisioning/provisioning_instructions_test.go
@@ -201,10 +201,13 @@ func TestBuildManifest_Instructions_SezioneAgent(t *testing.T) {
 	}
 	content := string(findInstructionsArtifact(t, m, "homelab").Files[0].Content)
 
-	// Names only, alphabetically sorted, no description (already in the
-	// client's agent registry, D65).
-	if !strings.Contains(content, "Subagents installed by this KB: anonimo, zorro —") {
-		t.Errorf("agent section missing or not sorted by name:\n%s", content)
+	// Since D154 the server-generated block carries NO subagent sentence: it
+	// cannot know which provider will receive the block, and a provider whose
+	// "agent" cell is unsupported receives none of them. The sentence is emitted
+	// per provider by Apply, from what that client can actually install — see
+	// TestApply_InstructionsSubagentSentence*.
+	if strings.Contains(content, "Subagents installed") {
+		t.Errorf("the server-generated block must not claim installed subagents (D154):\n%s", content)
 	}
 	if strings.Contains(content, "Defends the KB from intruders") {
 		t.Errorf("agent descriptions must not be duplicated in the instructions (D65):\n%s", content)
@@ -310,8 +313,13 @@ func TestBuildManifest_Instructions_HashStabileConDescriptionAgent(t *testing.T)
 		t.Fatalf("BuildManifest 3: %v", err)
 	}
 	h3 := findInstructionsArtifact(t, m3, "homelab").ContentHash
-	if h3 == h1 {
-		t.Error("the instructions ContentHash must change when an agent is added")
+	// Since D154 the block no longer names agents, so its hash is independent of
+	// the agent set — deliberately: the sentence naming installed subagents is
+	// per-provider and emitted client-side. What guarantees the block is rewritten
+	// when the agent set changes is Apply's trigger, which now fires on an "agent"
+	// artifact too (see TestApply_InstructionsRewrittenWhenAgentSetChanges).
+	if h3 != h1 {
+		t.Error("the instructions ContentHash must not depend on the agent set (D154)")
 	}
 }
 
@@ -845,5 +853,171 @@ func TestBuildManifest_Instructions_ToolPrefix(t *testing.T) {
 		if strings.Contains(prefixedContent, "`"+base+"`") {
 			t.Errorf("prefixed block still names the bare tool `%s`:\n%s", base, prefixedContent)
 		}
+	}
+}
+
+// --- D154: the block describes what THIS client received ---
+
+func agentManifest(t *testing.T, kbRoot string, names ...string) provisioning.Manifest {
+	t.Helper()
+	agentsDir := filepath.Join(kbRoot, "agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range names {
+		writeFile(t, filepath.Join(agentsDir, n+".md"), "---\nname: "+n+"\ndescription: Agent "+n+".\n---\nPrompt.\n")
+	}
+	m, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, provisioning.BuildOptions{})
+	if err != nil {
+		t.Fatalf("BuildManifest: %v", err)
+	}
+	for i := range m.Artifacts {
+		m.Artifacts[i].Signed = true
+	}
+	return m
+}
+
+func instructionsBody(t *testing.T, base string, provider configurator.Provider) string {
+	t.Helper()
+	rel := map[configurator.Provider]string{
+		configurator.ProviderClaudeCode: filepath.Join(".claude", "CLAUDE.md"),
+		configurator.ProviderKiro:       filepath.Join(".kiro", "steering", "cartographer.md"),
+	}[provider]
+	data, err := os.ReadFile(filepath.Join(base, rel))
+	if err != nil {
+		t.Fatalf("read instructions for %s: %v", provider, err)
+	}
+	return string(data)
+}
+
+// An agent reading its own steering was told to delegate to subagents that did
+// not exist on that client: kiro's "agent" cell is unsupportedDest, so it
+// receives none of them.
+func TestApply_InstructionsSubagentSentenceReflectsThisClient(t *testing.T) {
+	for _, tc := range []struct {
+		provider  configurator.Provider
+		wantNames bool
+	}{
+		{configurator.ProviderClaudeCode, true},
+		{configurator.ProviderKiro, false},
+	} {
+		t.Run(string(tc.provider), func(t *testing.T) {
+			kbRoot := makeKBWithArchives(t, map[string][]string{"entities": {"a.md"}})
+			m := agentManifest(t, kbRoot, "zorro", "anonimo")
+			base := t.TempDir()
+			if _, err := provisioning.Apply(m, provisioning.ApplyOptions{Provider: tc.provider, BaseDir: base, Lock: provisioning.Lock{}, KBRoots: map[string]string{"homelab": kbRoot}}); err != nil {
+				t.Fatal(err)
+			}
+			body := instructionsBody(t, base, tc.provider)
+			has := strings.Contains(body, "Subagents installed")
+			if has != tc.wantNames {
+				t.Errorf("%s: subagent sentence present = %v, want %v\n%s", tc.provider, has, tc.wantNames, body)
+			}
+			if tc.wantNames && !strings.Contains(body, "anonimo, zorro") {
+				t.Errorf("%s: sentence does not name the installed agents in order:\n%s", tc.provider, body)
+			}
+		})
+	}
+}
+
+// The per-artifact "unsupported" line only appears on a run where the artifact
+// enters the diff; afterwards the condition is invisible while the KB keeps
+// declaring artifacts that are silently not installed.
+func TestApply_WarnsEveryRunAboutUnsupportedKinds(t *testing.T) {
+	kbRoot := makeKBWithArchives(t, map[string][]string{"entities": {"a.md"}})
+	m := agentManifest(t, kbRoot, "zorro")
+	base := t.TempDir()
+
+	first, err := provisioning.Apply(m, provisioning.ApplyOptions{Provider: configurator.ProviderKiro, BaseDir: base, Lock: provisioning.Lock{}, KBRoots: map[string]string{"homelab": kbRoot}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	warned := func(r provisioning.AppliedResult) bool {
+		for _, w := range r.Warnings {
+			if strings.Contains(w, "cannot receive") && strings.Contains(w, "agent") {
+				return true
+			}
+		}
+		return false
+	}
+	if !warned(first) {
+		t.Fatalf("first run did not warn: %v", first.Warnings)
+	}
+	// Second run: nothing in the diff, and the warning must still be there.
+	second, err := provisioning.Apply(m, provisioning.ApplyOptions{Provider: configurator.ProviderKiro, BaseDir: base, Lock: first.NewLock, KBRoots: map[string]string{"homelab": kbRoot}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !warned(second) {
+		t.Errorf("the condition became invisible on the second run: %v", second.Warnings)
+	}
+}
+
+// The block's content now depends on the agent set even though its hash does
+// not, so the trigger has to reflect that dependency or the sentence goes stale.
+func TestApply_InstructionsRewrittenWhenAgentSetChanges(t *testing.T) {
+	kbRoot := makeKBWithArchives(t, map[string][]string{"entities": {"a.md"}})
+	m1 := agentManifest(t, kbRoot, "zorro")
+	base := t.TempDir()
+	first, err := provisioning.Apply(m1, provisioning.ApplyOptions{Provider: configurator.ProviderClaudeCode, BaseDir: base, Lock: provisioning.Lock{}, KBRoots: map[string]string{"homelab": kbRoot}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body := instructionsBody(t, base, configurator.ProviderClaudeCode); strings.Contains(body, "nuovo") {
+		t.Fatalf("unexpected agent in the first block:\n%s", body)
+	}
+
+	m2 := agentManifest(t, kbRoot, "zorro", "nuovo")
+	if _, err := provisioning.Apply(m2, provisioning.ApplyOptions{Provider: configurator.ProviderClaudeCode, BaseDir: base, Lock: first.NewLock, KBRoots: map[string]string{"homelab": kbRoot}}); err != nil {
+		t.Fatal(err)
+	}
+	body := instructionsBody(t, base, configurator.ProviderClaudeCode)
+	if !strings.Contains(body, "nuovo") {
+		t.Errorf("adding an agent did not rewrite the block, so the sentence is stale:\n%s", body)
+	}
+}
+
+// A KB whose instructions.md is written in the team's working language yielded a
+// steering file that switched language twice, with the generated English first —
+// the worst position, since it sets the expected output language.
+func TestGenerateKBInstructions_PreambleNoneDirective(t *testing.T) {
+	kbRoot := makeKBWithArchives(t, map[string][]string{"entities": {"a.md"}})
+	writeFile(t, filepath.Join(kbRoot, "instructions.md"),
+		"<!-- cartographer: preamble: none -->\nRegola: leggi prima l'indice.\n")
+
+	m, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, provisioning.BuildOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(findInstructionsArtifact(t, m, "homelab").Files[0].Content)
+
+	if strings.Contains(content, "Operational instructions:") {
+		t.Errorf("preamble: none did not suppress the generated bullets:\n%s", content)
+	}
+	if strings.Contains(content, "cartographer: preamble: none") {
+		t.Errorf("the directive itself leaked into the block:\n%s", content)
+	}
+	// The routing sentence is generated state, not prose: it always stays.
+	if !strings.Contains(content, `The "homelab" KB is served via MCP`) {
+		t.Errorf("the routing sentence must stay:\n%s", content)
+	}
+	if !strings.Contains(content, "Regola: leggi prima l'indice.") {
+		t.Errorf("the curated content is missing:\n%s", content)
+	}
+}
+
+// A KB must be able to document the directive without triggering it.
+func TestGenerateKBInstructions_DirectiveNotOnFirstLineIsContent(t *testing.T) {
+	kbRoot := makeKBWithArchives(t, map[string][]string{"entities": {"a.md"}})
+	writeFile(t, filepath.Join(kbRoot, "instructions.md"),
+		"How to opt out of the preamble:\n<!-- cartographer: preamble: none -->\n")
+
+	m, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, provisioning.BuildOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(findInstructionsArtifact(t, m, "homelab").Files[0].Content)
+	if !strings.Contains(content, "Operational instructions:") {
+		t.Errorf("a directive that is not on the first line must be content:\n%s", content)
 	}
 }


### PR DESCRIPTION
The generated instructions described **intended** state rather than what provisioning achieved on that client, so any partially-supported client got confidently wrong instructions.

`generateKBInstructions` emitted *"Subagents installed by this KB: …"* whenever the KB declared any agent, from `kbAgentNames(kbRoot)` — what the KB **declares** on disk. It could not do better: the function has no provider argument and its only caller, `BuildManifest`, runs exclusively server-side. Meanwhile `destinationMatrix["agent"]` marks `kiro` and `hermes` `unsupportedDest`, so a KB with two agents synced to Claude Code and Kiro materialized them for the first and **not at all** for the second — while both were told they were installed. On the reporting deployment the only agents in that client's registry were stale files from an earlier bootstrap, pointing at a decommissioned source.

## Two corrections to the report, made while implementing

**The omission was not silent, it was not *persistent*.** `printApplySummary` already prints `unsupported: agent/<name> …` for every artifact routed to `Unsupported`. What was missing is persistence: the line appears only on a run where the artifact enters the diff, `doctor` never reported it, and the steering sentence was wrong regardless of any output — the part that misleads the model rather than the operator.

**"Written once per mounted KB" is a reporting defect, not three writes.** `applyInstructionsGroup` accumulates every KB's snippet and calls `writeInstructionsBlock` **once**; it then appends one `ManagedFile` per KB and the summary printed one line each. Nothing was rewritten N−1 times, so the fix belongs in the printer — this PR does not "fix" a loop that does not exist.

## What changed

- **The subagent sentence is emitted client-side, per provider**, listing only agents whose kind has a destination for that provider and that were actually authorized (an artifact awaiting approval was not installed). Exact precedent in the same function: the D75 WP4 local-paths table is appended there, client-side, deliberately outside the artifact hash. The sentence has the same nature.
- **The rewrite trigger now fires on an `agent` artifact too.** The block's content depends on the agent set while its hash deliberately does not, so without this the sentence goes stale the moment an agent is added. The test asserting "the hash changes when an agent is added" now asserts the opposite and names the trigger as the guarantee that replaced it — the invariant moved, it did not disappear.
- **A kind the provider cannot receive is warned about on every run**, computed from the manifest rather than the diff.
- **`<!-- cartographer: preamble: none -->` on the first line of `instructions.md`** suppresses the generated bullets. Deliberately *not* a localisation mechanism — a `language:` key would make Cartographer carry translations of its own prose forever — so the KB owns the prose instead. **The one-line routing sentence always stays**, being generated state: the residual is one English line rather than none, and the D entry says so rather than claiming the language break is gone. First line only, so a KB can document the directive without triggering it.
- **One report line per file written**, for the instructions kind only: `result.Written` keeps one entry per artifact because the lockfile depends on it, and a blanket dedup elsewhere would hide a real bug.

## Tests

`TestApply_InstructionsSubagentSentenceReflectsThisClient` (Claude Code names both agents, Kiro gets no sentence at all), `TestApply_WarnsEveryRunAboutUnsupportedKinds` (**runs `Apply` twice** and asserts the warning survives an empty diff), `TestApply_InstructionsRewrittenWhenAgentSetChanges`, `TestGenerateKBInstructions_PreambleNoneDirective` (bullets gone, directive not leaked, routing sentence kept, curated content present) and `TestGenerateKBInstructions_DirectiveNotOnFirstLineIsContent`.

Two existing tests asserted the server-generated block names agents and that its hash tracks the agent set; both are updated with a comment pointing at what replaced the guarantee.

## Docs

`docs/sync.md` gains a §The generated instructions block covering all four points. `D154` in `docs/decisions/sync-provisioning.md`.

## Verification

`make vet`, `make test` (23 packages), `make smoke-http` and `make e2e` (12/12) green locally; `gofmt -l` clean.

Closes #175
