### PR TITLE
feat(lint): per-concept lint_ignore, home-anchored allow prefixes and related size thresholds

### DIFF
--- a/docs/data-plane.md
+++ b/docs/data-plane.md
@@ -138,6 +138,34 @@ Concept ID = path relative to the bundle without `.md`. File names are `kebab-ca
 
 **In a curated index, both forms are accepted** for an expanded concept: `[c](c.md)` and `[c](c/index.md)` both satisfy `require_index_entry`. The two used to be inverses of each other — one valid between concepts, the other in an index — with nothing to tell them apart.
 
+### Silencing a lint finding on one concept
+
+`lint_ignore: [check, …]` in a concept's frontmatter drops the named findings **for that concept
+only** (D159). It exists because a concept documenting a false positive — a `~/.ssh/config` in prose,
+a deliberately-broken example link — could not be written without generating the findings it
+describes, so a KB's own "known false positives" page was impossible.
+
+Suppressible: `broken_link`, `machine_path`, `concept_oversize`, `stale_claim`, `imported_draft`,
+`secrets_on_non_service`, `orphan`. **Not** suppressible: every `error`-severity check
+(`missing_required_field`, `expanded_ambiguous`) — those are contract violations, not judgements, and
+letting a concept declare its own contract void would be a hole rather than an escape hatch — and the
+directory-level checks (`map_oversize`, `index_incomplete`, `expanded_*`, `orphan_asset`), which
+belong to a map or an expanded concept and have no single concept frontmatter that owns them. Naming
+an unsuppressible or unknown check is itself reported as `lint_ignore_invalid`: a typo that silently
+suppresses nothing is worse than no opt-out.
+
+`machine_path_allow_prefixes` accepts **`~/`-anchored** prefixes as well as POSIX- and
+Windows-absolute ones: `~/.ssh/config` means "your ssh config" on every machine, exactly as `/etc/…`
+does. Matching is literal and at segment boundaries — `~/.ssh` covers `~/.ssh/config` but not
+`~/.sshx` — with no home expansion anywhere, so the contract's meaning does not depend on the
+reader's home directory. `~user/…` is rejected, since the detector never produces that form.
+
+The two "too big" numbers are now related: `concept_oversize` fires at **half** the size at which
+`concept_read` degrades to an outline, so an author gets warning before reads change shape, and the
+message names both bounds. For a satellite the message does not advise `concept_expand` — the write
+path caps depth at three segments, so that remedy is structurally unavailable — and names splitting
+into sibling satellites instead.
+
 ## Extended concept types
 
 `Service` and `Contradiction` are conventional types used by dedicated tools.

--- a/docs/decisions/data-plane.md
+++ b/docs/decisions/data-plane.md
@@ -387,3 +387,66 @@ could clear.
 whose only inbound link came from a fenced example may newly report `orphan`. The alias form is
 new syntax, so nothing existing changes shape. `TestExtractLinks_WikiLinkAliasNotExtracted`
 asserted the old behaviour and became `TestExtractLinks_WikiLinkAliasIsExtracted`.
+
+## D159 — Per-concept lint opt-out, home-anchored allow prefixes, related size thresholds
+
+**Status: implemented (2026-08-28).** Amends [D124](#d124) and [D107](#d107). Closes #180.
+
+**Context.** Four findings an author could not legitimately clear, or a remedy the product itself
+made unavailable.
+
+1. **Lint fired on documentation *about* lint.** A concept documenting a `machine_path` false
+   positive raised `machine_path`; one documenting the Mermaid/POSIX link collision raised
+   `broken_link`. A KB's own "known false positives" page could not be written without generating the
+   findings it described, and there was no per-concept escape: the only allowlist was per-map and
+   covered path prefixes only.
+2. **The `machine_path` allowlist rejected home-anchored paths.** `normalizeAllowPrefix` accepted
+   only POSIX-absolute or Windows-drive-absolute prefixes, so `~/.ssh/config`, `~/.m2/settings.xml`
+   and friends stayed flagged forever — twelve of 73 initial findings in the field. They are
+   **conventional** paths: `~/.ssh/config` means "your ssh config" on every machine, exactly the
+   reasoning `machinePathRe`'s own comment already applies to `/etc` and `/var`.
+3. **The oversize remedy was structurally impossible for a satellite.** `concept_oversize` advised
+   `concept_expand`, which requires exactly two segments, while the write path caps depth at three.
+   The two largest concepts in the reporting KB were satellites, so the advice named an operation the
+   product refuses.
+4. **Two unrelated numbers decided "too big".** `conceptOversizeThreshold = 30000` advised a split;
+   `conceptReadSizeGuard = 60000` switched `concept_read` to an outline. A concept between them was
+   simultaneously "too big, split it" and "fine, here it is whole", and the lint constant's own
+   comment claimed it "mirrors" the read guard — which is false, 30000 does not mirror 60000.
+
+**Decision.**
+
+- **The opt-out is per-concept frontmatter, `lint_ignore: [check, …]`.** Not per-map: the cases are
+  individual pages, and a map-wide suppression would hide the same check on fifty concepts nobody
+  inspected. Implemented as one `emit` closure at the top of the per-concept loop rather than a
+  condition at each site.
+- **`error`-severity checks cannot be suppressed** and route around `emit` on purpose:
+  `missing_required_field` and `expanded_ambiguous` are contract violations, not judgements, and
+  allowing an opt-out would let a KB declare its own contract void.
+- **Directory-level checks are not suppressible either**, and that includes `orphan_asset`: it
+  belongs to an expanded concept's asset set and is reported in the directory pass, so there is no
+  single concept frontmatter that owns it. Listing it as suppressible would have been a promise the
+  implementation does not keep.
+- **An unsuppressible or unknown name in `lint_ignore` is itself a finding** (`lint_ignore_invalid`),
+  with the reason: a typo that silently suppresses nothing is worse than no opt-out. A bare string is
+  accepted as a one-element list, since the parser distinguishes the two and a bare string is the
+  obvious authoring mistake.
+- **`~/`-anchored prefixes are accepted, matched literally**, with **no home expansion anywhere**:
+  expanding `~` would make the contract's meaning depend on the reader's home directory, the opposite
+  of what an allowlist for portable paths is for. `~user/…` is rejected because the detector never
+  produces that form, so such a prefix could never match. `matchesAllowedPrefix` needed no change —
+  it already compares at segment boundaries — which a test asserts rather than assumes.
+- **No shipped default list of well-known tool paths.** The field report offers it as an alternative;
+  a built-in list is a policy every KB inherits without asking, and it would silently unflag
+  `~/.ssh/id_rsa` in a KB that wants exactly that flagged.
+- **The oversize suggestion is depth-aware**, and at maximum depth names what *is* available.
+- **The two thresholds are related, not merged.** They answer different questions — should this be
+  split for a human, can this be returned whole to a model — and merging them would couple lint
+  policy to a client's token budget. `conceptOversizeThreshold` is now
+  `okf.ConceptReadSizeGuard / 2`, in one expression, and the message names both bounds. The constant
+  moved to `internal/okf` because two packages need it with no import cycle.
+
+**Consequences.** Additive: one new frontmatter key, one widened allowlist form, two reworded
+messages. **The numeric value is unchanged** (60000/2 = 30000), deliberately: the fix is coherence,
+not a new policy, and a threshold change would belong to its own decision. A package-level test
+asserts the two constants cannot drift apart again.

--- a/internal/kb/kb.go
+++ b/internal/kb/kb.go
@@ -1306,7 +1306,8 @@ func (kb *KB) mapDescriptorRelPath(archive string) (string, error) {
 
 // MapContract declares the optional deterministic lint contract of a map.
 // RequiredFields apply to every concept; RequiredFieldsByType are additive.
-// MachinePathAllowPrefixes lists absolute path prefixes that the machine_path
+// MachinePathAllowPrefixes lists path prefixes — POSIX-absolute, Windows
+// drive-absolute, or "~/"-anchored (D159) — that the machine_path
 // lint (D124) must treat as this map's operational target paths rather than
 // client-local paths — e.g. a container image's home directory or a remote
 // node's runtime path, which are identical across every reader's machine and
@@ -1439,13 +1440,27 @@ func normalizeAllowPrefix(raw string) (string, bool) {
 
 	isPOSIX := strings.HasPrefix(trimmed, "/")
 	isWindows := isWindowsDriveAbsolute(trimmed)
-	if !isPOSIX && !isWindows {
+	// A "~/"-anchored prefix is accepted (D159): ~/.ssh/config means "your ssh
+	// config" on every machine, exactly as /etc/... does, and machinePathRe
+	// already matches that form — so a literal comparison works with no home
+	// expansion anywhere. Expanding ~ would make the contract's meaning depend on
+	// the reader's home directory, which is the opposite of what an allow-list
+	// for portable paths is for. "~user/..." is deliberately rejected: the regex
+	// never produces that form, so such a prefix could never match.
+	isTilde := trimmed == "~" || strings.HasPrefix(trimmed, "~/")
+	if !isPOSIX && !isWindows && !isTilde {
 		return "", false
+	}
+	if trimmed == "~" {
+		trimmed = "~/"
 	}
 
 	minLen := 1 // bare POSIX root "/"
 	if isWindows {
 		minLen = 3 // bare Windows drive root "C:\" or "C:/"
+	}
+	if isTilde {
+		minLen = 2 // bare "~/"
 	}
 	normalized := trimmed
 	for len(normalized) > minLen {

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -52,12 +52,63 @@ const (
 	// mapOversizeThreshold is the concept count above which a map should
 	// probably be split thematically (into a new map, not a subfolder).
 	mapOversizeThreshold = 50
-	// conceptOversizeThreshold is the body size (bytes) above which a
-	// concept is flagged for splitting via concept_expand — mirrors the
-	// concept_read size guard (D78): a concept this large risks blowing
-	// past a client's token budget on a plain read.
-	conceptOversizeThreshold = 30000
+	// conceptOversizeThreshold is the body size (bytes) above which a concept is
+	// flagged for splitting. Derived from the read guard rather than an
+	// independent number (D159): lint advises a split at half the size at which
+	// a plain concept_read degrades to an outline, so an author gets warning
+	// before reads change shape. The two used to be unrelated constants, and the
+	// claim that this one "mirrors" the guard was simply false — 30000 does not
+	// mirror 60000.
+	conceptOversizeThreshold = okf.ConceptReadSizeGuard / 2
 )
+
+// perConceptChecks are the checks a concept may silence with lint_ignore, i.e.
+// the warning/info ones driven by that concept's own body or frontmatter. Kept in
+// one place so an unknown name in lint_ignore can be reported rather than
+// silently suppressing nothing.
+//
+// Deliberately excluded: every SevError check. missing_required_field and
+// expanded_ambiguous are contract violations, not judgements — letting a concept
+// declare its own contract void is not an escape hatch, it is a hole. Also
+// excluded: the directory-based checks (map_oversize, index_incomplete,
+// expanded_*), which belong to a map or a directory and have no concept
+// frontmatter to read.
+var perConceptChecks = map[string]bool{
+	"broken_link":            true,
+	"machine_path":           true,
+	"concept_oversize":       true,
+	"stale_claim":            true,
+	"imported_draft":         true,
+	"secrets_on_non_service": true,
+	"orphan":                 true,
+}
+
+// lintIgnoreSet reads a concept's lint_ignore frontmatter key (D159). A bare
+// string is accepted as a one-element list: the frontmatter parser distinguishes
+// the two and a bare string is the obvious authoring mistake.
+func lintIgnoreSet(fm *okf.Frontmatter) map[string]bool {
+	if fm == nil {
+		return nil
+	}
+	v, ok := fm.Get("lint_ignore")
+	if !ok {
+		return nil
+	}
+	out := map[string]bool{}
+	switch value := v.(type) {
+	case string:
+		if strings.TrimSpace(value) != "" {
+			out[strings.TrimSpace(value)] = true
+		}
+	case []string:
+		for _, item := range value {
+			if strings.TrimSpace(item) != "" {
+				out[strings.TrimSpace(item)] = true
+			}
+		}
+	}
+	return out
+}
 
 // Finding represents a single lint finding.
 type Finding struct {
@@ -176,6 +227,44 @@ func Run(k *kb.KB, scope string, scopeNeighbors bool) ([]Finding, error) {
 		// sort on. The two coincide for a plain concept.
 		linkBase, _ := k.ConceptRelPath(id)
 		fmRaw, body, hasFM := okf.SplitFrontmatter(content)
+		// lint_ignore (D159): a concept that documents a false positive — a
+		// ~/.ssh/config in prose, a deliberately-broken example link — could not
+		// be written without generating the findings it describes. One closure
+		// rather than a condition at each site, and errors are never suppressible:
+		// they route around emit on purpose.
+		var conceptIgnores map[string]bool
+		if hasFM {
+			if parsedForIgnore, _ := okf.ParseFrontmatter(fmRaw); parsedForIgnore != nil {
+				conceptIgnores = lintIgnoreSet(parsedForIgnore)
+			}
+		}
+		emit := func(f Finding) {
+			if f.Severity != SevError && conceptIgnores[f.Check] {
+				return
+			}
+			findings = append(findings, f)
+		}
+		for name := range conceptIgnores {
+			if perConceptChecks[name] {
+				continue
+			}
+			reason := "not a known lint check"
+			if name == "missing_required_field" || name == "expanded_ambiguous" {
+				reason = "an error-severity contract violation, which lint_ignore cannot silence"
+			} else if name == "map_oversize" || name == "index_incomplete" || name == "orphan_asset" || strings.HasPrefix(name, "expanded_") {
+				// orphan_asset belongs to an expanded concept's asset set, reported
+				// in the directory pass: there is no single concept frontmatter that
+				// owns it, so listing it as suppressible would be a promise the
+				// implementation does not keep.
+				reason = "a directory-level check, not a per-concept one"
+			}
+			findings = append(findings, Finding{
+				Path:     relPath,
+				Check:    "lint_ignore_invalid",
+				Severity: SevWarning,
+				Message:  fmt.Sprintf("lint_ignore names %q: %s, so nothing is suppressed", name, reason),
+			})
+		}
 		parts := strings.Split(string(id), "/")
 		var allowPrefixes []string
 		if len(parts) > 1 && archiveSet[parts[0]] {
@@ -190,7 +279,7 @@ func Run(k *kb.KB, scope string, scopeNeighbors bool) ([]Finding, error) {
 			// concept_read now agree on what a valid target is (D149).
 			_, readErr := k.ReadConcept(target)
 			if readErr != nil && errors.Is(readErr, okf.ErrNotFound) {
-				findings = append(findings, Finding{
+				emit(Finding{
 					Path:     relPath,
 					Check:    "broken_link",
 					Severity: SevWarning,
@@ -201,7 +290,7 @@ func Run(k *kb.KB, scope string, scopeNeighbors bool) ([]Finding, error) {
 
 		// --- machine_path (warning, D75 WP6 / D124) ---
 		if disallowed := firstDisallowedMachinePath(body, allowPrefixes); disallowed != "" {
-			findings = append(findings, Finding{
+			emit(Finding{
 				Path:     relPath,
 				Check:    "machine_path",
 				Severity: SevWarning,
@@ -211,11 +300,19 @@ func Run(k *kb.KB, scope string, scopeNeighbors bool) ([]Finding, error) {
 
 		// --- concept_oversize (info) ---
 		if len(body) > conceptOversizeThreshold {
-			findings = append(findings, Finding{
+			// concept_expand requires exactly two segments and the write path caps
+			// depth at three, so for a satellite the remedy this check used to
+			// advise is structurally unavailable — and the two largest concepts in
+			// the reporting KB were satellites (D159).
+			remedy := "consider concept_expand to split it into a dossier"
+			if len(parts) > 2 {
+				remedy = "this is a satellite, so concept_expand does not apply: split it into sibling satellites of the same expanded concept and link them from its index"
+			}
+			emit(Finding{
 				Path:     string(id),
 				Check:    "concept_oversize",
 				Severity: SevInfo,
-				Message:  fmt.Sprintf("%d bytes in one concept (threshold %d) — consider concept_expand to split it into a dossier", len(body), conceptOversizeThreshold),
+				Message:  fmt.Sprintf("%d bytes in one concept (threshold %d; concept_read returns an outline instead of the body above %d) — %s", len(body), conceptOversizeThreshold, okf.ConceptReadSizeGuard, remedy),
 			})
 		}
 
@@ -230,7 +327,7 @@ func Run(k *kb.KB, scope string, scopeNeighbors bool) ([]Finding, error) {
 					if dateStr, ok := raVal.(string); ok {
 						t, parseErr := time.Parse("2006-01-02", dateStr)
 						if parseErr == nil && t.Before(Now()) {
-							findings = append(findings, Finding{
+							emit(Finding{
 								Path:     relPath,
 								Check:    "stale_claim",
 								Severity: SevWarning,
@@ -246,7 +343,7 @@ func Run(k *kb.KB, scope string, scopeNeighbors bool) ([]Finding, error) {
 				// across sessions instead of a big-bang rewrite.
 				if statusVal, ok := parsed.Get("status"); ok {
 					if statusStr, ok := statusVal.(string); ok && statusStr == "imported" {
-						findings = append(findings, Finding{
+						emit(Finding{
 							Path:     relPath,
 							Check:    "imported_draft",
 							Severity: SevWarning,
@@ -262,7 +359,7 @@ func Run(k *kb.KB, scope string, scopeNeighbors bool) ([]Finding, error) {
 				if !strings.EqualFold(parsed.Type(), "Service") {
 					for _, field := range []string{"secrets_source", "secret_refs"} {
 						if v, ok := parsed.Get(field); ok && !emptyFrontmatterValue(v) {
-							findings = append(findings, Finding{
+							emit(Finding{
 								Path:     relPath,
 								Check:    "secrets_on_non_service",
 								Severity: SevWarning,
@@ -303,7 +400,7 @@ func Run(k *kb.KB, scope string, scopeNeighbors bool) ([]Finding, error) {
 			// Skip concepts at depth=1 inside a known archive (expected entry points).
 			atArchiveTop := len(parts) == 2 && archiveSet[parts[0]]
 			if !atArchiveTop {
-				findings = append(findings, Finding{
+				emit(Finding{
 					Path:     relPath,
 					Check:    "orphan",
 					Severity: SevWarning,

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/BeppeTemp/cartographer/internal/kb"
+	"github.com/BeppeTemp/cartographer/internal/okf"
 )
 
 // helpers
@@ -1121,5 +1122,197 @@ func TestLint_DocumentingCodeExamplesRaisesNoBrokenLink(t *testing.T) {
 		if f.Check == "broken_link" {
 			t.Errorf("unexpected broken_link: %s — %s", f.Path, f.Message)
 		}
+	}
+}
+
+// --- D159 ---
+
+// A concept documenting a false positive could not be written without generating
+// the findings it describes: a KB's own "known false positives" page was
+// impossible.
+func TestLint_LintIgnoreSuppressesNamedChecks(t *testing.T) {
+	k := tempKB(t)
+	writeFile(t, k.DataRoot(), "m/_map.md", "---\ntype: Map\nkind: map\ntitle: M\n---\n# M\n")
+	writeFile(t, k.DataRoot(), "m/index.md", "---\ntype: Index\ntitle: M\n---\n- [fp](fp.md)\n")
+	writeFile(t, k.DataRoot(), "m/fp.md",
+		"---\ntype: Note\ntitle: FP\nlint_ignore: [machine_path]\n---\nThe path ~/.ssh/config is conventional.\n- [missing](missing.md)\n")
+
+	findings, err := Run(k, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var machinePath, brokenLink bool
+	for _, f := range findings {
+		switch f.Check {
+		case "machine_path":
+			machinePath = true
+		case "broken_link":
+			brokenLink = true
+		}
+	}
+	if machinePath {
+		t.Error("lint_ignore did not suppress machine_path")
+	}
+	// Only the named check is silenced: the others still fire.
+	if !brokenLink {
+		t.Error("lint_ignore silenced a check it does not name")
+	}
+}
+
+func TestLint_LintIgnoreAcceptsABareString(t *testing.T) {
+	k := tempKB(t)
+	writeFile(t, k.DataRoot(), "m/_map.md", "---\ntype: Map\nkind: map\ntitle: M\n---\n# M\n")
+	writeFile(t, k.DataRoot(), "m/index.md", "---\ntype: Index\ntitle: M\n---\n- [fp](fp.md)\n")
+	writeFile(t, k.DataRoot(), "m/fp.md", "---\ntype: Note\ntitle: FP\nlint_ignore: machine_path\n---\n~/.ssh/config\n")
+
+	findings, err := Run(k, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range findings {
+		if f.Check == "machine_path" {
+			t.Error("a bare-string lint_ignore was not honoured")
+		}
+	}
+}
+
+// An error is a contract violation, not a judgement: letting a concept declare
+// its own contract void would be a hole, not an escape hatch.
+func TestLint_LintIgnoreCannotSilenceAnError(t *testing.T) {
+	k := tempKB(t)
+	writeFile(t, k.DataRoot(), "m/_map.md", "---\ntype: Map\nkind: map\ntitle: M\nrequired_fields: [status]\n---\n# M\n")
+	writeFile(t, k.DataRoot(), "m/index.md", "---\ntype: Index\ntitle: M\n---\n- [c](c.md)\n")
+	writeFile(t, k.DataRoot(), "m/c.md", "---\ntype: Note\ntitle: C\nlint_ignore: [missing_required_field]\n---\n# C\n")
+
+	findings, err := Run(k, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stillErrors, invalid bool
+	for _, f := range findings {
+		if f.Check == "missing_required_field" {
+			stillErrors = true
+		}
+		if f.Check == "lint_ignore_invalid" {
+			invalid = true
+		}
+	}
+	if !stillErrors {
+		t.Error("lint_ignore silenced an error-severity contract violation")
+	}
+	if !invalid {
+		t.Error("naming an unsuppressible check must be reported, not ignored")
+	}
+}
+
+// A typo that silently suppresses nothing is worse than no opt-out at all.
+func TestLint_LintIgnoreUnknownCheckIsReported(t *testing.T) {
+	k := tempKB(t)
+	writeFile(t, k.DataRoot(), "m/_map.md", "---\ntype: Map\nkind: map\ntitle: M\n---\n# M\n")
+	writeFile(t, k.DataRoot(), "m/index.md", "---\ntype: Index\ntitle: M\n---\n- [c](c.md)\n")
+	writeFile(t, k.DataRoot(), "m/c.md", "---\ntype: Note\ntitle: C\nlint_ignore: [nonsense]\n---\n# C\n")
+
+	findings, err := Run(k, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, f := range findings {
+		if f.Check == "lint_ignore_invalid" && strings.Contains(f.Message, "nonsense") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want a lint_ignore_invalid naming the unknown check, got %+v", findings)
+	}
+}
+
+// ~/.ssh/config means "your ssh config" on every machine, exactly as /etc/... does,
+// and there was no way to declare it legitimate.
+func TestLint_MachinePathAllowsTildePrefixes(t *testing.T) {
+	k := tempKB(t)
+	writeFile(t, k.DataRoot(), "m/_map.md", "---\ntype: Map\nkind: map\ntitle: M\nmachine_path_allow_prefixes: [~/.ssh]\n---\n# M\n")
+	writeFile(t, k.DataRoot(), "m/index.md", "---\ntype: Index\ntitle: M\n---\n- [c](c.md)\n- [d](d.md)\n")
+	writeFile(t, k.DataRoot(), "m/c.md", "---\ntype: Note\ntitle: C\n---\nSee ~/.ssh/config for the host list.\n")
+	writeFile(t, k.DataRoot(), "m/d.md", "---\ntype: Note\ntitle: D\n---\nSee ~/.sshx/other for something else.\n")
+
+	findings, err := Run(k, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var covered, boundary, malformed bool
+	for _, f := range findings {
+		if f.Check == "machine_path" && strings.Contains(f.Path, "m/c.md") {
+			covered = true
+		}
+		if f.Check == "machine_path" && strings.Contains(f.Path, "m/d.md") {
+			boundary = true
+		}
+		if f.Check == "contract_malformed" {
+			malformed = true
+		}
+	}
+	if malformed {
+		t.Error("a ~/-anchored allow prefix was rejected as malformed")
+	}
+	if covered {
+		t.Error("~/.ssh did not cover ~/.ssh/config")
+	}
+	// Segment-boundary matching: ~/.ssh must not cover ~/.sshx.
+	if !boundary {
+		t.Error("~/.ssh wrongly covered ~/.sshx/other")
+	}
+}
+
+// concept_expand requires two segments, so for a satellite the old advice named
+// an operation the product refuses.
+func TestLint_OversizeRemedyIsDepthAware(t *testing.T) {
+	big := strings.Repeat("x", 30001)
+	k := tempKB(t)
+	writeFile(t, k.DataRoot(), "m/_map.md", "---\ntype: Map\nkind: map\ntitle: M\n---\n# M\n")
+	writeFile(t, k.DataRoot(), "m/index.md", "---\ntype: Index\ntitle: M\n---\n- [c](c.md)\n")
+	writeFile(t, k.DataRoot(), "m/c/index.md", "---\ntype: Note\ntitle: C\n---\n"+big+"\n- [s](s.md)\n")
+	writeFile(t, k.DataRoot(), "m/c/s.md", "---\ntype: Note\ntitle: S\n---\n"+big+"\n")
+
+	findings, err := Run(k, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var forConcept, forSatellite string
+	for _, f := range findings {
+		if f.Check != "concept_oversize" {
+			continue
+		}
+		switch f.Path {
+		case "m/c":
+			forConcept = f.Message
+		case "m/c/s":
+			forSatellite = f.Message
+		}
+	}
+	if !strings.Contains(forConcept, "concept_expand") {
+		t.Errorf("an expandable concept should still be told to expand: %q", forConcept)
+	}
+	// It may mention concept_expand only to say it does not apply.
+	if strings.Contains(forSatellite, "consider concept_expand") {
+		t.Errorf("a satellite must not be advised to concept_expand: %q", forSatellite)
+	}
+	if !strings.Contains(forSatellite, "concept_expand does not apply") {
+		t.Errorf("a satellite should be told why the usual remedy is unavailable: %q", forSatellite)
+	}
+	if !strings.Contains(forSatellite, "sibling satellites") {
+		t.Errorf("a satellite should be told what is actually available: %q", forSatellite)
+	}
+	// Both messages name the read bound as well as the split threshold.
+	if !strings.Contains(forConcept, "60000") {
+		t.Errorf("the message should name the read guard too: %q", forConcept)
+	}
+}
+
+// The two thresholds are now related rather than independent numbers.
+func TestOversizeThresholdIsDerivedFromTheReadGuard(t *testing.T) {
+	if conceptOversizeThreshold*2 != okf.ConceptReadSizeGuard {
+		t.Errorf("conceptOversizeThreshold=%d, ConceptReadSizeGuard=%d: the two have drifted apart",
+			conceptOversizeThreshold, okf.ConceptReadSizeGuard)
 	}
 }

--- a/internal/mcpserver/tools_read.go
+++ b/internal/mcpserver/tools_read.go
@@ -125,7 +125,7 @@ func toolIndexGet(k *kb.KB) Tool {
 // 'outline' was requested — a 92 KB concept blew past a client's token
 // budget and forced a workaround outside the MCP surface (D78). 'full: true'
 // overrides the guard.
-const conceptReadSizeGuard = 60000
+const conceptReadSizeGuard = okf.ConceptReadSizeGuard
 
 // maxSectionNotFoundHeadings caps the heading list surfaced in a "section
 // not found" error, so the agent sees the real outline instead of guessing.

--- a/internal/okf/okf.go
+++ b/internal/okf/okf.go
@@ -73,6 +73,14 @@ func PathToID(relPath string) (ConceptID, error) {
 }
 
 // IDToPath converts a ConceptID to the relative path of the corresponding .md file.
+// ConceptReadSizeGuard is the body size (bytes) above which concept_read returns
+// an outline instead of the whole body. It lives here because two packages need
+// it: mcpserver enforces it, and lint derives its own "too big" threshold from it
+// (D159) — before that they were unrelated numbers, so a concept between them was
+// simultaneously "too big, split it" and "fine, here it is whole", with nothing
+// explaining the relationship.
+const ConceptReadSizeGuard = 60000
+
 func IDToPath(id ConceptID) string {
 	return string(id) + ".md"
 }


### PR DESCRIPTION
Four findings an author could not legitimately clear, or a remedy the product itself made unavailable.

## 1. Lint fired on documentation *about* lint

A concept documenting a `machine_path` false positive raised `machine_path`; one documenting the Mermaid/POSIX collision raised `broken_link`. **A KB's own "known false positives" page could not be written without generating the findings it described**, and the only allowlist was per-map and path-prefixes-only.

`lint_ignore: [check, …]` in a concept's frontmatter drops the named findings for that concept only — one `emit` closure at the top of the per-concept loop, not a condition at each site. Per-concept and not per-map deliberately: the cases are individual pages, and a map-wide suppression would hide the same check on fifty concepts nobody inspected.

**`error`-severity checks cannot be suppressed** and route around `emit` on purpose: `missing_required_field` and `expanded_ambiguous` are contract violations, not judgements. **Directory-level checks cannot either**, and that includes `orphan_asset` — it belongs to an expanded concept's asset set and is reported in the directory pass, so no single concept frontmatter owns it. Listing it as suppressible would have been a promise the implementation does not keep.

An unsuppressible or unknown name is itself reported as `lint_ignore_invalid`, with the reason: a typo that silently suppresses nothing is worse than no opt-out.

## 2. The allowlist rejected `~/`-anchored paths

`~/.ssh/config` means "your ssh config" on every machine, exactly the reasoning `machinePathRe`'s own comment already applies to `/etc` and `/var` — twelve of 73 initial findings in the field, with no way to declare them legitimate. Now accepted and matched **literally, with no home expansion anywhere**: expanding `~` would make the contract's meaning depend on the reader's home directory, the opposite of what an allowlist for portable paths is for. `~user/…` is rejected, since the detector never produces that form. `matchesAllowedPrefix` needed no change — it already compares at segment boundaries — and a test asserts that rather than assuming it.

**No shipped default list of well-known tool paths**: a built-in list is a policy every KB inherits without asking, and it would silently unflag `~/.ssh/id_rsa` in a KB that wants exactly that flagged.

## 3. The oversize remedy was impossible for a satellite

`concept_oversize` advised `concept_expand`, which requires two segments, while the write path caps depth at three — and the two largest concepts in the reporting KB were satellites. The message is now depth-aware and names splitting into sibling satellites instead.

## 4. Two unrelated numbers decided "too big"

`conceptOversizeThreshold = 30000` advised a split; `conceptReadSizeGuard = 60000` switched `concept_read` to an outline. A concept between them was simultaneously "too big, split it" and "fine, here it is whole" — and the lint constant's comment claimed it "mirrors" the guard, which is false. It is now `okf.ConceptReadSizeGuard / 2` in one expression, the constant having moved to `internal/okf` so both packages can reference it with no cycle, and the message names both bounds.

**The numeric value is unchanged** (60000/2 = 30000), deliberately: the fix is coherence, not a new policy, so **no KB sees a different set of findings** unless it opts out. A package-level test asserts the two cannot drift apart again.

## Tests

Six new tests: suppression of a named check while others still fire, bare-string form, an error that cannot be silenced (plus the `lint_ignore_invalid` it produces), an unknown check reported, `~/.ssh` covering `~/.ssh/config` but **not** `~/.sshx` and not reported malformed, and the depth-aware remedy for both an expandable concept and a satellite.

## Docs

`docs/data-plane.md` gains §Silencing a lint finding on one concept, covering all four points. `D159` in `docs/decisions/data-plane.md`.

## Verification

`make vet`, `make test` (23 packages), `make smoke-http` and `make e2e` (12/12) green locally; `gofmt -l` clean.

Closes #180
