### PR TITLE
feat(git): advisory KB lock, rebase-state refusal and a reindex hint after import

### DIFF
--- a/cmd/cartographer/import.go
+++ b/cmd/cartographer/import.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/BeppeTemp/cartographer/internal/clientconfig"
 	"github.com/BeppeTemp/cartographer/internal/kb"
 	"github.com/BeppeTemp/cartographer/internal/okf"
 )
@@ -62,6 +63,19 @@ func cmdImport(args []string) int {
 		return 2
 	}
 
+	// The server writes into this same directory, and the two interleaving
+	// corrupted the git index (D155). Fail fast rather than wait: an import is an
+	// operator action at a keyboard, and a silent ten-minute block is worse than
+	// an error naming what to stop. --dry-run returns above, before the KB is
+	// opened, so it never takes the lock.
+	release, lockErr := k.AcquireProcessLock(0, "cartographer import")
+	if lockErr != nil {
+		fmt.Fprintln(os.Stderr, "Error:", lockErr)
+		fmt.Fprintln(os.Stderr, "  Stop it first: cartographer service stop && cartographer import … && cartographer service start")
+		return 2
+	}
+	defer release()
+
 	scaffoldPaths, err := createImportMaps(k, plan)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)
@@ -87,10 +101,45 @@ func cmdImport(args []string) int {
 		}
 	}
 	fmt.Printf("imported: %d, skipped: %d, errors: %d\n", imported, len(plan.skipped), errored)
+	if imported > 0 {
+		// This process writes through the KB write path but from outside the
+		// server, so the server's FTS index knows nothing about it: search
+		// returned zero results while concept_list saw everything, and the natural
+		// conclusion was that the import had failed (D155). reindex is in the
+		// advanced visibility profile, so an agent session does not see it either.
+		printReindexHint(imported)
+	}
 	if errored > 0 {
 		return 1
 	}
 	return 0
+}
+
+// printReindexHint tells the operator that the search index is stale, and
+// rebuilds it first when a server is reachable (D155). The instruction is the
+// mandatory half; the automatic call is convenience and degrades to the
+// instruction on any failure — the import itself succeeded, so it never changes
+// the exit code.
+func printReindexHint(imported int) {
+	if reindexAfterImportFn() {
+		fmt.Println("search index rebuilt")
+		return
+	}
+	fmt.Printf("search index not updated by this process — run `cartographer reindex` so search sees the %d imported concept(s)\n", imported)
+}
+
+// reindexAfterImportFn is indirected so tests can describe the outcome instead of
+// needing a live server.
+var reindexAfterImportFn = func() bool {
+	dir, err := clientconfig.TargetDir()
+	if err != nil {
+		return false
+	}
+	cfg, err := clientconfig.Load(dir)
+	if err != nil || cfg == nil || cfg.ServerURL == "" {
+		return false
+	}
+	return cmdReindex(nil) == 0
 }
 
 // stringSliceFlag implements flag.Value, accumulating one entry per

--- a/cmd/cartographer/import_test.go
+++ b/cmd/cartographer/import_test.go
@@ -4,8 +4,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/BeppeTemp/cartographer/internal/kb"
 )
@@ -402,5 +404,107 @@ func TestSlugify(t *testing.T) {
 		if got := slugify(in); got != want {
 			t.Errorf("slugify(%q) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+// --- D155 ---
+
+// `cartographer import` writes into the same directory the server's sync loop
+// manages, and the two interleaving corrupted the git index. It fails fast rather
+// than waiting: an import is an operator action at a keyboard, and a silent block
+// is worse than an error naming what to stop.
+func TestCmdImport_RefusesWhileTheKBIsLocked(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("flock semantics differ on Windows")
+	}
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "a.md"), []byte("# A\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	kbDir := t.TempDir()
+	k, err := kb.Init(kbDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	release, err := k.AcquireProcessLock(time.Second, "cartographer serve")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	out := withStderr(t, func() {
+		if code := cmdImport([]string{"--source", src, "--kb", kbDir, "--default-map", "notes"}); code != 2 {
+			t.Errorf("cmdImport with the KB locked = %d, want 2", code)
+		}
+	})
+	for _, want := range []string{"locked by", "cartographer serve", "service stop"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output %q does not mention %q", out, want)
+		}
+	}
+}
+
+// A dry run writes nothing, so it must not contend for the lock either.
+func TestCmdImport_DryRunDoesNotTakeTheLock(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("flock semantics differ on Windows")
+	}
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "a.md"), []byte("# A\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	kbDir := t.TempDir()
+	k, err := kb.Init(kbDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	release, err := k.AcquireProcessLock(time.Second, "cartographer serve")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	withStdout(t, func() {
+		if code := cmdImport([]string{"--source", src, "--kb", kbDir, "--default-map", "notes", "--dry-run"}); code != 0 {
+			t.Errorf("dry run with the KB locked = %d, want 0", code)
+		}
+	})
+}
+
+// The import writes through the KB write path but from outside the server, so its
+// FTS index knows nothing: search returned zero while concept_list saw
+// everything, and the natural conclusion was that the import had failed.
+func TestCmdImport_TellsTheOperatorToReindex(t *testing.T) {
+	orig := reindexAfterImportFn
+	t.Cleanup(func() { reindexAfterImportFn = orig })
+
+	run := func() string {
+		src := t.TempDir()
+		if err := os.WriteFile(filepath.Join(src, "a.md"), []byte("# A\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		kbDir := t.TempDir()
+		if _, err := kb.Init(kbDir); err != nil {
+			t.Fatal(err)
+		}
+		return withStdout(t, func() {
+			if code := cmdImport([]string{"--source", src, "--kb", kbDir, "--default-map", "notes"}); code != 0 {
+				t.Errorf("cmdImport = %d, want 0", code)
+			}
+		})
+	}
+
+	reindexAfterImportFn = func() bool { return false }
+	if out := run(); !strings.Contains(out, "cartographer reindex") {
+		t.Errorf("with no reachable server the instruction must be printed: %q", out)
+	}
+
+	reindexAfterImportFn = func() bool { return true }
+	out := run()
+	if !strings.Contains(out, "search index rebuilt") {
+		t.Errorf("with a reachable server the index should be rebuilt: %q", out)
+	}
+	if strings.Contains(out, "cartographer reindex") {
+		t.Errorf("the instruction is redundant once the index was rebuilt: %q", out)
 	}
 }

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -25,6 +25,36 @@ observe either the complete batch or the exact pre-call KB state. It does
 not open a nested git commit; a rolled-back call also leaves no commit,
 since `gitWrap` only commits after the handler returns success.
 
+## The advisory KB lock
+
+Inside one server process, git operations are serialised by a per-KB mutex. That mutex is blind to
+any **other** process, and `cartographer import` is exactly that: a separate process writing into the
+same directory the sync loop manages. The two interleaving corrupted the git index — 617 staged
+deletions and 224 untracked entries for the same paths, with `HEAD` and the working tree verified
+byte-identical — so since D155 both take an **advisory lock file**, `.cartographer.lock` in the KB
+root (dot-prefixed, so every walker already skips it, and excluded via `.git/info/exclude` so it can
+never dirty the working tree).
+
+Advisory, not mandatory, on purpose:
+
+- a lock whose recorded pid no longer exists is **reclaimed** with a note on stderr — a crash must
+  not block a KB forever;
+- the **server waits** for a bounded window and then proceeds under its mutex alone, reporting the
+  condition: a lock held by something else must not stop the server from writing;
+- **`import` fails fast**, naming the holder and how to stop it. An import is an operator action at a
+  keyboard, and a silent ten-minute block is worse than an error. `--dry-run` writes nothing and never
+  takes the lock.
+
+**An in-progress rebase makes sync refuse.** An aborted `pull --rebase --autostash` left a
+`.git/rebase-merge` containing only an autostash, and from then on every MCP write failed with git's
+own *"there is already a rebase-merge directory"* — a message that names no way out — until the
+directory was removed by hand. `SyncIn`/`SyncOut` now detect the state first and return an error that
+names the remedy: `rebase --continue`/`--abort` for a real rebase, or the `stash list` inspection
+followed by removing the directory for an orphan autostash. **Detection plus instruction, never
+automatic deletion**: the directory may hold a real operator rebase, or an autostash holding the only
+copy of uncommitted work, and deleting another writer's state is the class of action that caused the
+incident in the first place.
+
 ## Git profiles
 
 `git.profile: local` is the default and the historical behavior. When

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -406,6 +406,18 @@ cartographer import --source ./docs --kb ./kb-clone \
 | `--message` | `import: <source> -> <kb>` | Commit message; implies `--commit` |
 | `--dir-as-concept` | `false` | Promotes a source directory with `index.md` (or `README.md`) into an expanded concept and keeps its satellites together |
 
+**`import` takes the KB's advisory lock** and fails fast when the server holds it (D155), naming the
+holder and the `service stop … && service start` sequence: it writes into the same directory the
+server's sync loop manages, and the two interleaving corrupted the git index. `--dry-run` writes
+nothing and never contends for it.
+
+**The search index is not updated by this process.** `import` writes through the KB write path but
+from outside the server, so the server's FTS index knows nothing about it — `search` returned zero
+results while `concept_list` saw everything, and the natural conclusion was that the import had
+failed. On completion the command rebuilds the index when a configured server is reachable, and
+otherwise prints the `cartographer reindex` instruction. It never changes the exit code: the import
+itself succeeded.
+
 **`import` rewrites markdown links.** Every `[text](path.md)` whose target is part of the same
 import is rewritten to the destination's relative form, computed from the file it lands in — the
 base lint uses since D149, so the importer's output no longer generates findings against itself.

--- a/docs/decisions/concurrency-git.md
+++ b/docs/decisions/concurrency-git.md
@@ -170,3 +170,59 @@ means, and putting the remote facts where the agent is already looking, removes 
 misreading without growing `tools/list`. The remote URL is redacted because it flows into
 an LLM context and into audit output.
 
+
+## D155 — Surviving an external process writing into a synced KB
+
+**Status: implemented (2026-08-28).** Amends [D76](#d76). Closes #176.
+
+**Context.** `cartographer import` is a separate process writing into the same directory the server's
+sync loop manages, and nothing coordinated the two. The only serialisation was `WithGitLock`, a
+`sync.Mutex` on the `KB` struct: it serialises concurrent tool calls **in one process** and is blind
+to any other. Three failures were observed on one migration.
+
+1. **The git index was corrupted.** After a large import, `git status --porcelain` reported 617
+   staged deletions and 224 untracked entries **for the same paths**, with `HEAD` and the working tree
+   verified byte-identical in both directions. Recovered with a mixed `git reset`. The mechanism is an
+   autostash/rebase interleaving with a foreign `git add`: git's index is process-global state and both
+   writers assumed exclusive use of it.
+2. **An aborted rebase froze the KB.** An interrupted `pull --rebase --autostash` left a
+   `.git/rebase-merge` containing **only** an autostash — no `head-name`, no todo. From then on every
+   MCP write failed with git's own *"there is already a rebase-merge directory"*, and the KB stayed
+   frozen until the directory was removed by hand. `PullRebaseAutostash` does abort on the failures it
+   recognises, but a process killed mid-rebase leaves the directory behind and nothing looked for it.
+3. **The search index was stale and nothing said so.** `import` writes through the KB write path but
+   from another process, so the server's FTS index was untouched: `search` returned zero results while
+   `concept_list` saw everything. `reindex` fixes it but sits in the advanced visibility profile, so it
+   is not among the tools an agent session sees. The natural conclusion was that the import had failed.
+
+**Decision.**
+
+- **An advisory on-disk lock**, `.cartographer.lock` in the KB root, taken by the server around its
+  git critical section and by `import` for its whole run. Dot-prefixed, so every existing walker
+  already skips it, and added to `.git/info/exclude` in **both** `Init` and `Open` — a lock file that
+  shows in `git status` would block a server-profile PR reconciliation, which is how the first
+  implementation announced itself.
+- **Advisory, not mandatory**, deliberately: a stale lock from a killed process must never
+  permanently block a KB, so a lock whose recorded pid is gone is reclaimed with a note. `flock(2)`
+  where the filesystem supports it, the pid file alone as the weaker fallback.
+- **Asymmetric waiting.** The server waits a bounded window and then proceeds under its mutex alone,
+  reporting the condition — a foreign lock must not stop the server from writing. `import` **fails
+  fast**, naming the holder and the stop/start sequence: an import is an operator action at a
+  keyboard, and a silent block is worse than an error. `--dry-run` returns before the KB is opened and
+  never contends.
+- **Orphan-rebase recovery is detection plus instruction, never automatic deletion.**
+  `.git/rebase-merge/` may hold a real operator rebase, or an autostash holding the only copy of
+  uncommitted work. `SyncIn`/`SyncOut` refuse first and return an error naming the remedy —
+  `rebase --continue`/`--abort`, or the `stash list` inspection then removing the directory. Deleting
+  another writer's state automatically is the class of action that caused the incident.
+- **`import` tells the operator to reindex**, and rebuilds the index itself when a configured server
+  is reachable. Printing the instruction is the mandatory half; the automatic call is convenience and
+  degrades to the instruction on any failure, never changing the exit code — the import succeeded.
+- **Deliberately not done: a marker file the server watches.** It adds a background code path and a
+  new failure mode to save one command, and the server already reconciles derived indexes after a sync
+  that changed `HEAD`; the gap is only for writes that bypass the server entirely, which an explicit
+  instruction covers.
+
+**Consequences.** Every KB root gains a gitignored `.cartographer.lock`, and `import` can now refuse
+to start. **This does not make concurrent writing safe** — it makes it *detected*: the server remains
+the single writer for MCP traffic, and `WithGitLock`'s in-process semantics are unchanged.

--- a/internal/gitx/gitx.go
+++ b/internal/gitx/gitx.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -439,6 +440,51 @@ func Rebase(dir, onto string) error {
 		return fmt.Errorf("git rebase %s: %w: %s", onto, err, out)
 	}
 	return nil
+}
+
+// Rebase state kinds returned by RebaseInProgress.
+const (
+	// RebaseStateNormal: a real rebase is in progress (a head-name or todo is
+	// present), so someone is mid-operation and git owns the worktree.
+	RebaseStateNormal = "rebase"
+	// RebaseStateOrphanAutostash: the rebase directory exists but holds no
+	// rebase — only an autostash. Observed after a process was killed mid
+	// `pull --rebase --autostash`: from then on every write failed with "there is
+	// already a rebase-merge directory", and the KB was frozen until the
+	// directory was removed by hand (D155).
+	RebaseStateOrphanAutostash = "orphan-autostash"
+)
+
+// RebaseInProgress reports whether dir has a rebase state directory and what kind
+// it is. A caller must not run git in the worktree while this returns true: the
+// point is to refuse with an actionable message instead of letting git fail with
+// one that names no way out.
+func RebaseInProgress(dir string) (kind string, ok bool) {
+	for _, name := range []string{"rebase-merge", "rebase-apply"} {
+		d := filepath.Join(dir, ".git", name)
+		if _, err := os.Stat(d); err != nil {
+			continue
+		}
+		for _, marker := range []string{"head-name", "git-rebase-todo", "onto", "next"} {
+			if _, err := os.Stat(filepath.Join(d, marker)); err == nil {
+				return RebaseStateNormal, true
+			}
+		}
+		return RebaseStateOrphanAutostash, true
+	}
+	return "", false
+}
+
+// RebaseStateDir returns the path of the rebase state directory in dir, or "".
+// Named in the operator-facing message so the remedy points at a real path.
+func RebaseStateDir(dir string) string {
+	for _, name := range []string{"rebase-merge", "rebase-apply"} {
+		d := filepath.Join(dir, ".git", name)
+		if _, err := os.Stat(d); err == nil {
+			return d
+		}
+	}
+	return ""
 }
 
 // RebaseAbort aborts an in-progress rebase.

--- a/internal/kb/gitsync.go
+++ b/internal/kb/gitsync.go
@@ -4,11 +4,16 @@ import (
 	"errors"
 	"fmt"
 	neturl "net/url"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/BeppeTemp/cartographer/internal/gitx"
 )
+
+// processLockTimeout bounds how long a server write waits for the advisory KB
+// lock before proceeding without it (D155).
+var processLockTimeout = 30 * time.Second
 
 var (
 	syncOutMaxAttempts    = 5
@@ -16,12 +21,58 @@ var (
 	syncOutSleep          = time.Sleep
 )
 
+// ErrRebaseStatePresent reports a rebase state directory in the KB clone. Sync
+// refuses rather than letting git fail with a message that names no way out: an
+// aborted rebase left a .git/rebase-merge containing only an autostash, and from
+// then on every MCP write failed with "there is already a rebase-merge
+// directory" until it was removed by hand (D155).
+type ErrRebaseStatePresent struct {
+	Root string
+	Kind string
+	Dir  string
+}
+
+func (e *ErrRebaseStatePresent) Error() string {
+	if e.Kind == gitx.RebaseStateOrphanAutostash {
+		return fmt.Sprintf("%s exists but holds no rebase (only an autostash): the KB cannot sync until it is cleared. "+
+			"Inspect it with `git -C %s stash list` and `git -C %s log -1 --stat refs/stash`, then remove the directory once you are sure nothing in it is needed",
+			e.Dir, e.Root, e.Root)
+	}
+	return fmt.Sprintf("a git rebase is in progress in %s: finish it with `git -C %s rebase --continue` or abort it with `git -C %s rebase --abort`, then retry",
+		e.Root, e.Root, e.Root)
+}
+
+// checkRebaseState refuses to touch git while a rebase state directory exists.
+// Deliberately detection plus instruction, never automatic deletion: the
+// directory may hold a real operator rebase, or an autostash holding the only
+// copy of uncommitted work, and deleting another writer's state is the class of
+// action that caused the incident in the first place.
+func (k *KB) checkRebaseState() error {
+	kind, present := gitx.RebaseInProgress(k.Root)
+	if !present {
+		return nil
+	}
+	return &ErrRebaseStatePresent{Root: k.Root, Kind: kind, Dir: gitx.RebaseStateDir(k.Root)}
+}
+
 // WithGitLock acquires the per-KB mutex, executes fn, then releases it.
 // This serialises git operations so that concurrent tool calls do not interleave
 // their working-tree changes and commits.
 func (k *KB) WithGitLock(fn func() error) error {
 	k.mu.Lock()
 	defer k.mu.Unlock()
+	// The mutex serialises this process; the advisory lock file serialises
+	// against another one — `cartographer import` writes into the same directory
+	// the sync loop manages, and the two interleaving corrupted the git index
+	// (D155). Best-effort by design: a KB on a filesystem without flock, or a
+	// lock held past the window, must not make the server stop writing, so the
+	// condition is reported and the write proceeds under the mutex alone.
+	release, err := k.AcquireProcessLock(processLockTimeout, "cartographer serve")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cartographer: proceeding without the KB lock: %v\n", err)
+	} else {
+		defer release()
+	}
 	return fn()
 }
 
@@ -91,6 +142,9 @@ func (k *KB) lastSyncInAt() time.Time {
 // is. lastSyncIn is only updated after a fetch+pull that actually succeeds.
 // Callers must hold the git lock.
 func (k *KB) SyncIn() (bool, error) {
+	if err := k.checkRebaseState(); err != nil {
+		return false, err
+	}
 	if err := k.ServerWritesBlocked(); err != nil {
 		return false, err
 	}
@@ -139,6 +193,9 @@ func (k *KB) SyncIn() (bool, error) {
 // If PullRebaseAutostash returns ErrRebaseConflict, SyncOut returns immediately.
 // After 5 failed attempts it returns an error.
 func (k *KB) SyncOut() error {
+	if err := k.checkRebaseState(); err != nil {
+		return err
+	}
 	if !k.GitSync || !gitx.IsRepo(k.Root) {
 		k.setGitStatus("disabled", nil, 0)
 		return nil

--- a/internal/kb/kb.go
+++ b/internal/kb/kb.go
@@ -280,6 +280,9 @@ func Open(root string) (*KB, error) {
 		return nil, fmt.Errorf("%w: %s is not a valid KB (missing data/index.md)", okf.ErrNotFound, abs)
 	}
 	_ = ensureInfoExclude(abs, ".cartographer/")
+	// The advisory process lock is local state too (D155): never versioned, and
+	// excluded the same way rather than through a tracked .gitignore.
+	_ = ensureInfoExclude(abs, LockFileName)
 	return &KB{Root: abs}, nil
 }
 
@@ -380,6 +383,10 @@ func Init(root string) (*KB, error) {
 	// (D62): unlike a tracked .gitignore, this needs no commit and leaves no trace
 	// for a remote clone.
 	_ = ensureInfoExclude(abs, ".cartographer/")
+	// The advisory process lock is local state too (D155): never versioned, and
+	// excluded here as well as in Open so it can never show up as a dirty working
+	// tree — which is what blocks a server-profile PR reconciliation.
+	_ = ensureInfoExclude(abs, LockFileName)
 
 	return &KB{Root: abs}, nil
 }

--- a/internal/kb/lockfile.go
+++ b/internal/kb/lockfile.go
@@ -1,0 +1,125 @@
+package kb
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// LockFileName is the advisory per-KB lock a writer takes for the duration of a
+// git-touching critical section. Dot-prefixed so every walker already skips it
+// (listMDFiles, walkConceptPaths and discoverKBPaths all ignore dotfiles).
+const LockFileName = ".cartographer.lock"
+
+// lockPollInterval is how often AcquireProcessLock retries while waiting.
+const lockPollInterval = 100 * time.Millisecond
+
+// LockHeldError reports that another process holds the KB lock, naming the
+// holder so the operator knows what to stop.
+type LockHeldError struct {
+	Path    string
+	PID     int
+	Command string
+	Since   string
+}
+
+func (e *LockHeldError) Error() string {
+	holder := e.Command
+	if holder == "" {
+		holder = "another cartographer process"
+	}
+	return fmt.Sprintf("KB is locked by %s (pid %d) since %s", holder, e.PID, e.Since)
+}
+
+// AcquireProcessLock takes the advisory per-KB lock and returns the release
+// function. It exists because the only serialisation before D155 was an
+// in-process mutex (WithGitLock), blind to any other process: `cartographer
+// import` writes into the same directory the server's sync loop manages, and the
+// two interleaving corrupted the git index — 617 staged deletions and 224
+// untracked entries for the same paths, with HEAD and the working tree verified
+// byte-identical.
+//
+// Advisory, not mandatory: a stale lock from a killed process must never
+// permanently block a KB, so a lock whose recorded pid is gone is reclaimed with
+// a note on stderr. flock(2) where the filesystem supports it; the pid file alone
+// is the fallback, which is weaker but still catches the common case.
+func (k *KB) AcquireProcessLock(timeout time.Duration, command string) (release func(), err error) {
+	path := filepath.Join(k.Root, LockFileName)
+	deadline := time.Now().Add(timeout)
+
+	for {
+		f, openErr := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o644)
+		if openErr != nil {
+			return nil, fmt.Errorf("kb: open lock %s: %w", path, openErr)
+		}
+		if flockErr := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); flockErr == nil {
+			if err := writeLockOwner(f, command); err != nil {
+				_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+				f.Close()
+				return nil, err
+			}
+			return func() {
+				_ = f.Truncate(0)
+				_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+				f.Close()
+			}, nil
+		}
+
+		pid, cmd, since := readLockOwner(f)
+		f.Close()
+
+		// A recorded pid that no longer exists is a crash, not contention.
+		if pid > 0 && !processAlive(pid) {
+			fmt.Fprintf(os.Stderr, "cartographer: reclaiming stale KB lock from pid %d (%s)\n", pid, cmd)
+			_ = os.Remove(path)
+			continue
+		}
+		if time.Now().After(deadline) {
+			return nil, &LockHeldError{Path: path, PID: pid, Command: cmd, Since: since}
+		}
+		time.Sleep(lockPollInterval)
+	}
+}
+
+func writeLockOwner(f *os.File, command string) error {
+	if err := f.Truncate(0); err != nil {
+		return fmt.Errorf("kb: truncate lock: %w", err)
+	}
+	if _, err := f.Seek(0, 0); err != nil {
+		return fmt.Errorf("kb: seek lock: %w", err)
+	}
+	_, err := fmt.Fprintf(f, "%d\n%s\n%s\n", os.Getpid(), time.Now().UTC().Format(time.RFC3339), command)
+	return err
+}
+
+func readLockOwner(f *os.File) (pid int, command, since string) {
+	if _, err := f.Seek(0, 0); err != nil {
+		return 0, "", ""
+	}
+	buf := make([]byte, 512)
+	n, _ := f.Read(buf)
+	lines := strings.Split(strings.TrimSpace(string(buf[:n])), "\n")
+	if len(lines) > 0 {
+		pid, _ = strconv.Atoi(strings.TrimSpace(lines[0]))
+	}
+	if len(lines) > 1 {
+		since = strings.TrimSpace(lines[1])
+	}
+	if len(lines) > 2 {
+		command = strings.TrimSpace(lines[2])
+	}
+	if since == "" {
+		since = "an unknown time"
+	}
+	return pid, command, since
+}
+
+// processAlive reports whether pid exists. Signal 0 performs the existence and
+// permission check without delivering anything.
+func processAlive(pid int) bool {
+	return syscall.Kill(pid, 0) == nil
+}

--- a/internal/kb/lockfile_test.go
+++ b/internal/kb/lockfile_test.go
@@ -1,0 +1,196 @@
+package kb
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/BeppeTemp/cartographer/internal/gitx"
+)
+
+func skipWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("flock semantics differ on Windows")
+	}
+}
+
+func mustInitKB(t *testing.T) *KB {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "kb-lock-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	k, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return k
+}
+
+func gitStatusPorcelain(dir string) (string, error) {
+	out, err := exec.Command("git", "-C", dir, "status", "--porcelain").Output()
+	return string(out), err
+}
+
+// Before D155 the only serialisation was an in-process mutex, blind to any other
+// process: `cartographer import` wrote into the same directory the sync loop
+// managed, and the two interleaving corrupted the git index.
+func TestAcquireProcessLock(t *testing.T) {
+	skipWindows(t)
+
+	t.Run("serialises two acquirers", func(t *testing.T) {
+		k := mustInitKB(t)
+		release, err := k.AcquireProcessLock(time.Second, "first")
+		if err != nil {
+			t.Fatal(err)
+		}
+		// A second acquirer with no patience gets a typed error naming the holder.
+		_, err = k.AcquireProcessLock(0, "second")
+		var held *LockHeldError
+		if !errors.As(err, &held) {
+			t.Fatalf("second acquire = %v, want LockHeldError", err)
+		}
+		if held.PID != os.Getpid() || !strings.Contains(held.Error(), "first") {
+			t.Errorf("error does not name the holder: %v", held)
+		}
+		release()
+		// Released: available again.
+		release2, err := k.AcquireProcessLock(time.Second, "third")
+		if err != nil {
+			t.Fatalf("acquire after release: %v", err)
+		}
+		release2()
+	})
+
+	t.Run("a lock whose pid is dead is reclaimed", func(t *testing.T) {
+		k := mustInitKB(t)
+		// pid 0 is never a live process for Kill(pid, 0).
+		lockPath := filepath.Join(k.Root, LockFileName)
+		if err := os.WriteFile(lockPath, []byte("0\n2020-01-01T00:00:00Z\nghost\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		release, err := k.AcquireProcessLock(0, "live")
+		if err != nil {
+			t.Fatalf("a stale lock must not block a KB forever: %v", err)
+		}
+		release()
+	})
+
+	t.Run("concurrent acquirers do not overlap", func(t *testing.T) {
+		k := mustInitKB(t)
+		var mu sync.Mutex
+		inside, maxInside := 0, 0
+		var wg sync.WaitGroup
+		for i := 0; i < 4; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				release, err := k.AcquireProcessLock(5*time.Second, "worker")
+				if err != nil {
+					t.Errorf("acquire: %v", err)
+					return
+				}
+				mu.Lock()
+				inside++
+				if inside > maxInside {
+					maxInside = inside
+				}
+				mu.Unlock()
+				time.Sleep(10 * time.Millisecond)
+				mu.Lock()
+				inside--
+				mu.Unlock()
+				release()
+			}()
+		}
+		wg.Wait()
+		if maxInside != 1 {
+			t.Errorf("%d acquirers were inside the lock at once", maxInside)
+		}
+	})
+
+	t.Run("the lock file never dirties the working tree", func(t *testing.T) {
+		k := mustInitKB(t)
+		release, err := k.AcquireProcessLock(time.Second, "writer")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer release()
+		out, err := gitStatusPorcelain(k.Root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(out, LockFileName) {
+			t.Errorf("the lock file shows in git status, which blocks a server-profile PR reconciliation:\n%s", out)
+		}
+	})
+}
+
+// An aborted rebase left a .git/rebase-merge holding only an autostash, and from
+// then on every write failed with a message that named no way out.
+func TestSyncRefusesWhileARebaseStateExists(t *testing.T) {
+	skipWindows(t)
+
+	t.Run("orphan autostash", func(t *testing.T) {
+		k := mustInitKB(t)
+		dir := filepath.Join(k.Root, ".git", "rebase-merge")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "autostash"), []byte("deadbeef\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		kind, present := gitx.RebaseInProgress(k.Root)
+		if !present || kind != gitx.RebaseStateOrphanAutostash {
+			t.Fatalf("RebaseInProgress = %q, %v", kind, present)
+		}
+		err := k.SyncOut()
+		var state *ErrRebaseStatePresent
+		if !errors.As(err, &state) {
+			t.Fatalf("SyncOut = %v, want ErrRebaseStatePresent", err)
+		}
+		// The message must name the way out, which is the whole point.
+		for _, want := range []string{"only an autostash", "stash list", "remove the directory"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("message %q does not mention %q", err, want)
+			}
+		}
+	})
+
+	t.Run("a real rebase in progress", func(t *testing.T) {
+		k := mustInitKB(t)
+		dir := filepath.Join(k.Root, ".git", "rebase-merge")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "head-name"), []byte("refs/heads/main\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		kind, present := gitx.RebaseInProgress(k.Root)
+		if !present || kind != gitx.RebaseStateNormal {
+			t.Fatalf("RebaseInProgress = %q, %v", kind, present)
+		}
+		err := k.SyncOut()
+		if err == nil || !strings.Contains(err.Error(), "rebase --continue") {
+			t.Fatalf("SyncOut = %v, want the continue/abort remedy", err)
+		}
+	})
+
+	t.Run("a clean repo syncs", func(t *testing.T) {
+		k := mustInitKB(t)
+		if _, present := gitx.RebaseInProgress(k.Root); present {
+			t.Fatal("a fresh KB must have no rebase state")
+		}
+		if err := k.checkRebaseState(); err != nil {
+			t.Errorf("checkRebaseState on a clean repo = %v", err)
+		}
+	})
+}


### PR DESCRIPTION
`cartographer import` is a separate process writing into the same directory the server's sync loop manages, and nothing coordinated the two. The only serialisation was `WithGitLock` — a `sync.Mutex` on the `KB` struct, which serialises tool calls **in one process** and is blind to any other.

Three failures from one field migration:

1. **Corrupted git index.** After a large import, `git status --porcelain` reported 617 staged deletions and 224 untracked entries **for the same paths**, with `HEAD` and the working tree verified byte-identical. git's index is process-global state and both writers assumed exclusive use of it.
2. **An aborted rebase froze the KB.** An interrupted `pull --rebase --autostash` left `.git/rebase-merge` holding **only** an autostash — no `head-name`, no todo — and from then on every MCP write failed with git's own *"there is already a rebase-merge directory"*, a message naming no way out, until it was removed by hand.
3. **The search index was stale and nothing said so.** `search` returned zero while `concept_list` saw everything; `reindex` fixes it but is in the advanced profile, so an agent session never sees it. The natural conclusion was that the import had failed.

## What changed

- **An advisory lock file**, `.cartographer.lock` in the KB root, taken by the server around its git critical section and by `import` for its whole run. `flock(2)` where available, pid file as the weaker fallback.
- **Excluded via `.git/info/exclude` in both `Init` and `Open`.** A lock file visible in `git status` blocks a server-profile PR reconciliation — which is how the first cut of this announced itself, and there is now a test asserting the lock never dirties the working tree.
- **Advisory, not mandatory**: a lock whose recorded pid is gone is reclaimed with a note, so a crash cannot block a KB forever.
- **Asymmetric waiting.** The server waits a bounded window then proceeds under its mutex alone, reporting the condition — a foreign lock must not stop the server from writing. **`import` fails fast**, naming the holder and the stop/start sequence: an import is an operator action at a keyboard, and a silent block is worse than an error. `--dry-run` never contends.
- **Rebase state makes sync refuse**, with an error naming the remedy: `rebase --continue`/`--abort` for a real rebase, or the `stash list` inspection then removing the directory for an orphan autostash. **Detection plus instruction, never automatic deletion** — the directory may hold a real operator rebase, or an autostash holding the only copy of uncommitted work, and deleting another writer's state is the class of action that caused the incident.
- **`import` tells the operator to reindex**, and rebuilds the index itself when a configured server is reachable. The instruction is the mandatory half; the automatic call degrades to it on any failure and never changes the exit code — the import succeeded.

**Deliberately not done:** a marker file the server watches. It adds a background code path and a new failure mode to save one command, and the server already reconciles derived indexes after a sync that changed `HEAD`.

## Tests

`TestAcquireProcessLock`: two acquirers serialise with a typed error naming the holder, a dead pid is reclaimed, four concurrent acquirers never overlap, **and the lock file never appears in `git status`**. `TestSyncRefusesWhileARebaseStateExists`: orphan autostash and real rebase both refused with their own remedy in the message, clean repo unaffected. `TestCmdImport_RefusesWhileTheKBIsLocked`, `TestCmdImport_DryRunDoesNotTakeTheLock`, `TestCmdImport_TellsTheOperatorToReindex` (both branches, and the instruction is *not* printed once the index was rebuilt).

## Docs

`docs/concurrency.md` gains §The advisory KB lock; `docs/configurator.md` covers both new `import` behaviours. `D155` in `docs/decisions/concurrency-git.md`.

## Release impact

Every KB root gains a gitignored `.cartographer.lock`, and `import` can now refuse to start. **This does not make concurrent writing safe** — it makes it *detected*: the server remains the single writer for MCP traffic.

## Verification

`make vet`, `make test` (23 packages), `make smoke-http` and `make e2e` (12/12) green locally; `gofmt -l` clean.

Closes #176
