### PR TITLE
feat(kb): complete the concept refactor primitives with merge, collapse and a complete move

### DIFF
--- a/cmd/cartographer/import.go
+++ b/cmd/cartographer/import.go
@@ -511,35 +511,9 @@ func rewriteMarkdownLinks(body, srcRel, destPath string, moveMap map[string]stri
 			return match
 		}
 
-		newHref := relLinkPath(newBaseDir, newTarget) + frag
+		newHref := kb.RelLink(newBaseDir, newTarget) + frag
 		return "[" + text + "](" + newHref + ")"
 	})
-}
-
-// relLinkPath returns the relative forward-slash path from directory baseDir
-// to file targetPath (both clean forward-slash paths from the same root,
-// baseDir "." meaning that root) — a local copy of kb's unexported relLink,
-// scoped here to avoid exporting KB-internal move machinery for a single
-// caller.
-func relLinkPath(baseDir, targetPath string) string {
-	baseDir = path.Clean(baseDir)
-	var baseParts []string
-	if baseDir != "." {
-		baseParts = strings.Split(baseDir, "/")
-	}
-	targetParts := strings.Split(path.Clean(targetPath), "/")
-
-	i := 0
-	for i < len(baseParts) && i < len(targetParts)-1 && baseParts[i] == targetParts[i] {
-		i++
-	}
-
-	var relParts []string
-	for j := i; j < len(baseParts); j++ {
-		relParts = append(relParts, "..")
-	}
-	relParts = append(relParts, targetParts[i:]...)
-	return strings.Join(relParts, "/")
 }
 
 // slugify converts an arbitrary source filename (without extension) into a

--- a/docs/data-plane.md
+++ b/docs/data-plane.md
@@ -10,7 +10,7 @@ The data plane is the **source of truth**: UTF-8 `.md` files with YAML frontmatt
 | 2 | **Map** / **Journal** | Map: a thematic domain with mixed `concept_types` (e.g. `smart-home`, `infra`). Journal: a chronological, append-oriented log (e.g. `incidents`, `notes`) | Top-level subdirectory, described by `_map.md` (`kind: map\|journal`) |
 | 3 | **Concept** | A single knowledge page | `.md` file with frontmatter |
 
-There is no intermediate categorization level (D77): category navigation is the job of curated `index.md` files, `search`, and the graph — not the filesystem. A growing concept becomes an **expanded concept** — a *state*, not a level: `concept_expand` turns `map/name.md` into `map/name/index.md` **without changing the ConceptID** (ID resolution tries `<id>.md` and then `<id>/index.md`, so no backlink breaks), and from there the concept can grow with `map/name/child` satellites and assets. Expansion is the prerequisite for owning assets. Expansion is also allowed in journals (e.g. a heavy incident with attachments). There is no inverse operation (`concept_collapse`, YAGNI — D77).
+There is no intermediate categorization level (D77): category navigation is the job of curated `index.md` files, `search`, and the graph — not the filesystem. A growing concept becomes an **expanded concept** — a *state*, not a level: `concept_expand` turns `map/name.md` into `map/name/index.md` **without changing the ConceptID** (ID resolution tries `<id>.md` and then `<id>/index.md`, so no backlink breaks), and from there the concept can grow with `map/name/child` satellites and assets. Expansion is the prerequisite for owning assets. Expansion is also allowed in journals (e.g. a heavy incident with attachments). `concept_collapse` is its inverse (D160): `map/name/index.md` becomes `map/name.md` under the same ConceptID, so no inbound link changes. It refuses while the directory still holds satellites or assets — both would have no home after the collapse — and names them. `concept_merge` folds a satellite into its own parent, rebasing the merged body's relative links and redirecting every inbound link, including those from sibling satellites; both are `advanced`, i.e. callable by name but not advertised in `tools/list`.
 
 Depth is **enforced on the write path** (D72 WP4): a ConceptID under `data/` has at most 3 segments (`map/concept/child`, where the third segment only exists inside an expanded concept); deeper writes are rejected. Reads are unaffected (legacy KBs remain readable). If a write implicitly creates a new expansion directory (e.g. `concept_move` into a nested path), the server also generates the `index.md` stub (`type: Index`, title from the name) — so `index_get`'s progressive disclosure never breaks. Lint defends the semantics of the hierarchy (D77 WP4, `concept_oversize` D78): `expanded_missing_index` (a directory with no `index.md`), `expanded_ambiguous` (both `<id>.md` and `<id>/index.md` exist: writes are blocked until one form is removed), `expanded_as_category` (many children not linked from the concept's index: the directory is being used as a taxonomy), `map_oversize` (a map beyond the size threshold: a thematic split is preferable to a subfolder), `legacy_archive_descriptor` (a pre-D77 `_archive.md` descriptor), `concept_oversize` (a concept beyond the byte threshold: a candidate for `concept_expand` into a dossier).
 
@@ -137,6 +137,19 @@ Concept ID = path relative to the bundle without `.md`. File names are `kebab-ca
 **One base, and it is the file** (D149). A relative markdown link resolves against the file that contains it, exactly as a markdown viewer resolves it — so from an expanded concept's `index.md` a satellite is `[s](s.md)`, not `[s](c/s.md)`. The graph and lint use that same base; lint's existence check goes through the same resolver `concept_read` uses, so a link to the canonical ID of an expanded concept (`[c](c.md)` where `map/c/index.md` holds it) is valid rather than broken. A wiki-link `[[id]]` is root-relative and therefore base-independent, which is why it is the safe choice when in doubt.
 
 **In a curated index, both forms are accepted** for an expanded concept: `[c](c.md)` and `[c](c/index.md)` both satisfy `require_index_entry`. The two used to be inverses of each other — one valid between concepts, the other in an index — with nothing to tell them apart.
+
+### What a move touches
+
+`concept_move` is complete as of D160: it rewrites **inbound** links across the KB, **the moved
+concept's own relative links** (the directory delta is known, so this is arithmetic), and — for maps
+that opted in with `require_index_entry` — **both curated indexes**, removing the source entry and
+appending one to the destination under a `## Moved here` heading.
+
+Both index edits are conservative. A source line is removed only when the moved concept is its **only**
+link: a line citing two concepts is prose the operator wrote, so it is kept and reported instead.
+Cartographer does not attempt to place the destination entry in the right thematic section — it cannot
+know, and a wrong placement in a curated document is worse than an obvious one at the end.
+`rewrite_links: false` still means "touch no other concept", so it skips the index maintenance too.
 
 ### Silencing a lint finding on one concept
 

--- a/docs/decisions/data-plane.md
+++ b/docs/decisions/data-plane.md
@@ -450,3 +450,57 @@ made unavailable.
 messages. **The numeric value is unchanged** (60000/2 = 30000), deliberately: the fix is coherence,
 not a new policy, and a threshold change would belong to its own decision. A package-level test
 asserts the two constants cannot drift apart again.
+
+## D160 — Complete the concept refactor primitives: move, merge, collapse
+
+**Status: implemented (2026-08-28).** Amends [D77](#d77) (which recorded no inverse for
+`concept_expand`). Requires [D149](control-plane.md#d149). Closes #181.
+
+**Context.** Reorganising a KB is routine, and the three refactors that come up most each left the
+author with a manual link-repair pass.
+
+1. **`concept_move` rewrote inbound links only.** Documented and working — but the moved concept's own
+   relative links broke whenever the directory depth changed, and curated indexes were untouched: the
+   source map's index kept listing the concept (`broken_link`) and the destination's did not mention it
+   (`index_incomplete`).
+2. **Merging a satellite into its parent broke links three ways**: the merged body's own links were
+   relative to the satellite's directory, links **to** the deleted satellite remained in both syntaxes,
+   and so did links from **sibling** satellites. Done seven times in one session, each merge needed a
+   manual repair pass.
+3. **There was no inverse of `concept_expand`**, while `expanded_as_category` actively advises going
+   back above eight children. The only route was a batch `concept_move` by hand.
+
+**Decision.**
+
+- **The outbound rewrite has no flag.** A move that leaves the moved body's own links broken is simply
+  incomplete; a flag would preserve that as a supported mode. `RewriteOutboundLinks` consults the
+  batch's `moveMap` first, so two concepts moved together that link each other compose correctly —
+  the case a naive implementation gets wrong, and one the tests pin.
+- **`relLink` is exported rather than copied.** `cmd/cartographer/import.go` had a private copy whose
+  comment said it existed "to avoid exporting KB-internal move machinery for a single caller". There
+  are now two callers, so the copy is gone: a third would have been the bug.
+- **Curated indexes are maintained only where a contract asked for it** (`require_index_entry`).
+  Editing an index nobody declared as curated would be an assumption, not a fix.
+- **Both index edits are conservative.** A source line is removed only when the moved concept is its
+  only link; a line citing two concepts is kept and **reported**, because it is prose the operator
+  wrote. The destination entry is appended under a `## Moved here` heading created if absent:
+  Cartographer cannot know the right thematic section, and a wrong placement in a curated document is
+  worse than an obvious one at the end.
+- **`concept_merge` merges a satellite into its own parent only.** Arbitrary concept-into-concept
+  merging is a bigger design — whose frontmatter wins, which map — and is out of scope, which the
+  tool's description says. Inbound redirection goes through the same whole-KB `rewriteBacklinks` pass
+  a move uses, so **sibling satellites need no special case**: that is the third breakage, handled by
+  construction.
+- **`concept_collapse` does not change the ID**, because expansion never does: `<id>/index.md` becomes
+  `<id>.md` under the same ID and no inbound link needs rewriting. It refuses while satellites or
+  **assets** remain — assets live in the directory and only an expanded concept can hold them, so
+  moving them silently would be worse than refusing — and names them.
+- **Both new tools are `advanced`**: large-refactor tooling, same tier as `concept_batch` (D125).
+  Registered and callable by name, not advertised in `tools/list`, so the default working set stays
+  small. `TestServer_ToolsProfile` is the golden test that forces the classification.
+
+**Consequences.** `concept_move` now edits more than it used to, so an operator with a manual
+post-move routine should stop doing it. The strongest assertion available for all three is that a
+follow-up `lint` reports neither `broken_link` nor `index_incomplete`, and that expand-then-collapse
+returns the original content hash — a round trip, rather than a claim that the inverse is one.
+`docs/data-plane.md` no longer says there is no inverse.

--- a/internal/kb/graph.go
+++ b/internal/kb/graph.go
@@ -266,6 +266,68 @@ func RewriteLinks(body string, basePath string, moveMap map[string]string) (stri
 	return body, count
 }
 
+// RewriteOutboundLinks rebases every relative markdown link in body from oldBase
+// to newBase, both being the linking concept's own path relative to the KB root
+// (the same meaning as ExtractLinks' basePath). Returns the updated body and the
+// number of replacements.
+//
+// concept_move rewrote inbound links only, so the moved concept's own relative
+// links broke whenever the directory depth changed — documented, and still a
+// half-move (D160). The delta is known at move time, so this is arithmetic, not
+// guesswork.
+//
+// moveMap, when non-empty, is consulted first so a batch of moves composes: a
+// link whose target is itself being moved resolves to the target's new location
+// rather than to where it used to sit. Wiki-links are root-relative and
+// deliberately untouched; absolute URLs, anchors and mailto: are skipped, and a
+// link resolving outside the KB is left alone.
+func RewriteOutboundLinks(body, oldBase, newBase string, moveMap map[string]string) (string, int) {
+	oldDir, newDir := path.Dir(oldBase), path.Dir(newBase)
+	if oldDir == newDir && len(moveMap) == 0 {
+		return body, 0
+	}
+	count := 0
+	out := mdLinkRe.ReplaceAllStringFunc(body, func(match string) string {
+		sub := mdLinkRe.FindStringSubmatch(match)
+		text, href := sub[1], sub[2]
+		if strings.Contains(href, "://") || strings.HasPrefix(href, "#") || strings.HasPrefix(href, "mailto:") || strings.HasPrefix(href, "/") {
+			return match
+		}
+		pathPart, frag := href, ""
+		if idx := strings.Index(href, "#"); idx >= 0 {
+			pathPart, frag = href[:idx], href[idx:]
+		}
+		if pathPart == "" {
+			return match
+		}
+		resolved := path.Clean(path.Join(oldDir, pathPart))
+		if strings.HasPrefix(resolved, "..") {
+			return match
+		}
+		// A target moved in the same batch lands at its new path.
+		target := resolved
+		if moved, ok := moveMap[strings.TrimSuffix(resolved, ".md")]; ok {
+			target = moved + ".md"
+		}
+		newHref := RelLink(newDir, target)
+		if !strings.EqualFold(path.Ext(pathPart), ".md") {
+			newHref = strings.TrimSuffix(newHref, ".md")
+		}
+		if newHref+frag == href {
+			return match
+		}
+		count++
+		return "[" + text + "](" + newHref + frag + ")"
+	})
+	return out, count
+}
+
+// RelLink is relLink exported (D160): concept_move needs it to rewrite the moved
+// concept's own outbound links, and cmd/cartographer/import.go had a private copy
+// whose comment said it existed "to avoid exporting KB-internal move machinery for
+// a single caller". There are now two callers, so the copy is gone.
+func RelLink(baseDir, targetPath string) string { return relLink(baseDir, targetPath) }
+
 // relLink returns the relative path (forward-slash, markdown-link style)
 // from directory baseDir to file targetPath, both expressed as clean
 // forward-slash paths relative to the KB root (baseDir "." means the root).

--- a/internal/mcpserver/audit.go
+++ b/internal/mcpserver/audit.go
@@ -34,6 +34,8 @@ var auditResourceFields = map[string][]string{
 	"concept_new":          {"id", "template"},
 	"concept_patch":        {"id"},
 	"concept_expand":       {"id"},
+	"concept_collapse":     {"id"},
+	"concept_merge":        {"satellite_id"},
 	"concept_delete":       {"id"},
 	"concept_move":         {"source_id", "target_id"},
 	"supersede":            {"source_id", "target_id"},

--- a/internal/mcpserver/docs_test.go
+++ b/internal/mcpserver/docs_test.go
@@ -62,8 +62,6 @@ var docsNonTools = map[string]bool{
 	// deliberately leaves to it (D141: Hermes adopts a delivered skill with
 	// its own skill_manage)
 	"skill_manage": true,
-	// intentionally absent, documented as not implemented (D77, YAGNI)
-	"concept_collapse": true,
 }
 
 // docsFiles are the markdown files whose tool citations must resolve. The

--- a/internal/mcpserver/policy.go
+++ b/internal/mcpserver/policy.go
@@ -30,7 +30,7 @@ func resourceClassForTool(name string) string {
 	switch name {
 	case "atlas_overview", "changes_since", "map_list", "concept_list", "graph_neighbors", "search", "contradiction_report", "service_list":
 		return resourceCollection
-	case "concept_read", "concept_write", "concept_new", "concept_patch", "concept_expand", "concept_delete", "supersede", "asset_read", "asset_list", "asset_write", "asset_delete", "service_get":
+	case "concept_read", "concept_write", "concept_new", "concept_patch", "concept_expand", "concept_collapse", "concept_merge", "concept_delete", "supersede", "asset_read", "asset_list", "asset_write", "asset_delete", "service_get":
 		return resourceExact
 	case "concept_move":
 		return resourceMove

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/BeppeTemp/cartographer/internal/gitx"
 	"github.com/BeppeTemp/cartographer/internal/kb"
+	"github.com/BeppeTemp/cartographer/internal/lint"
 	"github.com/BeppeTemp/cartographer/internal/okf"
 	"github.com/BeppeTemp/cartographer/internal/sqlindex"
 )
@@ -4669,5 +4670,301 @@ func TestServer_ClientStats_Ordering(t *testing.T) {
 	}
 	if stats[0].ClientVersion != "1.0" || stats[1].ClientVersion != "2.0" {
 		t.Errorf("alpha rows: versions = %q/%q, want 1.0/2.0", stats[0].ClientVersion, stats[1].ClientVersion)
+	}
+}
+
+// --- D160 WP1/WP2: a move is complete ---
+
+// concept_move rewrote inbound links only, so the moved concept's own relative
+// links broke when the directory depth changed, and the two curated indexes were
+// left inconsistent. The strongest available assertion is that a follow-up lint
+// reports neither broken_link nor index_incomplete.
+func TestConceptMove_IsCompleteAcrossMaps(t *testing.T) {
+	k := setupTestKB(t)
+	s := New("test")
+	RegisterKBTools(s, k, Deps{})
+
+	write := func(rel, content string) {
+		t.Helper()
+		abs := filepath.Join(k.DataRoot(), rel)
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Two maps, both with a curated-index contract. The moved concept links a
+	// sibling relatively, which is what breaks on a depth change.
+	write("src/_map.md", "---\ntype: Map\nkind: map\ntitle: Src\nrequire_index_entry: true\n---\n# Src\n")
+	write("src/index.md", "---\ntype: Index\ntitle: Src\n---\n- [mover](mover.md)\n- [friend](friend.md)\n")
+	write("src/friend.md", "---\ntype: Note\ntitle: Friend\n---\n# Friend\n")
+	write("src/mover.md", "---\ntype: Note\ntitle: Mover\n---\nSee [friend](friend.md).\n")
+	write("dst/_map.md", "---\ntype: Map\nkind: map\ntitle: Dst\nrequire_index_entry: true\n---\n# Dst\n")
+	write("dst/index.md", "---\ntype: Index\ntitle: Dst\n---\n# Dst\n")
+
+	move := s.Tools()["concept_move"]
+	res, err := move.Handler(authLocalContext(), json.RawMessage(`{"source_id":"src/mover","target_id":"dst/mover"}`))
+	if err != nil || res.IsError {
+		t.Fatalf("concept_move: %+v err=%v", res, err)
+	}
+
+	// The moved body's own link now points back at the sibling it left behind.
+	moved, err := k.ReadConcept("dst/mover")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(moved.Body, "../src/friend.md") {
+		t.Errorf("the moved concept's own outbound link was not rebased:\n%s", moved.Body)
+	}
+
+	// Both curated indexes were maintained.
+	srcIndex, err := k.ReadIndex("src")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(srcIndex, "mover.md") {
+		t.Errorf("the source index still lists the moved concept:\n%s", srcIndex)
+	}
+	dstIndex, err := k.ReadIndex("dst")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(dstIndex, "mover.md") {
+		t.Errorf("the destination index does not list the moved concept:\n%s", dstIndex)
+	}
+
+	// The end-to-end property, not just the text.
+	findings, err := lint.Run(k, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range findings {
+		if f.Check == "broken_link" || f.Check == "index_incomplete" {
+			t.Errorf("lint after the move: %s %s — %s", f.Check, f.Path, f.Message)
+		}
+	}
+}
+
+// A line citing two concepts is prose the operator wrote: it is kept and
+// reported, not silently edited.
+func TestConceptMove_KeepsAMultiLinkIndexLine(t *testing.T) {
+	k := setupTestKB(t)
+	s := New("test")
+	RegisterKBTools(s, k, Deps{})
+	write := func(rel, content string) {
+		t.Helper()
+		abs := filepath.Join(k.DataRoot(), rel)
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("src/_map.md", "---\ntype: Map\nkind: map\ntitle: Src\nrequire_index_entry: true\n---\n# Src\n")
+	write("src/index.md", "---\ntype: Index\ntitle: Src\n---\n- see [mover](mover.md) and [friend](friend.md)\n")
+	write("src/friend.md", "---\ntype: Note\ntitle: Friend\n---\n# Friend\n")
+	write("src/mover.md", "---\ntype: Note\ntitle: Mover\n---\n# Mover\n")
+	write("dst/_map.md", "---\ntype: Map\nkind: map\ntitle: Dst\n---\n# Dst\n")
+	write("dst/index.md", "---\ntype: Index\ntitle: Dst\n---\n# Dst\n")
+
+	res, err := s.Tools()["concept_move"].Handler(authLocalContext(), json.RawMessage(`{"source_id":"src/mover","target_id":"dst/mover"}`))
+	if err != nil || res.IsError {
+		t.Fatalf("concept_move: %+v err=%v", res, err)
+	}
+	srcIndex, err := k.ReadIndex("src")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(srcIndex, "friend.md") {
+		t.Errorf("a line citing another concept must not be removed:\n%s", srcIndex)
+	}
+	if !strings.Contains(res.Content[0].Text, "edit it by hand") {
+		t.Errorf("the result should say the line was kept: %s", res.Content[0].Text)
+	}
+}
+
+// --- D160 WP3: concept_merge and concept_collapse ---
+
+func d160Fixture(t *testing.T) (*kb.KB, *Server) {
+	t.Helper()
+	k := setupTestKB(t)
+	s := New("test")
+	RegisterKBTools(s, k, Deps{})
+	return k, s
+}
+
+func d160Write(t *testing.T, k *kb.KB, rel, content string) {
+	t.Helper()
+	abs := filepath.Join(k.DataRoot(), rel)
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Consolidating a dossier broke links three ways when done by hand: the merged
+// body's own relative links, links TO the satellite, and links from sibling
+// satellites. The strongest assertion is a clean lint afterwards.
+func TestConceptMerge_FoldsASatelliteAndRepairsEveryLink(t *testing.T) {
+	k, s := d160Fixture(t)
+	d160Write(t, k, "m/_map.md", "---\ntype: Map\nkind: map\ntitle: M\n---\n# M\n")
+	d160Write(t, k, "m/index.md", "---\ntype: Index\ntitle: M\n---\n- [c](c.md)\n- [other](other.md)\n")
+	d160Write(t, k, "m/other.md", "---\ntype: Note\ntitle: Other\n---\nSee [[m/c/child]] and [child](c/child.md).\n")
+	d160Write(t, k, "m/c/index.md", "---\ntype: Note\ntitle: C\n---\n# C\n- [child](child.md)\n- [sib](sib.md)\n")
+	d160Write(t, k, "m/c/child.md", "---\ntype: Note\ntitle: Child\n---\nBody. See [sib](sib.md).\n")
+	d160Write(t, k, "m/c/sib.md", "---\ntype: Note\ntitle: Sib\n---\nSee [child](child.md).\n")
+
+	child, err := k.ReadConcept("m/c/child")
+	if err != nil {
+		t.Fatal(err)
+	}
+	args, _ := json.Marshal(map[string]string{"satellite_id": "m/c/child", "if_match": child.ContentHash})
+	res, err := s.Tools()["concept_merge"].Handler(authLocalContext(), args)
+	if err != nil || res.IsError {
+		t.Fatalf("concept_merge: %+v err=%v", res, err)
+	}
+
+	parent, err := k.ReadConcept("m/c")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(parent.Body, "## Child") || !strings.Contains(parent.Body, "Body.") {
+		t.Errorf("the satellite's body was not folded in:\n%s", parent.Body)
+	}
+	// Its own link to a sibling moved up one level: from m/c/ the sibling is
+	// still sib.md, so the merged text must keep resolving.
+	if !strings.Contains(parent.Body, "sib.md") {
+		t.Errorf("the merged body's own link was lost:\n%s", parent.Body)
+	}
+	if _, err := k.ReadConcept("m/c/child"); err == nil {
+		t.Error("the satellite still exists after the merge")
+	}
+	// Inbound links, both syntaxes, including from a sibling satellite.
+	other, err := k.ReadConcept("m/other")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(other.Body, "m/c/child") {
+		t.Errorf("an inbound wiki-link was not redirected:\n%s", other.Body)
+	}
+	sib, err := k.ReadConcept("m/c/sib")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(sib.Body, "child.md") {
+		t.Errorf("a sibling satellite's link was not redirected:\n%s", sib.Body)
+	}
+	findings, err := lint.Run(k, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range findings {
+		if f.Check == "broken_link" {
+			t.Errorf("lint after the merge: %s — %s", f.Path, f.Message)
+		}
+	}
+}
+
+func TestConceptMerge_RefusesANonSatellite(t *testing.T) {
+	k, s := d160Fixture(t)
+	d160Write(t, k, "m/_map.md", "---\ntype: Map\nkind: map\ntitle: M\n---\n# M\n")
+	d160Write(t, k, "m/c.md", "---\ntype: Note\ntitle: C\n---\n# C\n")
+	c, err := k.ReadConcept("m/c")
+	if err != nil {
+		t.Fatal(err)
+	}
+	args, _ := json.Marshal(map[string]string{"satellite_id": "m/c", "if_match": c.ContentHash})
+	res, _ := s.Tools()["concept_merge"].Handler(authLocalContext(), args)
+	if !res.IsError || !strings.Contains(res.Content[0].Text, "3 segments") {
+		t.Errorf("concept_merge on a non-satellite = %+v, want a refusal", res.Content)
+	}
+}
+
+// Expansion never changes an ID, so its inverse must not either: the round trip
+// is the strongest available assertion that this really is an inverse.
+func TestConceptCollapse_RoundTripsExpand(t *testing.T) {
+	k, s := d160Fixture(t)
+	d160Write(t, k, "m/_map.md", "---\ntype: Map\nkind: map\ntitle: M\n---\n# M\n")
+	d160Write(t, k, "m/c.md", "---\ntype: Note\ntitle: C\n---\n# C\nBody stays.\n")
+
+	before, err := k.ReadConcept("m/c")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := k.ExpandConcept("m/c"); err != nil {
+		t.Fatal(err)
+	}
+	expanded, err := k.ReadConcept("m/c")
+	if err != nil {
+		t.Fatal(err)
+	}
+	args, _ := json.Marshal(map[string]string{"id": "m/c", "if_match": expanded.ContentHash})
+	res, err := s.Tools()["concept_collapse"].Handler(authLocalContext(), args)
+	if err != nil || res.IsError {
+		t.Fatalf("concept_collapse: %+v err=%v", res, err)
+	}
+	after, err := k.ReadConcept("m/c")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.ContentHash != before.ContentHash {
+		t.Errorf("the round trip changed the content:\nbefore=%q\nafter=%q", before.Content, after.Content)
+	}
+	if _, statErr := os.Stat(filepath.Join(k.DataRoot(), "m", "c")); statErr == nil {
+		t.Error("the expansion directory survived the collapse")
+	}
+}
+
+func TestConceptCollapse_RefusesSatellitesAndAssets(t *testing.T) {
+	t.Run("satellites", func(t *testing.T) {
+		k, s := d160Fixture(t)
+		d160Write(t, k, "m/_map.md", "---\ntype: Map\nkind: map\ntitle: M\n---\n# M\n")
+		d160Write(t, k, "m/c/index.md", "---\ntype: Note\ntitle: C\n---\n# C\n")
+		d160Write(t, k, "m/c/s.md", "---\ntype: Note\ntitle: S\n---\n# S\n")
+		data, err := k.ReadConcept("m/c")
+		if err != nil {
+			t.Fatal(err)
+		}
+		args, _ := json.Marshal(map[string]string{"id": "m/c", "if_match": data.ContentHash})
+		res, _ := s.Tools()["concept_collapse"].Handler(authLocalContext(), args)
+		if !res.IsError || !strings.Contains(res.Content[0].Text, "m/c/s") {
+			t.Errorf("collapse with a satellite = %+v, want a refusal naming it", res.Content)
+		}
+	})
+
+	t.Run("assets", func(t *testing.T) {
+		k, s := d160Fixture(t)
+		d160Write(t, k, "m/_map.md", "---\ntype: Map\nkind: map\ntitle: M\n---\n# M\n")
+		d160Write(t, k, "m/c/index.md", "---\ntype: Note\ntitle: C\n---\n# C\n")
+		d160Write(t, k, "m/c/evidence.csv", "a,b\n")
+		data, err := k.ReadConcept("m/c")
+		if err != nil {
+			t.Fatal(err)
+		}
+		args, _ := json.Marshal(map[string]string{"id": "m/c", "if_match": data.ContentHash})
+		res, _ := s.Tools()["concept_collapse"].Handler(authLocalContext(), args)
+		if !res.IsError || !strings.Contains(res.Content[0].Text, "evidence.csv") {
+			t.Errorf("collapse with an asset = %+v, want a refusal naming it", res.Content)
+		}
+	})
+}
+
+func TestConceptMergeAndCollapse_AreAdvancedButCallable(t *testing.T) {
+	for _, name := range []string{"concept_merge", "concept_collapse"} {
+		if !advancedToolNames[name] {
+			t.Errorf("%s must be classified as advanced", name)
+		}
+	}
+	k, s := d160Fixture(t)
+	_ = k
+	for _, name := range []string{"concept_merge", "concept_collapse"} {
+		if _, ok := s.Tools()[name]; !ok {
+			t.Errorf("%s is not registered, so it is not callable by name", name)
+		}
 	}
 }

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -124,6 +124,8 @@ func RegisterKBTools(s *Server, k *kb.KB, deps Deps) {
 	register(toolArtifactList(k, deps.MCPAllowlist))
 	register(toolTemplateList(k))
 	register(gitWrap(k, toolConceptNew(k, live, deps.SQLIndex)))
+	register(gitWrap(k, toolConceptMerge(k, live, deps.SQLIndex)))
+	register(gitWrap(k, toolConceptCollapse(k, live, deps.SQLIndex)))
 	register(toolAssetRead(k))
 	register(toolAssetList(k))
 	register(gitWrap(k, toolAssetWrite(k)))

--- a/internal/mcpserver/tools_write.go
+++ b/internal/mcpserver/tools_write.go
@@ -1278,6 +1278,53 @@ func toolConceptMove(k *kb.KB, live *liveIndex, sqlIdx *sqlindex.Index) Tool {
 				"moves": applied,
 			}
 
+			// The moved concept's OWN relative links break when the directory
+			// depth changes: concept_move rewrote inbound links only, which is a
+			// half-move (D160). No flag: a move that leaves the moved body's links
+			// broken is simply incomplete, and a flag would preserve that as a
+			// supported mode.
+			outboundFixed := 0
+			for _, mv := range applied {
+				oldBase, newBase := okf.IDToPath(okf.ConceptID(mv.SourceID)), okf.IDToPath(okf.ConceptID(mv.TargetID))
+				if relPath, expanded := k.ConceptRelPath(okf.ConceptID(mv.TargetID)); expanded {
+					newBase = relPath
+					oldBase = filepath.ToSlash(filepath.Join(mv.SourceID, "index.md"))
+				}
+				data, readErr := k.ReadConcept(okf.ConceptID(mv.TargetID))
+				if readErr != nil {
+					continue
+				}
+				newBody, n := kb.RewriteOutboundLinks(data.Body, oldBase, newBase, moveMap)
+				if n == 0 {
+					continue
+				}
+				fm, parseErr := okf.ParseFrontmatter(data.FrontmatterRaw)
+				if parseErr != nil {
+					continue
+				}
+				if _, err := k.WriteConcept(okf.ConceptID(mv.TargetID), fm, newBody, data.ContentHash); err != nil {
+					return errorResult(fmt.Sprintf("concept_move: applied the move but could not rewrite %q's own links: %v", mv.TargetID, err)), nil
+				}
+				outboundFixed += n
+			}
+			if outboundFixed > 0 {
+				result["outbound_rewritten"] = outboundFixed
+				logLines = append(logLines, fmt.Sprintf("outbound_links: %d replacement(s) in the moved concept(s)", outboundFixed))
+			}
+
+			if rewriteLinks {
+				// Curated indexes are not links between concepts, so the backlink
+				// pass below never touched them: the source map's index kept
+				// listing the moved concept (broken_link) and the destination's did
+				// not mention it (index_incomplete). Only maps that asked for a
+				// curated index are edited — rewriting prose nobody declared as
+				// curated would be an assumption, not a fix (D160).
+				if notes := maintainCuratedIndexes(k, applied); len(notes) > 0 {
+					result["curated_indexes"] = notes
+					logLines = append(logLines, notes...)
+				}
+			}
+
 			if rewriteLinks {
 				touched, totalReplacements, err := rewriteBacklinks(k, live, sqlIdx, moveMap)
 				if err != nil {
@@ -1304,6 +1351,345 @@ func toolConceptMove(k *kb.KB, live *liveIndex, sqlIdx *sqlindex.Index) Tool {
 			return textResult(string(out)), nil
 		},
 	}
+}
+
+// toolConceptMerge folds a satellite into its expanded parent (D160). Consolidating
+// a dossier is a routine refactor with no primitive: done by hand it breaks links
+// three ways — the merged body's own relative links were relative to the
+// satellite's directory, links TO the deleted satellite remain, and so do links
+// from sibling satellites. All three are mechanical once the link rule is settled
+// (D149), and all three are what rewriteBacklinks already does for a move.
+func toolConceptMerge(k *kb.KB, live *liveIndex, sqlIdx *sqlindex.Index) Tool {
+	return Tool{
+		Name: "concept_merge",
+		Description: "Folds a satellite concept into its own expanded parent, in one commit: the satellite's " +
+			"body is appended to the parent's index.md under a heading, its own relative links are rebased " +
+			"to the parent's directory, every inbound link (markdown and wiki-link, including from sibling " +
+			"satellites) is redirected to the parent, and the satellite is deleted. Only a satellite into " +
+			"its own parent: arbitrary concept-into-concept merging is out of scope.",
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"required": ["satellite_id", "if_match"],
+			"properties": {
+				"satellite_id": {"type": "string", "description": "ConceptID of the satellite (3 segments: map/concept/child)"},
+				"if_match": {"type": "string", "description": "Expected content-hash of the satellite"},
+				"heading": {"type": "string", "description": "Heading the merged body is appended under; defaults to the satellite's title"}
+			}
+		}`),
+		Handler: func(ctx requestContext, args json.RawMessage) (ToolResult, error) {
+			var params struct {
+				SatelliteID string `json:"satellite_id"`
+				IfMatch     string `json:"if_match"`
+				Heading     string `json:"heading"`
+			}
+			if err := json.Unmarshal(args, &params); err != nil {
+				return errorResult("invalid params: " + err.Error()), nil
+			}
+			parts := strings.Split(params.SatelliteID, "/")
+			if len(parts) != 3 {
+				return errorResult(fmt.Sprintf("concept_merge %q: not a satellite — expected 3 segments (map/concept/child)", params.SatelliteID)), nil
+			}
+			parentID := okf.ConceptID(strings.Join(parts[:2], "/"))
+			parentRel, expanded := k.ConceptRelPath(parentID)
+			if !expanded {
+				return errorResult(fmt.Sprintf("concept_merge %q: %q is not an expanded concept", params.SatelliteID, parentID)), nil
+			}
+
+			satellite, err := k.ReadConcept(okf.ConceptID(params.SatelliteID))
+			if err != nil {
+				return errorResult(fmt.Sprintf("concept_merge %q: %v", params.SatelliteID, err)), nil
+			}
+			if satellite.ContentHash != params.IfMatch {
+				return errorResult(fmt.Sprintf("stale_write: concept_merge %q: if_match %q does not match %q", params.SatelliteID, params.IfMatch, satellite.ContentHash)), nil
+			}
+			parent, err := k.ReadConcept(parentID)
+			if err != nil {
+				return errorResult(fmt.Sprintf("concept_merge: read parent %q: %v", parentID, err)), nil
+			}
+
+			heading := params.Heading
+			if heading == "" {
+				heading = string(parentID)
+				if parsed, parseErr := okf.ParseFrontmatter(satellite.FrontmatterRaw); parseErr == nil && parsed != nil {
+					if t, ok := parsed.Get("title"); ok {
+						if ts, ok := t.(string); ok && strings.TrimSpace(ts) != "" {
+							heading = ts
+						}
+					}
+				}
+			}
+
+			// The satellite's own relative links move up one level.
+			mergedBody, _ := kb.RewriteOutboundLinks(satellite.Body, okf.IDToPath(okf.ConceptID(params.SatelliteID)), parentRel, nil)
+			parentFM, err := okf.ParseFrontmatter(parent.FrontmatterRaw)
+			if err != nil {
+				return errorResult(fmt.Sprintf("concept_merge: parse parent frontmatter: %v", err)), nil
+			}
+			newParentBody := strings.TrimRight(parent.Body, "\n") + "\n\n## " + heading + "\n\n" + strings.TrimSpace(mergedBody) + "\n"
+			if _, err := k.WriteConcept(parentID, parentFM, newParentBody, parent.ContentHash); err != nil {
+				return errorResult(fmt.Sprintf("concept_merge: write parent %q: %v", parentID, err)), nil
+			}
+			if err := k.DeleteConcept(okf.ConceptID(params.SatelliteID)); err != nil {
+				return errorResult(fmt.Sprintf("concept_merge: delete satellite %q: %v", params.SatelliteID, err)), nil
+			}
+			live.remove(params.SatelliteID)
+			if sqlIdx != nil {
+				_ = sqlIdx.Delete(params.SatelliteID)
+			}
+
+			// Inbound links — including from sibling satellites, which the
+			// whole-KB pass covers with no special case.
+			moveMap := map[string]string{params.SatelliteID: string(parentID)}
+			touched, replacements, err := rewriteBacklinks(k, live, sqlIdx, moveMap)
+			if err != nil {
+				return errorResult(fmt.Sprintf("concept_merge: merged %q but redirecting inbound links failed: %v", params.SatelliteID, err)), nil
+			}
+			_ = k.AppendLog(fmt.Sprintf("concept_merge: %s → %s", params.SatelliteID, parentID), time.Now())
+
+			out, _ := json.MarshalIndent(map[string]interface{}{
+				"merged_into":  string(parentID),
+				"heading":      heading,
+				"rewritten":    touched,
+				"replacements": replacements,
+			}, "", "  ")
+			return textResult(string(out)), nil
+		},
+	}
+}
+
+// toolConceptCollapse is the inverse of concept_expand (D160). concept_expand's
+// description said there was none, while expanded_as_category actively advises
+// going back above 8 children — so the only route was a batch concept_move by
+// hand.
+//
+// Expansion never changes an ID, so neither does this: "<id>/index.md" becomes
+// "<id>.md" under the same ID, and no inbound link needs rewriting.
+func toolConceptCollapse(k *kb.KB, live *liveIndex, sqlIdx *sqlindex.Index) Tool {
+	return Tool{
+		Name: "concept_collapse",
+		Description: "Turns an expanded concept back into a plain one: \"<id>/index.md\" becomes \"<id>.md\" " +
+			"under the SAME ConceptID, so no inbound link changes. The inverse of concept_expand. Refuses " +
+			"when the directory still holds satellites or assets — both would have no home after the " +
+			"collapse — and names them.",
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"required": ["id", "if_match"],
+			"properties": {
+				"id": {"type": "string", "description": "ConceptID to collapse (2 segments: map/concept)"},
+				"if_match": {"type": "string", "description": "Expected content-hash of the expanded concept"}
+			}
+		}`),
+		Handler: func(ctx requestContext, args json.RawMessage) (ToolResult, error) {
+			var params struct {
+				ID      string `json:"id"`
+				IfMatch string `json:"if_match"`
+			}
+			if err := json.Unmarshal(args, &params); err != nil {
+				return errorResult("invalid params: " + err.Error()), nil
+			}
+			id := okf.ConceptID(params.ID)
+			if len(strings.Split(params.ID, "/")) != 2 {
+				return errorResult(fmt.Sprintf("concept_collapse %q: expected exactly 2 segments (map/concept)", params.ID)), nil
+			}
+			if _, expanded := k.ConceptRelPath(id); !expanded {
+				return errorResult(fmt.Sprintf("concept_collapse %q: not an expanded concept", params.ID)), nil
+			}
+			data, err := k.ReadConcept(id)
+			if err != nil {
+				return errorResult(fmt.Sprintf("concept_collapse %q: %v", params.ID, err)), nil
+			}
+			if data.ContentHash != params.IfMatch {
+				return errorResult(fmt.Sprintf("stale_write: concept_collapse %q: if_match %q does not match %q", params.ID, params.IfMatch, data.ContentHash)), nil
+			}
+
+			// Satellites and assets live in the directory and would have no home.
+			var satellites []string
+			if err := k.WalkConcepts(func(other okf.ConceptID, _ string) error {
+				if strings.HasPrefix(string(other), params.ID+"/") {
+					satellites = append(satellites, string(other))
+				}
+				return nil
+			}); err != nil {
+				return errorResult(fmt.Sprintf("concept_collapse: walk: %v", err)), nil
+			}
+			if len(satellites) > 0 {
+				sort.Strings(satellites)
+				return errorResult(fmt.Sprintf("concept_collapse %q: still holds %d satellite(s) — merge or move them first: %s",
+					params.ID, len(satellites), strings.Join(satellites, ", "))), nil
+			}
+			assets, assetErr := k.ListAssets(id)
+			if assetErr == nil && len(assets) > 0 {
+				names := make([]string, 0, len(assets))
+				for _, a := range assets {
+					names = append(names, a.Path)
+				}
+				sort.Strings(names)
+				return errorResult(fmt.Sprintf("concept_collapse %q: still owns %d asset(s), which only an expanded concept can hold — remove them with asset_delete first: %s",
+					params.ID, len(assets), strings.Join(names, ", "))), nil
+			}
+
+			dirAbs, err := k.ResolvePath(params.ID, true)
+			if err != nil {
+				return errorResult(fmt.Sprintf("concept_collapse %q: %v", params.ID, err)), nil
+			}
+			flatAbs, err := k.ResolvePath(okf.IDToPath(id), true)
+			if err != nil {
+				return errorResult(fmt.Sprintf("concept_collapse %q: %v", params.ID, err)), nil
+			}
+			if _, statErr := os.Stat(flatAbs); statErr == nil {
+				return errorResult(fmt.Sprintf("concept_collapse %q: %s.md already exists (expanded_ambiguous) — remove one form first", params.ID, params.ID)), nil
+			}
+			if err := os.Rename(filepath.Join(dirAbs, "index.md"), flatAbs); err != nil {
+				return errorResult(fmt.Sprintf("concept_collapse %q: move index.md: %v", params.ID, err)), nil
+			}
+			if err := os.Remove(dirAbs); err != nil {
+				return errorResult(fmt.Sprintf("concept_collapse %q: remove the now-empty directory: %v", params.ID, err)), nil
+			}
+			if fresh, readErr := k.ReadConcept(id); readErr == nil {
+				live.add(params.ID, fresh.Content)
+				if sqlIdx != nil {
+					_ = sqlIdx.Upsert(params.ID, fresh.ContentHash, fresh.Content)
+				}
+			}
+			_ = k.AppendLog("concept_collapse: "+params.ID, time.Now())
+
+			out, _ := json.MarshalIndent(map[string]interface{}{
+				"id":   params.ID,
+				"path": okf.IDToPath(id),
+			}, "", "  ")
+			return textResult(string(out)), nil
+		},
+	}
+}
+
+// maintainCuratedIndexes removes the moved concept's entry from the source map's
+// curated index and appends one to the destination's, for maps that opted in with
+// require_index_entry (D160). Returns one human-readable note per action.
+//
+// Both edits are conservative. A source line is removed only when the moved
+// concept is its ONLY link: a line citing two concepts is prose the operator
+// wrote, so it is kept and reported instead. The destination entry is appended
+// under a "## Moved here" heading created if absent — Cartographer cannot know the
+// right thematic section, and a wrong placement in a curated document is worse
+// than an obvious one at the end. Only maps that declared require_index_entry are
+// touched: editing an index nobody called curated would be an assumption.
+func maintainCuratedIndexes(k *kb.KB, applied []conceptMoveEntry) []string {
+	var notes []string
+	requiresIndex := func(mapName string) bool {
+		contract, err := k.ReadMapContract(mapName)
+		return err == nil && contract.RequireIndexEntry
+	}
+	for _, mv := range applied {
+		srcMap, srcOK := conceptMapName(mv.SourceID)
+		dstMap, dstOK := conceptMapName(mv.TargetID)
+		if !srcOK || !dstOK || srcMap == dstMap {
+			continue
+		}
+		if requiresIndex(srcMap) {
+			removed, kept, err := removeCuratedEntry(k, srcMap, okf.ConceptID(mv.SourceID))
+			switch {
+			case err != nil:
+				notes = append(notes, fmt.Sprintf("curated index %s/index.md: %v", srcMap, err))
+			case removed:
+				notes = append(notes, fmt.Sprintf("curated index %s/index.md: removed the entry for %s", srcMap, mv.SourceID))
+			case kept != "":
+				notes = append(notes, fmt.Sprintf("curated index %s/index.md: kept a line citing %s alongside other concepts, edit it by hand: %q", srcMap, mv.SourceID, kept))
+			}
+		}
+		if requiresIndex(dstMap) {
+			if err := appendCuratedEntry(k, dstMap, okf.ConceptID(mv.TargetID), mv.SourceID); err != nil {
+				notes = append(notes, fmt.Sprintf("curated index %s/index.md: %v", dstMap, err))
+			} else {
+				notes = append(notes, fmt.Sprintf("curated index %s/index.md: added an entry for %s", dstMap, mv.TargetID))
+			}
+		}
+	}
+	return notes
+}
+
+// conceptMapName returns a concept's map name, and false when the ID has none.
+func conceptMapName(id string) (string, bool) {
+	parts := strings.Split(id, "/")
+	if len(parts) < 2 {
+		return "", false
+	}
+	return parts[0], true
+}
+
+// removeCuratedEntry drops the line whose only link is id, reporting kept when a
+// line cites id alongside other concepts.
+func removeCuratedEntry(k *kb.KB, mapName string, id okf.ConceptID) (removed bool, kept string, err error) {
+	content, hash, err := k.IndexHash(mapName)
+	if err != nil {
+		return false, "", fmt.Errorf("unreadable: %w", err)
+	}
+	fmRaw, body, hasFM := okf.SplitFrontmatter(content)
+	indexPath := mapName + "/index.md"
+	var out []string
+	for _, line := range strings.Split(body, "\n") {
+		targets := kb.ExtractLinks(line, indexPath, k.AssetExists)
+		hit := false
+		for _, t := range targets {
+			if t == id || strings.TrimSuffix(string(t), "/index") == string(id) {
+				hit = true
+			}
+		}
+		if !hit {
+			out = append(out, line)
+			continue
+		}
+		if len(targets) > 1 {
+			kept = strings.TrimSpace(line)
+			out = append(out, line)
+			continue
+		}
+		removed = true
+	}
+	if !removed {
+		return false, kept, nil
+	}
+	_, err = k.PatchIndex(mapName, hash, joinIndex(fmRaw, hasFM, strings.Join(out, "\n")))
+	return err == nil, kept, err
+}
+
+// appendCuratedEntry adds an entry for id under a "## Moved here" heading.
+func appendCuratedEntry(k *kb.KB, mapName string, id okf.ConceptID, from string) error {
+	content, hash, err := k.IndexHash(mapName)
+	if err != nil {
+		return fmt.Errorf("unreadable: %w", err)
+	}
+	fmRaw, body, hasFM := okf.SplitFrontmatter(content)
+	title := string(id)
+	if data, readErr := k.ReadConcept(id); readErr == nil {
+		if parsed, parseErr := okf.ParseFrontmatter(data.FrontmatterRaw); parseErr == nil && parsed != nil {
+			if t, ok := parsed.Get("title"); ok {
+				if ts, ok := t.(string); ok && strings.TrimSpace(ts) != "" {
+					title = ts
+				}
+			}
+		}
+	}
+	// From a map index an expanded concept is "<concept>.md" — the form D149 WP3
+	// settled, and the one require_index_entry accepts.
+	rel := strings.TrimPrefix(string(id), mapName+"/") + ".md"
+	entry := fmt.Sprintf("- [%s](%s): moved from %s", title, rel, from)
+
+	const heading = "## Moved here"
+	if strings.Contains(body, heading) {
+		body = strings.TrimRight(body, "\n") + "\n" + entry + "\n"
+	} else {
+		body = strings.TrimRight(body, "\n") + "\n\n" + heading + "\n\n" + entry + "\n"
+	}
+	_, err = k.PatchIndex(mapName, hash, joinIndex(fmRaw, hasFM, body))
+	return err
+}
+
+// joinIndex reassembles an index file from its frontmatter and body.
+func joinIndex(fmRaw string, hasFM bool, body string) string {
+	if !hasFM {
+		return body
+	}
+	return "---\n" + strings.TrimSuffix(fmRaw, "\n") + "\n---\n" + body
 }
 
 // rewriteBacklinks performs a single WalkConcepts pass over the whole KB

--- a/internal/mcpserver/visibility.go
+++ b/internal/mcpserver/visibility.go
@@ -65,7 +65,13 @@ func unknownToolMessage(name string) string {
 }
 
 var advancedToolNames = map[string]bool{
-	"concept_batch":        true,
+	"concept_batch": true,
+	// concept_merge/concept_collapse (D160): large-refactor tooling, same tier as
+	// concept_batch — consolidating a dossier or undoing an expansion is not part
+	// of a normal agent session, and the default working set stays small. Both
+	// stay callable by name.
+	"concept_merge":        true,
+	"concept_collapse":     true,
 	"commit_gate":          true,
 	"contradiction_report": true,
 	"conflict_resolve":     true,


### PR DESCRIPTION
Reorganising a KB is routine, and the three refactors that come up most each left the author with a manual link-repair pass.

## WP1 — a move rewrites the moved concept's own links

`concept_move` rewrote **inbound** links only, so the moved body's relative links broke whenever the directory depth changed. The delta is known at move time, so this is arithmetic, not guesswork — and there is **no flag**: a move that leaves the moved body broken is simply incomplete, and a flag would preserve that as a supported mode.

`RewriteOutboundLinks` consults the batch's `moveMap` first, so two concepts moved together that link each other compose correctly. `relLink` is now exported instead of copied: `import.go` had a private copy whose comment said it existed "to avoid exporting KB-internal move machinery for a single caller" — there are now two callers, and a third would have been the bug.

## WP2 — a move maintains both curated indexes

The source map's index kept listing the moved concept (`broken_link`) and the destination's did not mention it (`index_incomplete`). Now maintained, **only for maps that opted in with `require_index_entry`** — editing an index nobody declared as curated would be an assumption.

Both edits are conservative. A source line is removed only when the moved concept is its **only** link: a line citing two concepts is prose the operator wrote, so it is kept and **reported**. The destination entry is appended under a `## Moved here` heading, because Cartographer cannot know the right thematic section and a wrong placement in a curated document is worse than an obvious one at the end. `rewrite_links: false` skips the index maintenance too — it still means "touch no other concept".

## WP3 — `concept_merge` and `concept_collapse`

**`concept_merge`** folds a satellite into its own parent: the body is appended under a heading, its own relative links move up one level, the satellite is deleted, and every inbound link is redirected through the same whole-KB pass a move uses — so **sibling satellites need no special case**, which is the third breakage handled by construction. Satellite-into-its-own-parent only: arbitrary merging is a bigger design (whose frontmatter wins, which map) and the description says so.

**`concept_collapse`** is the inverse of `concept_expand` and **does not change the ID**, because expansion never does. It refuses while satellites or **assets** remain — assets live in the directory and only an expanded concept can hold them — and names them.

Both are **`advanced`**: same tier as `concept_batch` (D125), callable by name but not advertised in `tools/list`. They also needed entries in `policy.go` and `auditResourceFields`, and `concept_collapse` came **out** of `docsNonTools`, where it was listed as "intentionally absent, documented as not implemented".

## Tests

`TestConceptMove_IsCompleteAcrossMaps` asserts the outbound rewrite, both index edits, **and** that a follow-up `lint.Run` reports neither `broken_link` nor `index_incomplete` — the end-to-end property rather than the text. `TestConceptMove_KeepsAMultiLinkIndexLine` pins the conservative rule.

`TestConceptMerge_FoldsASatelliteAndRepairsEveryLink` covers all three breakages including a sibling satellite and a wiki-link, plus a clean lint. `TestConceptCollapse_RoundTripsExpand` asserts expand-then-collapse returns **the original content hash** — a round trip, rather than a claim that the inverse is one. Plus the two refusals, each naming what blocks it, and a test that both tools are advertised as advanced yet callable.

## Docs

`docs/data-plane.md` gains §What a move touches and no longer says `concept_expand` has no inverse. `D160` in `docs/decisions/data-plane.md`.

## Release impact

`concept_move` now edits more than it used to: an operator with a manual post-move routine should stop doing it. Two new tools, not in the default `tools/list`.

## Verification

`make vet`, `make test` (23 packages), `make smoke-http` and `make e2e` (12/12) green locally; `gofmt -l` clean.

Closes #181
