### PR TITLE
feat(okf): multi-line flow lists, literal placeholders, configurable repo depth and --map prefixes

### DIFF
--- a/cmd/cartographer/clientsync.go
+++ b/cmd/cartographer/clientsync.go
@@ -161,7 +161,16 @@ func pinnedPublicKeys(cfg *clientconfig.Config) (map[string][]ed25519.PublicKey,
 // clientconfig.Config (cfg.SearchRoots/cfg.Paths) and drive placeholder expansion
 // (D75 WP3) — this is the one place cmd/cartographer turns
 // ApplyOptions.ExpandPlaceholders on; internal/mcpserver never does.
-func materializeForProviders(m provisioning.Manifest, providers []string, targetDir, serverVersion string, autoTrust, dryRun, noHeal bool, searchRoots []string, paths map[string]string, approvalHashes ...map[string]string) (map[string]provisioning.AppliedResult, error) {
+// portabilityOptions bundles the path-portability inputs (D75, D162): they travel
+// together and a fourth positional argument in an eight-argument call is how the
+// next bug gets written.
+type portabilityOptions struct {
+	SearchRoots []string
+	SearchDepth int
+	Paths       map[string]string
+}
+
+func materializeForProviders(m provisioning.Manifest, providers []string, targetDir, serverVersion string, autoTrust, dryRun, noHeal bool, portability portabilityOptions, approvalHashes ...map[string]string) (map[string]provisioning.AppliedResult, error) {
 	lockPath := lockFilePath(targetDir)
 	lockFile, err := provisioning.ReadLockFile(lockPath)
 	if err != nil {
@@ -199,8 +208,9 @@ func materializeForProviders(m provisioning.Manifest, providers []string, target
 			Lock:               previous,
 			SkipLockWrite:      true,
 			ExpandPlaceholders: true,
-			SearchRoots:        searchRoots,
-			Paths:              paths,
+			SearchRoots:        portability.SearchRoots,
+			SearchDepth:        portability.SearchDepth,
+			Paths:              portability.Paths,
 		}
 		// Apply only the artifacts the provider knows how to materialize:
 		// unsupported kinds (e.g. hook outside Claude Code, or agent outside

--- a/cmd/cartographer/clientsync_test.go
+++ b/cmd/cartographer/clientsync_test.go
@@ -155,7 +155,7 @@ func TestFetchMergedManifestVerifiesPinnedSignatureAndRejectsTampering(t *testin
 	}
 
 	target := t.TempDir()
-	if _, err := materializeForProviders(m, []string{"claude"}, target, "", false, false, false, nil, nil); err != nil {
+	if _, err := materializeForProviders(m, []string{"claude"}, target, "", false, false, false, portabilityOptions{}); err != nil {
 		t.Fatalf("materialize valid manifest: %v", err)
 	}
 	lockPath := filepath.Join(target, provisioning.LockFileName)
@@ -191,7 +191,7 @@ func TestFetchMergedManifestVerifiesPinnedSignatureAndRejectsTampering(t *testin
 			fetched, fetchErr := fetchMergedManifest(cfg)
 			srv.Close()
 			if fetchErr == nil {
-				_, fetchErr = materializeForProviders(fetched, []string{"claude"}, target, "", false, false, false, nil, nil)
+				_, fetchErr = materializeForProviders(fetched, []string{"claude"}, target, "", false, false, false, portabilityOptions{})
 			}
 			if fetchErr == nil {
 				t.Fatal("tampered sync unexpectedly succeeded")
@@ -282,7 +282,7 @@ func TestAuthorizationDoesNotSetSigned(t *testing.T) {
 	if m.Artifacts[0].Signed {
 		t.Fatal("test fixture must be unsigned")
 	}
-	if _, err := materializeForProviders(m, []string{"claude"}, t.TempDir(), "", true, true, false, nil, nil); err != nil {
+	if _, err := materializeForProviders(m, []string{"claude"}, t.TempDir(), "", true, true, false, portabilityOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	if m.Artifacts[0].Signed {
@@ -294,7 +294,7 @@ func TestMaterializeForProviders_TrustAvoidsNeedsApproval(t *testing.T) {
 	dir := t.TempDir()
 	m := kbSkillManifest()
 
-	results, err := materializeForProviders(m, []string{"claude"}, dir, "", true, true /* dryRun */, false, nil, nil)
+	results, err := materializeForProviders(m, []string{"claude"}, dir, "", true, true /* dryRun */, false, portabilityOptions{})
 	if err != nil {
 		t.Fatalf("materializeForProviders: %v", err)
 	}
@@ -311,7 +311,7 @@ func TestMaterializeForProviders_NoTrustNeedsApproval(t *testing.T) {
 	dir := t.TempDir()
 	m := kbSkillManifest()
 
-	results, err := materializeForProviders(m, []string{"claude"}, dir, "", false, true /* dryRun */, false, nil, nil)
+	results, err := materializeForProviders(m, []string{"claude"}, dir, "", false, true /* dryRun */, false, portabilityOptions{})
 	if err != nil {
 		t.Fatalf("materializeForProviders: %v", err)
 	}
@@ -352,7 +352,7 @@ func TestMaterializeForProviders_Instructions_ClaudeEKiro(t *testing.T) {
 	dir := t.TempDir()
 	m := instructionsManifest("homelab", "Contenuto di imprinting per homelab.\n")
 
-	results, err := materializeForProviders(m, []string{"claude", "kiro"}, dir, "", true, false /* dryRun */, false, nil, nil)
+	results, err := materializeForProviders(m, []string{"claude", "kiro"}, dir, "", true, false /* dryRun */, false, portabilityOptions{})
 	if err != nil {
 		t.Fatalf("materializeForProviders: %v", err)
 	}
@@ -475,7 +475,7 @@ func TestMaterializeForProviders_StdioPreflightIsAtomic(t *testing.T) {
 		Kind: "mcp", Name: "missing", Source: "kb:kb", Signed: true,
 		ContentHash: provisioning.ContentHashFiles([]provisioning.ArtifactFile{file}), Files: []provisioning.ArtifactFile{file},
 	}}}
-	_, err := materializeForProviders(m, []string{"claude", "codex"}, dir, "", false, false, false, nil, nil)
+	_, err := materializeForProviders(m, []string{"claude", "codex"}, dir, "", false, false, false, portabilityOptions{})
 	if err == nil || !strings.Contains(err.Error(), "not found on PATH") || !strings.Contains(err.Error(), "for claude") {
 		t.Fatalf("preflight error = %v", err)
 	}
@@ -497,7 +497,7 @@ func TestMaterializeForProviders_PerProviderBaseDir(t *testing.T) {
 	t.Setenv("HERMES_HOME", hermesHome)
 
 	m := kbSkillManifest()
-	if _, err := materializeForProviders(m, []string{"claude", "hermes"}, dir, "", true, false /* dryRun */, false, nil, nil); err != nil {
+	if _, err := materializeForProviders(m, []string{"claude", "hermes"}, dir, "", true, false /* dryRun */, false, portabilityOptions{}); err != nil {
 		t.Fatalf("materializeForProviders: %v", err)
 	}
 
@@ -545,7 +545,7 @@ func TestMaterializeForProviders_PerProviderBaseDir(t *testing.T) {
 // fallback to the home directory (D141).
 func TestMaterializeForProviders_MissingProviderBaseDir(t *testing.T) {
 	t.Setenv("HERMES_HOME", "")
-	_, err := materializeForProviders(kbSkillManifest(), []string{"hermes"}, t.TempDir(), "", true, false, false, nil, nil)
+	_, err := materializeForProviders(kbSkillManifest(), []string{"hermes"}, t.TempDir(), "", true, false, false, portabilityOptions{})
 	if err == nil {
 		t.Fatal("materializeForProviders succeeded with $HERMES_HOME unset")
 	}

--- a/cmd/cartographer/connect.go
+++ b/cmd/cartographer/connect.go
@@ -604,7 +604,7 @@ func doConnect(opts connectOptions) (connectResult, error) {
 		res.Deferred = true
 		res.DeferredErr = err
 	} else {
-		applied, err := materializeForProviders(m, opts.Providers, opts.Dir, facts.Version, opts.Trust || opts.AutoTrust, opts.DryRun, false /* noHeal */, existing.SearchRoots, existing.Paths, existing.ApprovedMCPHashes())
+		applied, err := materializeForProviders(m, opts.Providers, opts.Dir, facts.Version, opts.Trust || opts.AutoTrust, opts.DryRun, false /* noHeal */, portabilityOptions{SearchRoots: existing.SearchRoots, SearchDepth: existing.SearchDepth, Paths: existing.Paths}, existing.ApprovedMCPHashes())
 		if err != nil {
 			return connectResult{}, err
 		}

--- a/cmd/cartographer/import.go
+++ b/cmd/cartographer/import.go
@@ -173,9 +173,40 @@ func parseImportMap(raw []string) ([]importMapEntry, error) {
 		}
 		from := path.Clean(filepath.ToSlash(fromRaw))
 		to := strings.Trim(filepath.ToSlash(toRaw), "/")
+		// With prefix semantics a duplicate is ambiguous, and it used to be
+		// silently overwritten by the later entry — which mis-files documents
+		// (D162).
+		for _, prev := range out {
+			if prev.from == from {
+				return nil, fmt.Errorf("invalid --map %q: duplicate source directory %q (already mapped to %q)", r, from, prev.to)
+			}
+		}
 		out = append(out, importMapEntry{from: from, to: to})
 	}
 	return out, nil
+}
+
+// mapDepth is a --map source path's segment count, "." counting as zero so the
+// source root sorts last and acts as the catch-all.
+func mapDepth(from string) int {
+	if from == "." || from == "" {
+		return 0
+	}
+	return len(strings.Split(from, "/"))
+}
+
+// mapPrefixCovers reports whether a --map entry covers a source directory,
+// comparing at SEGMENT boundaries so "a/b" covers "a/b/c" but not "a/bc". Same
+// rule internal/lint's pathHasPrefix applies to the machine_path allow-list; the
+// two live in different packages for good reason and are kept consistent by hand.
+func mapPrefixCovers(from, dir string) bool {
+	if from == "." || from == "" {
+		return true
+	}
+	if dir == from {
+		return true
+	}
+	return strings.HasPrefix(dir, from+"/")
 }
 
 // importFile is one planned import: the source path (relative to --source,
@@ -191,9 +222,12 @@ type importFile struct {
 // destination-map mapping, before any write happens — the same plan is
 // printed by --dry-run and executed by applyImportPlan.
 type importPlan struct {
-	files   []importFile
-	skipped []string // non-.md files found under --source, for the summary count
-	maps    []string // destination map names, one per map touched by the plan
+	files []importFile
+	// attribution records which flag produced each destination, so --dry-run can
+	// answer "why did this file go there" (D162).
+	attribution map[string]string
+	skipped     []string // non-.md files found under --source, for the summary count
+	maps        []string // destination map names, one per map touched by the plan
 }
 
 // buildImportPlan walks source for .md files (skipping hidden directories),
@@ -245,25 +279,63 @@ func buildImportPlanWithOptions(source string, mapping []importMapEntry, default
 	}
 	sort.Strings(mdFiles)
 
-	mapIndex := map[string]string{}
-	for _, m := range mapping {
-		mapIndex[m.from] = m.to
-	}
+	// Longest-prefix matching, with exact match as its degenerate case (D162): a
+	// corpus with 58 source directories needed 58 flags, because the lookup was
+	// keyed on the exact path.Dir(rel) with no prefix semantics — leaving only the
+	// choice between one map for everything (--default-map) and one flag per
+	// directory, with nothing in between, which is exactly where a real corpus
+	// lives.
+	ordered := append([]importMapEntry(nil), mapping...)
+	sort.Slice(ordered, func(i, j int) bool {
+		li, lj := mapDepth(ordered[i].from), mapDepth(ordered[j].from)
+		if li != lj {
+			return li > lj
+		}
+		if len(ordered[i].from) != len(ordered[j].from) {
+			return len(ordered[i].from) > len(ordered[j].from)
+		}
+		return ordered[i].from < ordered[j].from
+	})
 
 	destDirFor := map[string]string{}
 	unmapped := map[string]bool{}
+	usedMap := map[string]bool{}
+	attribution := map[string]string{}
 	for _, rel := range mdFiles {
 		srcDir := path.Dir(rel)
 		if _, done := destDirFor[srcDir]; done {
 			continue
 		}
-		if dest, ok := mapIndex[srcDir]; ok {
-			destDirFor[srcDir] = dest
-		} else if defaultMap != "" {
-			destDirFor[srcDir] = defaultMap
-		} else {
-			unmapped[srcDir] = true
+		matched := false
+		for _, m := range ordered {
+			if mapPrefixCovers(m.from, srcDir) {
+				destDirFor[srcDir] = m.to
+				attribution[srcDir] = "--map " + m.from + "=" + m.to
+				usedMap[m.from] = true
+				matched = true
+				break
+			}
 		}
+		if matched {
+			continue
+		}
+		if defaultMap != "" {
+			destDirFor[srcDir] = defaultMap
+			attribution[srcDir] = "--default-map " + defaultMap
+			usedMap["\x00default"] = true
+			continue
+		}
+		unmapped[srcDir] = true
+	}
+	// A --map that matched nothing is a typo that would otherwise fall through to
+	// --default-map silently.
+	for _, m := range mapping {
+		if !usedMap[m.from] {
+			fmt.Fprintf(os.Stderr, "warning: --map %s=%s matched no source directory\n", m.from, m.to)
+		}
+	}
+	if defaultMap != "" && !usedMap["\x00default"] {
+		fmt.Fprintf(os.Stderr, "warning: --default-map %s matched no source directory\n", defaultMap)
 	}
 	if len(unmapped) > 0 {
 		var dirs []string
@@ -290,7 +362,7 @@ func buildImportPlanWithOptions(source string, mapping []importMapEntry, default
 		}
 	}
 
-	plan := &importPlan{skipped: skipped}
+	plan := &importPlan{skipped: skipped, attribution: attribution}
 	mapNames := map[string]bool{}
 	used := map[string]int{}
 	for _, rel := range mdFiles {
@@ -346,6 +418,19 @@ func printImportPlan(plan *importPlan) {
 			fmt.Printf("[dry-run] promote %s -> %s\n", f.srcRel, f.destPath)
 		} else {
 			fmt.Printf("[dry-run] %s -> %s\n", f.srcRel, f.destPath)
+		}
+	}
+	// Which flag produced each destination, so a dry run answers "why did this
+	// file go there" — the check an operator needs now that a --map covers a whole
+	// subtree (D162).
+	if len(plan.attribution) > 0 {
+		dirs := make([]string, 0, len(plan.attribution))
+		for d := range plan.attribution {
+			dirs = append(dirs, d)
+		}
+		sort.Strings(dirs)
+		for _, d := range dirs {
+			fmt.Printf("[dry-run] %s/ ← %s\n", d, plan.attribution[d])
 		}
 	}
 	fmt.Printf("would import: %d, skipped: %d\n", len(plan.files), len(plan.skipped))

--- a/cmd/cartographer/import_test.go
+++ b/cmd/cartographer/import_test.go
@@ -508,3 +508,115 @@ func TestCmdImport_TellsTheOperatorToReindex(t *testing.T) {
 		t.Errorf("the instruction is redundant once the index was rebuilt: %q", out)
 	}
 }
+
+// --- D162 WP5: --map covers a subtree ---
+
+// A corpus with 58 source directories needed 58 flags, because the lookup was
+// keyed on the exact path.Dir(rel): the only choices were one map for everything
+// or one flag per directory, with nothing in between.
+func TestBuildImportPlan_MapPrefixMatching(t *testing.T) {
+	src := t.TempDir()
+	for _, rel := range []string{"a/one.md", "a/b/two.md", "a/b/c/three.md", "ab/four.md", "z/five.md"} {
+		abs := filepath.Join(src, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(abs, []byte("# X\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	destOf := func(plan *importPlan, srcRel string) string {
+		for _, f := range plan.files {
+			if f.srcRel == srcRel {
+				return string(f.destID)
+			}
+		}
+		return ""
+	}
+
+	t.Run("one flag covers a whole subtree", func(t *testing.T) {
+		mapping, err := parseImportMap([]string{"a=deep", "ab=flat", "z=other"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		plan, err := buildImportPlan(src, mapping, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, rel := range []string{"a/one.md", "a/b/two.md", "a/b/c/three.md"} {
+			if got := destOf(plan, rel); !strings.HasPrefix(got, "deep/") {
+				t.Errorf("%s -> %q, want it under deep/", rel, got)
+			}
+		}
+		// Segment boundary: "a" must not cover "ab".
+		if got := destOf(plan, "ab/four.md"); !strings.HasPrefix(got, "flat/") {
+			t.Errorf("ab/four.md -> %q, want it under flat/ — \"a\" wrongly covered \"ab\"", got)
+		}
+	})
+
+	t.Run("the longest prefix wins", func(t *testing.T) {
+		mapping, err := parseImportMap([]string{"a=outer", "a/b=inner", "ab=flat", "z=other"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		plan, err := buildImportPlan(src, mapping, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := destOf(plan, "a/one.md"); !strings.HasPrefix(got, "outer/") {
+			t.Errorf("a/one.md -> %q, want outer/", got)
+		}
+		for _, rel := range []string{"a/b/two.md", "a/b/c/three.md"} {
+			if got := destOf(plan, rel); !strings.HasPrefix(got, "inner/") {
+				t.Errorf("%s -> %q, want inner/", rel, got)
+			}
+		}
+	})
+
+	t.Run("the source root is a legal catch-all", func(t *testing.T) {
+		mapping, err := parseImportMap([]string{".=everything"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		plan, err := buildImportPlan(src, mapping, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, f := range plan.files {
+			if !strings.HasPrefix(string(f.destID), "everything/") {
+				t.Errorf("%s -> %q, want it under everything/", f.srcRel, f.destID)
+			}
+		}
+	})
+
+	t.Run("an exact mapping still works", func(t *testing.T) {
+		mapping, err := parseImportMap([]string{"a=one", "a/b=two", "a/b/c=three", "ab=four", "z=five"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		plan, err := buildImportPlan(src, mapping, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := destOf(plan, "a/b/c/three.md"); !strings.HasPrefix(got, "three/") {
+			t.Errorf("a/b/c/three.md -> %q, want three/", got)
+		}
+	})
+
+	t.Run("a duplicate source directory is an error", func(t *testing.T) {
+		_, err := parseImportMap([]string{"a=one", "a=two"})
+		if err == nil || !strings.Contains(err.Error(), "duplicate source directory") {
+			t.Errorf("parseImportMap = %v, want a duplicate error", err)
+		}
+	})
+
+	t.Run("an unmapped directory is still an error", func(t *testing.T) {
+		mapping, err := parseImportMap([]string{"a=one"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := buildImportPlan(src, mapping, ""); err == nil {
+			t.Error("an unmapped directory with no --default-map must remain an error")
+		}
+	})
+}

--- a/cmd/cartographer/reconnect_test.go
+++ b/cmd/cartographer/reconnect_test.go
@@ -189,7 +189,7 @@ func TestMaterializeForProviders_RecordsServerVersion(t *testing.T) {
 	dir := t.TempDir()
 	m := kbSkillManifest()
 
-	if _, err := materializeForProviders(m, []string{"claude"}, dir, "1.4.0", true, false, false, nil, nil); err != nil {
+	if _, err := materializeForProviders(m, []string{"claude"}, dir, "1.4.0", true, false, false, portabilityOptions{}); err != nil {
 		t.Fatalf("materializeForProviders: %v", err)
 	}
 	lockFile, err := provisioning.ReadLockFile(lockFilePath(dir))
@@ -201,7 +201,7 @@ func TestMaterializeForProviders_RecordsServerVersion(t *testing.T) {
 	}
 
 	// An offline sync (empty version) must not erase the knowledge.
-	if _, err := materializeForProviders(m, []string{"claude"}, dir, "", true, false, false, nil, nil); err != nil {
+	if _, err := materializeForProviders(m, []string{"claude"}, dir, "", true, false, false, portabilityOptions{}); err != nil {
 		t.Fatalf("materializeForProviders offline: %v", err)
 	}
 	lockFile, err = provisioning.ReadLockFile(lockFilePath(dir))

--- a/cmd/cartographer/resolve.go
+++ b/cmd/cartographer/resolve.go
@@ -53,7 +53,7 @@ func cmdResolve(args []string) int {
 	switch kind {
 	case "repo":
 		var warnings []string
-		resolved, warnings, err = repoindex.Resolve(key, cfg.Paths, cfg.SearchRoots)
+		resolved, warnings, err = repoindex.Resolve(key, cfg.Paths, cfg.SearchRoots, cfg.SearchDepth)
 		for _, w := range warnings {
 			fmt.Fprintln(os.Stderr, w)
 		}

--- a/cmd/cartographer/sync.go
+++ b/cmd/cartographer/sync.go
@@ -125,7 +125,7 @@ func runSync(dir string, cfg *clientconfig.Config, opts syncOptions) (syncResult
 		return syncResult{}, err
 	}
 
-	results, err := materializeForProviders(m, cfg.Agents, dir, facts.Version, cfg.Trust || opts.AutoTrust, opts.DryRun, opts.NoHeal, cfg.SearchRoots, cfg.Paths, cfg.ApprovedMCPHashes())
+	results, err := materializeForProviders(m, cfg.Agents, dir, facts.Version, cfg.Trust || opts.AutoTrust, opts.DryRun, opts.NoHeal, portabilityOptions{SearchRoots: cfg.SearchRoots, SearchDepth: cfg.SearchDepth, Paths: cfg.Paths}, cfg.ApprovedMCPHashes())
 	if err != nil {
 		return syncResult{}, err
 	}

--- a/cmd/cartographer/tui.go
+++ b/cmd/cartographer/tui.go
@@ -397,7 +397,7 @@ func syncCmd(provider, dir string) tea.Cmd {
 		// leaves it empty, which preserves the previously recorded value
 		// instead of erasing it.
 		facts, _ := enumerateKBs(cfg.ServerURL, cfg.Auth, cfg.TokenEnv)
-		applied, err := materializeForProviders(m, []string{provider}, dir, facts.Version, cfg.Trust, false, false /* noHeal */, cfg.SearchRoots, cfg.Paths, cfg.ApprovedMCPHashes())
+		applied, err := materializeForProviders(m, []string{provider}, dir, facts.Version, cfg.Trust, false, false /* noHeal */, portabilityOptions{SearchRoots: cfg.SearchRoots, SearchDepth: cfg.SearchDepth, Paths: cfg.Paths}, cfg.ApprovedMCPHashes())
 		if err != nil {
 			return syncDoneMsg{provider: provider, err: err}
 		}

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -406,6 +406,21 @@ cartographer import --source ./docs --kb ./kb-clone \
 | `--message` | `import: <source> -> <kb>` | Commit message; implies `--commit` |
 | `--dir-as-concept` | `false` | Promotes a source directory with `index.md` (or `README.md`) into an expanded concept and keeps its satellites together |
 
+**`--map` covers a subtree.** Resolution is longest matching prefix, then `--default-map`, then the
+unmapped error (D162): `--map a/b=m` covers `a/b`, `a/b/c` and below, a more specific `--map a/b/c=n`
+wins for its own subtree, and matching is at **segment boundaries**, so `a/b` never covers `a/bc`. `.`
+is a legal source and covers everything. Before this the lookup was keyed on the exact directory, so a
+corpus with 58 source directories needed 58 flags — the only choices were one map for everything or one
+flag per directory, with nothing in between.
+
+**The matched prefix is replaced, not appended to**: `--map a/b=m` sends `a/b/c/page.md` to `m`, not to
+`m/c`. The destination is a *map* (or `map/expanded-concept`) and the write path caps concept depth at
+three segments, so mirroring an arbitrarily deep source tree cannot work; preserving hierarchy is what
+`--dir-as-concept` is for. Two `--map` flags with the same source are an error rather than the later
+one silently winning, and a `--map` that matches nothing warns — otherwise a typo falls through to
+`--default-map` unnoticed. `--dry-run` names the flag behind every destination, which is how you check
+all of this.
+
 **`import` takes the KB's advisory lock** and fails fast when the server holds it (D155), naming the
 holder and the `service stop … && service start` sequence: it writes into the same directory the
 server's sync loop manages, and the two interleaving corrupted the git index. `--dry-run` writes

--- a/docs/data-plane.md
+++ b/docs/data-plane.md
@@ -138,6 +138,25 @@ Concept ID = path relative to the bundle without `.md`. File names are `kebab-ca
 
 **In a curated index, both forms are accepted** for an expanded concept: `[c](c.md)` and `[c](c/index.md)` both satisfy `require_index_entry`. The two used to be inverses of each other — one valid between concepts, the other in an index — with nothing to tell them apart.
 
+### Frontmatter value forms
+
+A value may be a scalar, a block list (`- item` on following lines), or a flow list `[a, b]` — the
+flow form **on one line or across several** (D162), which is what any editor produces when a list gets
+long:
+
+```yaml
+provenance: [
+  first/source.md,
+  second/source.md,
+]
+```
+
+A trailing comma before `]` is accepted and yields no empty element. A `]` inside a quoted element is
+not a terminator. An unclosed flow list is still an error and names the key **and the line**;
+`validate` wraps that with the concept's path, so a malformed value is locatable in a corpus of a
+thousand pages. The serializer always emits the single-line form: a multi-line source round-trips into
+one line, which is reflow, not data loss.
+
 ### What a move touches
 
 `concept_move` is complete as of D160: it rewrites **inbound** links across the KB, **the moved

--- a/docs/decisions/data-plane.md
+++ b/docs/decisions/data-plane.md
@@ -504,3 +504,73 @@ post-move routine should stop doing it. The strongest assertion available for al
 follow-up `lint` reports neither `broken_link` nor `index_incomplete`, and that expand-then-collapse
 returns the original content hash — a round trip, rather than a claim that the inverse is one.
 `docs/data-plane.md` no longer says there is no inverse.
+
+## D162 — Authoring and ingestion papercuts: frontmatter, placeholders, repo scan, import mapping
+
+**Status: implemented (2026-08-28).** Amends [D75](sync-provisioning.md#d75) and [D74](#d74).
+Closes #183.
+
+**Context.** Four independent defects, grouped because none justified a decision of its own and each
+one blocked **writing something down** or **getting a corpus in**.
+
+1. **A multi-line flow list was rejected.** The parser looked only at the current line, so
+   `provenance: [\n  a,\n  b,\n]` — valid YAML, and what any editor produces for a long list — failed
+   with `unclosed flow list`. 63 files in one corpus used the form and one of them aborted an import.
+   The block-list branch already had the lookahead; the flow branch simply did not use it.
+2. **The placeholder syntax could not be written down.** `{{repo:<name>}}` in a skill documenting the
+   generic form was indistinguishable from a real reference, producing eleven warnings per sync — which
+   trains people to ignore warnings — and the only workaround was to describe the syntax in prose,
+   without braces, in the one place where showing it verbatim is the point.
+3. **The repo scan stopped at a fixed depth of 4.** A workspace organised as
+   `<root>/<program>/<area>/<repo>` put clones one level too deep: ~160 repositories were invisible and
+   every `{{repo:<key>}}` citing one was unusable. The failure named no depth, so the limit had to be
+   guessed.
+4. **`--map` needed one flag per exact source directory.** 58 directories, 58 flags, because the lookup
+   was keyed on `path.Dir(rel)` with no prefix semantics. `--default-map` covers *everything*, so the
+   only choices were one map for the whole corpus or one flag per directory — with nothing in between,
+   which is exactly where a real corpus lives.
+
+**Decision.**
+
+- **Flow lists span lines**, terminated by the first depth-0 `]`, with bracket characters inside quoted
+  scalars skipped. A **trailing comma yields no empty element**: it is valid YAML and what every
+  wrapping editor emits. An unclosed list stays an error and gains **the line number** of the key.
+  Scanning stops at the frontmatter terminator: a `[` with no `]` before `---` is unclosed, not a
+  licence to consume the body.
+- **The file name comes from the callers, and needed no new code.** `Validate` already wraps the parser
+  error with the concept's path, and `applyImportPlan` already reports the source path and **counts the
+  file as an error without aborting** the rest of the batch. Together with the line number from the
+  parser, the report's ask — file, key, line — is satisfied. **A lint `frontmatter_malformed` check was
+  therefore dropped**: `validate` covers it, and adding a duplicate would only double-report. This is
+  the plan's own "defer to it if it exists" branch, taken.
+- **An explicit escape *and* a metasyntax heuristic, both.** The escape `{{\repo:...}}` is
+  authoritative and removes the backslash; chosen over doubling the braces (unreadable in a document
+  about the syntax) and over an HTML-comment wrapper (skills are also read as plain markdown). The
+  heuristic silences **the warning only** for a key of the form `<name>` or `...`, leaving the text
+  verbatim — which is what a documentation example wants — and fixes every existing document with no
+  edit. A real key cannot look like metasyntax: `repoindex` keys are git remote names or path keys, and
+  `<` `>` are legal in neither, so no lookup is needed to be sure.
+- **Scan depth is configurable per client, not per root**: per-root depth would turn `search_roots`
+  into a list of objects, a config-format break for a case nobody asked for. Default stays **4** —
+  raising it for everyone would slow every resolution to accommodate one layout — and the maximum is
+  **8**, because the scan runs on every unresolved placeholder and an unbounded depth on a large home
+  directory is a multi-second stall mid-sync. A value above the maximum is **clamped**, not rejected:
+  a config value that stops a sync is worse than one adjusted loudly.
+- **`--map` is longest-prefix, matched at segment boundaries** so `a/b` never covers `a/bc`, with exact
+  match as the degenerate case and `.` as a legal catch-all. **The matched prefix is replaced, not
+  appended to**: the destination is a map, and the write path caps concept depth at three segments, so
+  mirroring an arbitrarily deep source tree cannot work — preserving hierarchy is `--dir-as-concept`'s
+  job. A duplicate source is an error rather than the later flag silently winning, and a `--map` that
+  matches nothing warns, because otherwise a typo falls through to `--default-map` unnoticed.
+  `--dry-run` now names the flag behind every destination.
+- **The portability inputs became a struct.** `materializeForProviders` already took `searchRoots` and
+  `paths` positionally; a third positional argument in a seven-argument call is how the next bug gets
+  written.
+
+**Consequences.** Mostly additive: frontmatter that previously failed to parse now parses, one new
+optional client field with the default unchanged, new escape syntax nothing currently uses, and fewer
+warnings with no edit. One **behaviour change**: a `--map` that previously matched one directory now
+matches its subtree, so an import relying on subdirectories falling through to `--default-map` routes
+them differently — `--dry-run` is the check, and it now attributes every destination to its flag. One
+existing contract test moved its "empty entry" case from a trailing comma to an interior one, since the
+former is now valid YAML.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -106,6 +106,27 @@ repair never implies `--auto-trust`, never invents an approval and never broaden
 never disconnects or reconnects a provider. It only runs when the client is configured against
 that same native service over loopback HTTP; any other endpoint is skipped rather than contacted.
 
+## Writing a placeholder literally, and how deep the repo scan goes
+
+Documenting the generic form of a placeholder used to trigger it: eleven warnings per sync in one
+deployment, which trains people to ignore warnings. Two ways out (D162):
+
+- **the escape**, authoritative: `{{\repo:<key>}}` emits the literal `{{repo:<key>}}` with the
+  backslash removed and resolves nothing. Chosen over doubling the braces, unreadable in a document
+  that is *about* the syntax, and over an HTML-comment wrapper, since skills are also read as plain
+  markdown;
+- **metasyntax**, a convenience needing no edit to existing KBs: a key of the form `<name>`, or `...`,
+  is left verbatim **and silent**. A real key cannot look like that — `repoindex` keys are git remote
+  names or path keys, and `<` `>` are legal in neither.
+
+`search_depth` in `.cartographer.yaml` bounds how many directory levels the repo scan descends from
+each root: default **4**, maximum **8**, a value above it clamped with a warning rather than rejected.
+A workspace organised as `<root>/<program>/<area>/<repo>` puts the repository directory at the fourth
+level and its contents at the fifth, so it needs `search_depth: 5` — with the old fixed cap ~160
+repositories were invisible and every `{{repo:<key>}}` citing one was unusable. The not-found message
+now names the depth it searched, the maximum, and the setting. Keying stays on the **normalised git
+remote**, never on a directory name: that is what makes a `repo:` key identical for every operator.
+
 ## The generated instructions block
 
 The client steering file carries one managed block per mounted KB: a generated routing sentence (KB

--- a/internal/clientconfig/clientconfig.go
+++ b/internal/clientconfig/clientconfig.go
@@ -45,6 +45,13 @@ type Config struct {
 	// field existed (see Load).
 	SearchRoots []string `yaml:"search_roots,omitempty"`
 
+	// SearchDepth bounds how many directory levels repoindex descends from each
+	// root (D162). Zero means the default of 4; values above the maximum of 8 are
+	// clamped with a warning rather than rejected, since a config value that stops
+	// a sync is worse than one adjusted loudly. A workspace organised as
+	// <root>/<program>/<area>/<repo> needs 5.
+	SearchDepth int `yaml:"search_depth,omitempty"`
+
 	// Paths is the manual `{{path:<nome>}}` mapping (D75 WP1/WP3): a
 	// fallback for directories that aren't git repos, and an override for
 	// `{{repo:<key>}}` resolution (checked before repoindex's scan/cache,
@@ -80,6 +87,7 @@ type yamlConfig struct {
 	KBs          []string                          `yaml:"kbs,omitempty"`
 	Trust        *bool                             `yaml:"trust,omitempty"`
 	SearchRoots  []string                          `yaml:"search_roots,omitempty"`
+	SearchDepth  int                               `yaml:"search_depth,omitempty"`
 	Paths        map[string]string                 `yaml:"paths,omitempty"`
 	SigningKeys  map[string][]string               `yaml:"signing_keys,omitempty"`
 	MCPApprovals map[string]map[string]MCPApproval `yaml:"mcp_approvals,omitempty"`
@@ -147,6 +155,7 @@ func Load(dir string) (*Config, error) {
 		KBs:          y.KBs,
 		Trust:        true, // absent `trust` key defaults to true, see yamlConfig doc
 		SearchRoots:  y.SearchRoots,
+		SearchDepth:  y.SearchDepth,
 		Paths:        y.Paths,
 		SigningKeys:  y.SigningKeys,
 		MCPApprovals: y.MCPApprovals,

--- a/internal/kb/kb_test.go
+++ b/internal/kb/kb_test.go
@@ -944,7 +944,9 @@ func TestReadMapContract_MachinePathAllowPrefixes_Malformed(t *testing.T) {
 		name  string
 		value string
 	}{
-		{"empty entry", "[/home/nonroot, ]"},
+		// A TRAILING comma is valid YAML and no longer yields an empty element
+		// (D162), so the malformed case is an empty entry in the middle.
+		{"empty entry", "[/home/nonroot, , /home/other]"},
 		{"duplicate entry", "[/home/nonroot, /home/nonroot]"},
 		{"relative path", "[relative/path]"},
 		{"windows relative form", `[Users\foo]`},
@@ -1452,5 +1454,47 @@ func TestInit_IndexTitleFromDirectory(t *testing.T) {
 	raw, _ = os.ReadFile(filepath.Join(k.DataRoot(), "index.md"))
 	if string(raw) != custom {
 		t.Errorf("existing index.md was rewritten:\n%s", raw)
+	}
+}
+
+// The field report asked for the file and line alongside the key. validate
+// already wrapped the parser error with the concept's path, and D162 added the
+// line to the parser message, so the three together need no new check — a lint
+// duplicate would only double-report (D162).
+func TestValidate_UnparseableFrontmatterNamesPathKeyAndLine(t *testing.T) {
+	dir := tempKB(t)
+	k, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := k.CreateMap("notes", "Notes", "map", nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	rel := filepath.Join("notes", "broken.md")
+	abs := filepath.Join(k.DataRoot(), rel)
+	if err := os.WriteFile(abs, []byte("---\ntype: Note\nprovenance: [\n  a,\n---\n# Broken\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	errs, err := k.Validate("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found *ValidationError
+	for i := range errs {
+		if strings.Contains(errs[i].Message, "unparseable frontmatter") {
+			found = &errs[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("no unparseable-frontmatter error reported: %+v", errs)
+	}
+	if !strings.Contains(found.Path, "broken.md") {
+		t.Errorf("error path = %q, want it to name the file", found.Path)
+	}
+	for _, want := range []string{"provenance", "line"} {
+		if !strings.Contains(found.Message, want) {
+			t.Errorf("message %q does not mention %q", found.Message, want)
+		}
 	}
 }

--- a/internal/mcpserver/docs_test.go
+++ b/internal/mcpserver/docs_test.go
@@ -55,7 +55,7 @@ var docsNonTools = map[string]bool{
 	"secrets_source": true, "review_after": true, "asserted_by": true,
 	"last_indexed_commit": true, "content_hash": true, "applied_revision": true,
 	"allow_artifact_write": true, "sops_age_key_file": true, "token_env": true,
-	"search_roots": true, "resolution_strategy": true, "resolution_body": true,
+	"search_roots": true, "search_depth": true, "resolution_strategy": true, "resolution_body": true,
 	// kb_status / sync_status output fields (D145), not tools
 	"git_workflow": true, "git_profile": true, "git_sync": true,
 	// a tool of ANOTHER agent, cited where Cartographer explains what it

--- a/internal/okf/frontmatter.go
+++ b/internal/okf/frontmatter.go
@@ -92,14 +92,17 @@ func ParseFrontmatter(raw string) (*Frontmatter, error) {
 			}
 
 		case strings.HasPrefix(valueRaw, "["):
-			// Flow list: [a, b, c]
-			closing := strings.LastIndex(valueRaw, "]")
-			if closing < 0 {
-				return nil, fmt.Errorf("frontmatter: unclosed flow list at key %q", key)
+			// Flow list, on one line or several (D162): the multi-line form is
+			// valid YAML and is what any editor produces for a long list, but the
+			// parser only ever looked at the current line — 63 files in one corpus
+			// used it and one of them aborted an import. The block-list branch
+			// above already had the lookahead; this branch simply did not use it.
+			inner, consumed, closed := collectFlowList(lines[i:], colonIdx+1)
+			if !closed {
+				return nil, fmt.Errorf("frontmatter: unclosed flow list at key %q (line %d)", key, i+1)
 			}
-			inner := valueRaw[1:closing]
 			value = parseFlowList(inner)
-			i++
+			i += consumed
 
 		default:
 			// scalar
@@ -119,6 +122,55 @@ func ParseFrontmatter(raw string) (*Frontmatter, error) {
 	return fm, nil
 }
 
+// collectFlowList accumulates the inner text of a flow list starting on
+// lines[0] at byte offset start, across as many lines as needed, and reports how
+// many lines it consumed and whether the closing bracket was found.
+//
+// Depth is tracked over [ and ], and bracket characters inside quoted scalars are
+// skipped, so a "]" in a quoted element is not a terminator. Scanning stops at the
+// end of the frontmatter block: a "[" with no "]" before it is unclosed, not a
+// licence to consume the body.
+func collectFlowList(lines []string, start int) (inner string, consumed int, closed bool) {
+	var sb strings.Builder
+	depth := 0
+	var quote byte
+	for n, line := range lines {
+		segment := line
+		if n == 0 {
+			segment = line[start:]
+		} else {
+			sb.WriteByte(' ')
+		}
+		for i := 0; i < len(segment); i++ {
+			c := segment[i]
+			if quote != 0 {
+				if c == quote {
+					quote = 0
+				}
+				sb.WriteByte(c)
+				continue
+			}
+			switch c {
+			case '\'', '"':
+				quote = c
+			case '[':
+				depth++
+				if depth == 1 {
+					// The opening bracket itself is not part of the inner text.
+					continue
+				}
+			case ']':
+				depth--
+				if depth == 0 {
+					return sb.String(), n + 1, true
+				}
+			}
+			sb.WriteByte(c)
+		}
+	}
+	return sb.String(), len(lines), false
+}
+
 // parseFlowList parses the inner part of a YAML flow list (without the square brackets).
 func parseFlowList(inner string) []string {
 	if strings.TrimSpace(inner) == "" {
@@ -126,7 +178,13 @@ func parseFlowList(inner string) []string {
 	}
 	parts := splitFlowList(inner)
 	result := make([]string, 0, len(parts))
-	for _, p := range parts {
+	for n, p := range parts {
+		// A trailing comma before "]" is valid YAML and is what every editor
+		// emits when it wraps a list, so the empty final segment it leaves is
+		// dropped rather than becoming an empty element (D162).
+		if n == len(parts)-1 && strings.TrimSpace(p) == "" {
+			continue
+		}
 		result = append(result, unquoteScalar(strings.TrimSpace(p)))
 	}
 	return result

--- a/internal/okf/frontmatter_test.go
+++ b/internal/okf/frontmatter_test.go
@@ -327,3 +327,99 @@ func checkString(t *testing.T, fm *Frontmatter, key, want string) {
 		t.Fatalf("key %q: expected %q, got %q", key, want, got)
 	}
 }
+
+// --- D162 WP1: multi-line flow lists ---
+
+// Valid YAML that any editor produces for a long list used to be rejected: 63
+// files in one corpus used the multi-line form and one of them aborted an import.
+func TestParseFrontmatter_MultiLineFlowList(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{
+			"the reported example",
+			"type: Note\nprovenance: [\n  first/source.md,\n  second/source.md,\n]\ntitle: T",
+			[]string{"first/source.md", "second/source.md"},
+		},
+		{
+			"single line still parses identically",
+			"type: Note\nprovenance: [a, b]",
+			[]string{"a", "b"},
+		},
+		{
+			"a trailing comma yields no empty element",
+			"type: Note\nprovenance: [\n  a,\n  b,\n]",
+			[]string{"a", "b"},
+		},
+		{
+			"a bracket inside a quoted element is not a terminator",
+			"type: Note\nprovenance: [\n  \"x]y\",\n  b,\n]",
+			[]string{"x]y", "b"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fm, err := ParseFrontmatter(tc.raw)
+			if err != nil {
+				t.Fatalf("ParseFrontmatter: %v", err)
+			}
+			v, ok := fm.Get("provenance")
+			if !ok {
+				t.Fatal("provenance missing")
+			}
+			got, ok := v.([]string)
+			if !ok {
+				t.Fatalf("provenance = %#v, want []string", v)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("provenance = %#v, want %#v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("element %d = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+			// Keys after the list must still parse: the scan has to stop at the
+			// closing bracket, not swallow the rest.
+			if tc.name == "the reported example" && fm.Type() != "Note" {
+				t.Errorf("type = %q, want Note — the scan consumed too much", fm.Type())
+			}
+		})
+	}
+}
+
+// An unclosed list is still an error, and now names the line so it can be found
+// in a corpus of a thousand pages.
+func TestParseFrontmatter_UnclosedFlowListNamesTheLine(t *testing.T) {
+	_, err := ParseFrontmatter("type: Note\nprovenance: [\n  a,\n")
+	if err == nil {
+		t.Fatal("an unclosed flow list must remain an error")
+	}
+	for _, want := range []string{"provenance", "line 2"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+// The serializer is not required to preserve the wrapping: a multi-line source
+// round-trips into the single-line form, which is not a bug.
+func TestParseFrontmatter_MultiLineFlowListRoundTripsToOneLine(t *testing.T) {
+	fm, err := ParseFrontmatter("type: Note\nprovenance: [\n  a,\n  b,\n]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := fm.Serialize()
+	if !strings.Contains(out, "provenance: [a, b]") {
+		t.Errorf("serialized form = %q, want the single-line list", out)
+	}
+	again, err := ParseFrontmatter(out)
+	if err != nil {
+		t.Fatalf("reparse: %v", err)
+	}
+	if v, _ := again.Get("provenance"); len(v.([]string)) != 2 {
+		t.Errorf("round trip lost elements: %#v", v)
+	}
+}

--- a/internal/provisioning/expand.go
+++ b/internal/provisioning/expand.go
@@ -15,7 +15,16 @@ import (
 
 // placeholderRe matches a {{repo:<key>}} or {{path:<name>}} placeholder
 // (D75): a literal "repo" or "path" kind, a colon, then anything but braces.
-var placeholderRe = regexp.MustCompile(`\{\{(repo|path):([^{}]+)\}\}`)
+var placeholderRe = regexp.MustCompile(`\{\{(\\?)(repo|path):([^{}]+)\}\}`)
+
+// isPlaceholderMetasyntax reports whether a key is obviously a documentation
+// placeholder rather than a real one: <name> or "...". It silences the WARNING
+// only — the text is still left verbatim, which is what a documentation example
+// wants (D162). No lookup is needed to be sure: repoindex keys are git remote
+// names or path keys, and "<" ">" are legal in neither.
+func isPlaceholderMetasyntax(key string) bool {
+	return key == "..." || (strings.HasPrefix(key, "<") && strings.HasSuffix(key, ">"))
+}
 
 // expansionTracker accumulates state across one whole Apply invocation:
 // every warning raised while expanding placeholders (surfaced once, at the
@@ -45,14 +54,29 @@ func expandPlaceholders(content []byte, opts ApplyOptions, tracker *expansionTra
 
 	return placeholderRe.ReplaceAllFunc(content, func(match []byte) []byte {
 		sub := placeholderRe.FindSubmatch(match)
-		kind, key := string(sub[1]), string(sub[2])
+		escaped, kind, key := string(sub[1]) != "", string(sub[2]), string(sub[3])
+
+		// {{\repo:...}} is the authoritative way to write the syntax down: the
+		// backslash is removed and nothing is resolved. Chosen over doubling the
+		// braces, which is unreadable in a document that is *about* the syntax,
+		// and over an HTML-comment wrapper, since skills are also read as plain
+		// markdown (D162).
+		if escaped {
+			return []byte(strings.Replace(string(match), "{{\\", "{{", 1))
+		}
+		// Documentation metasyntax: verbatim and silent. Before this, describing
+		// the generic form inside a skill produced eleven warnings per sync, which
+		// trains people to ignore warnings.
+		if isPlaceholderMetasyntax(key) {
+			return match
+		}
 
 		var resolved string
 		var err error
 		switch kind {
 		case "repo":
 			var warnings []string
-			resolved, warnings, err = repoindex.Resolve(key, opts.Paths, opts.SearchRoots)
+			resolved, warnings, err = repoindex.Resolve(key, opts.Paths, opts.SearchRoots, opts.SearchDepth)
 			tracker.warnings = append(tracker.warnings, warnings...)
 		case "path":
 			if p, ok := opts.Paths[key]; ok {

--- a/internal/provisioning/expand_test.go
+++ b/internal/provisioning/expand_test.go
@@ -641,3 +641,63 @@ func TestApply_ExpandPlaceholders_NoPathsTableServerSide(t *testing.T) {
 		t.Errorf("the server must never add the Local paths table:\n%s", data)
 	}
 }
+
+// --- D162 WP3: writing the placeholder syntax down ---
+
+// Documenting the generic form inside a skill produced eleven warnings per sync,
+// which trains people to ignore warnings, and the only workaround was to describe
+// the syntax in prose without braces — in the one place where showing it verbatim
+// is the point.
+func TestExpandPlaceholders_LiteralAndMetasyntax(t *testing.T) {
+	opts := ApplyOptions{ExpandPlaceholders: true, Paths: map[string]string{"kubeconfig": "/tmp/kube"}}
+
+	t.Run("an escaped placeholder is emitted literally and silently", func(t *testing.T) {
+		tr := newExpansionTracker()
+		out := expandPlaceholders([]byte(`use {{\path:kubeconfig}} for the generic form`), opts, tr)
+		if !strings.Contains(string(out), "{{path:kubeconfig}}") {
+			t.Errorf("output = %q, want the literal form without the backslash", out)
+		}
+		if len(tr.warnings) != 0 {
+			t.Errorf("warnings = %v, want none", tr.warnings)
+		}
+		if len(tr.resolved) != 0 {
+			t.Errorf("an escaped placeholder must not be recorded as resolved: %v", tr.resolved)
+		}
+	})
+
+	t.Run("the same key unescaped still resolves", func(t *testing.T) {
+		tr := newExpansionTracker()
+		out := expandPlaceholders([]byte(`{{path:kubeconfig}}`), opts, tr)
+		if string(out) != "/tmp/kube" {
+			t.Errorf("output = %q, want the resolved path", out)
+		}
+	})
+
+	t.Run("metasyntax is verbatim and silent", func(t *testing.T) {
+		tr := newExpansionTracker()
+		out := expandPlaceholders([]byte(`the form is {{repo:<name>}} or {{path:<name>}}`), opts, tr)
+		if !strings.Contains(string(out), "{{repo:<name>}}") {
+			t.Errorf("output = %q, want the metasyntax verbatim", out)
+		}
+		// The complaint was a count, so the assertion is a count.
+		if len(tr.warnings) != 0 {
+			t.Errorf("warnings = %v, want none", tr.warnings)
+		}
+	})
+
+	t.Run("a genuinely missing key still warns exactly once", func(t *testing.T) {
+		tr := newExpansionTracker()
+		expandPlaceholders([]byte(`{{path:missing}} and {{repo:<name>}}`), opts, tr)
+		if len(tr.warnings) != 1 {
+			t.Errorf("warnings = %v, want exactly one (the real one)", tr.warnings)
+		}
+	})
+
+	t.Run("content with no placeholder is returned byte-identical", func(t *testing.T) {
+		tr := newExpansionTracker()
+		in := []byte("nothing to expand here")
+		if out := expandPlaceholders(in, opts, tr); string(out) != string(in) {
+			t.Errorf("output = %q, want it unchanged", out)
+		}
+	})
+}

--- a/internal/provisioning/provisioning.go
+++ b/internal/provisioning/provisioning.go
@@ -192,7 +192,10 @@ type ApplyOptions struct {
 	// its own local filesystem.
 	ExpandPlaceholders bool
 	SearchRoots        []string
-	Paths              map[string]string
+	// SearchDepth bounds how deep repoindex descends from each search root when
+	// resolving a {{repo:<key>}} placeholder (D162). Zero means the default.
+	SearchDepth int
+	Paths       map[string]string
 
 	// NoHeal reports on-disk divergence (AppliedResult.Divergent) instead of
 	// restoring it (D139). The escape hatch for someone deliberately

--- a/internal/repoindex/repoindex.go
+++ b/internal/repoindex/repoindex.go
@@ -23,8 +23,20 @@ import (
 // internal/agents and internal/service.
 var userHomeDir = os.UserHomeDir
 
-// depthCap bounds how many directory levels Scan descends from each root.
-const depthCap = 4
+// DefaultDepth and MaxDepth bound how many directory levels Scan descends from
+// each root (D162). The old fixed cap of 4 made a workspace organised as
+// <root>/<program>/<area>/<repo> invisible — ~160 repositories unreachable in one
+// deployment, so every {{repo:<name>}} citing one was unusable — and the failure
+// message never mentioned a depth, so the limit had to be guessed.
+//
+// The default stays 4: raising it for everyone would slow every resolution to
+// accommodate one layout. MaxDepth exists because Scan walks the filesystem on
+// every unresolved placeholder, and an unbounded depth on a large home directory
+// is a multi-second stall in the middle of a sync.
+const (
+	DefaultDepth = 4
+	MaxDepth     = 8
+)
 
 // heavyDirs are non-hidden directories Scan never descends into: they are
 // large, never contain a repo of interest themselves, and walking them would
@@ -116,16 +128,31 @@ func SaveCache(idx *Index) error {
 // that canonical key. Scan does not descend into a repo's own working tree
 // once found. A directory with no readable/parseable origin remote is
 // silently skipped — not every clone has one, and that is not a scan error.
-func Scan(roots []string) (*Index, error) {
+func Scan(roots []string, maxDepth int) (*Index, error) {
 	idx := &Index{Roots: roots, Repos: map[RemoteKey][]string{}}
 	for _, root := range roots {
-		walkDir(expandHome(root), 0, idx)
+		walkDir(expandHome(root), 0, EffectiveDepth(maxDepth), idx)
 	}
 	return idx, nil
 }
 
-func walkDir(dir string, depth int, idx *Index) {
-	if depth > depthCap {
+// EffectiveDepth normalises a configured depth: zero or negative means the
+// default, and a value above MaxDepth is clamped rather than rejected — a config
+// value that stops a sync is worse than one adjusted loudly, and the caller
+// reports the clamp.
+func EffectiveDepth(configured int) int {
+	switch {
+	case configured <= 0:
+		return DefaultDepth
+	case configured > MaxDepth:
+		return MaxDepth
+	default:
+		return configured
+	}
+}
+
+func walkDir(dir string, depth, maxDepth int, idx *Index) {
+	if depth > maxDepth {
 		return
 	}
 	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
@@ -149,7 +176,7 @@ func walkDir(dir string, depth int, idx *Index) {
 		if strings.HasPrefix(name, ".") || heavyDirs[name] {
 			continue
 		}
-		walkDir(filepath.Join(dir, name), depth+1, idx)
+		walkDir(filepath.Join(dir, name), depth+1, maxDepth, idx)
 	}
 }
 
@@ -276,7 +303,7 @@ func lookupIndex(idx *Index, key string) (string, []string, error) {
 // roots on a cache miss (refreshing the cache for next time). Returns an
 // error — including any ambiguity error from lookupIndex — if key cannot be
 // resolved.
-func Resolve(key string, manualPaths map[string]string, roots []string) (string, []string, error) {
+func Resolve(key string, manualPaths map[string]string, roots []string, maxDepth int) (string, []string, error) {
 	if p, ok := manualPaths[key]; ok {
 		return expandHome(p), nil, nil
 	}
@@ -291,7 +318,7 @@ func Resolve(key string, manualPaths map[string]string, roots []string) (string,
 		}
 	}
 
-	idx, err := Scan(roots)
+	idx, err := Scan(roots, maxDepth)
 	if err != nil {
 		return "", nil, err
 	}
@@ -300,7 +327,7 @@ func Resolve(key string, manualPaths map[string]string, roots []string) (string,
 	path, warnings, err := lookupIndex(idx, key)
 	if err != nil {
 		if errors.Is(err, errNotIndexed) {
-			return "", nil, fmt.Errorf("repoindex: repo %q not found under search roots %v", key, roots)
+			return "", nil, fmt.Errorf("repoindex: repo %q not found within %d directory levels of search roots %v — raise search_depth (max %d) or add a closer root in .cartographer.yaml", key, EffectiveDepth(maxDepth), roots, MaxDepth)
 		}
 		return "", nil, err
 	}

--- a/internal/repoindex/repoindex_test.go
+++ b/internal/repoindex/repoindex_test.go
@@ -79,7 +79,7 @@ func TestScanFindsRepos(t *testing.T) {
 	os.MkdirAll(skipped, 0o755)
 	writeGitRepo(t, skipped, "git@github.com:acme/should-not-be-found.git")
 
-	idx, err := Scan([]string{root})
+	idx, err := Scan([]string{root}, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +104,7 @@ func TestScanDepthCap(t *testing.T) {
 	os.MkdirAll(deep, 0o755)
 	writeGitRepo(t, deep, "git@github.com:acme/too-deep.git")
 
-	idx, err := Scan([]string{root})
+	idx, err := Scan([]string{root}, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +169,7 @@ func TestResolveManualPathsOverride(t *testing.T) {
 	userHomeDir = func() (string, error) { return home, nil }
 	defer func() { userHomeDir = os.UserHomeDir }()
 
-	path, warnings, err := Resolve("mine", map[string]string{"mine": dir}, nil)
+	path, warnings, err := Resolve("mine", map[string]string{"mine": dir}, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +192,7 @@ func TestResolveRescanOnMiss(t *testing.T) {
 	writeGitRepo(t, repo, "git@github.com:acme/myrepo.git")
 
 	// No cache exists yet: Resolve must fall through to Scan and find it.
-	path, _, err := Resolve("myrepo", nil, []string{root})
+	path, _, err := Resolve("myrepo", nil, []string{root}, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,7 +201,7 @@ func TestResolveRescanOnMiss(t *testing.T) {
 	}
 
 	// The cache should now be populated, resolving from cache without roots.
-	path2, _, err := Resolve("myrepo", nil, nil)
+	path2, _, err := Resolve("myrepo", nil, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,7 +216,7 @@ func TestResolveNotFound(t *testing.T) {
 	defer func() { userHomeDir = os.UserHomeDir }()
 
 	root := t.TempDir()
-	_, _, err := Resolve("nope", nil, []string{root})
+	_, _, err := Resolve("nope", nil, []string{root}, 0)
 	if err == nil {
 		t.Fatal("expected not-found error")
 	}


### PR DESCRIPTION
Four independent defects, grouped because none justified a plan of its own and each one blocked **writing something down** or **getting a corpus in**.

## 1. A multi-line flow list was rejected

The parser looked only at the current line, so `provenance: [\n  a,\n  b,\n]` — valid YAML, and what any editor produces for a long list — failed with `unclosed flow list`. 63 files in one corpus used the form and one of them aborted an import. The block-list branch already had the lookahead; the flow branch simply did not use it.

Now spans lines, terminated by the first depth-0 `]`, skipping brackets inside quoted scalars. **A trailing comma yields no empty element** — it is valid YAML and what every wrapping editor emits. An unclosed list stays an error and gains the **line number**. Scanning stops at the frontmatter terminator: a `[` with no `]` before `---` is unclosed, not a licence to consume the body.

**The file name needed no new code**, and this is the one place the plan's scope shrank on contact with the code: `Validate` already wraps the parser error with the concept's path, and `applyImportPlan` already reports the source path and **counts the file without aborting** the batch. Together with the new line number, the report's ask — file, key, line — is satisfied, so **the planned lint `frontmatter_malformed` check was dropped**: `validate` covers it and a duplicate would only double-report. That is the plan's own "defer to it if it exists" branch, taken, and there is a test asserting path + key + line together.

## 2. The placeholder syntax could not be written down

Eleven warnings per sync in one deployment, which trains people to ignore warnings. Two ways out, **both**: the escape `{{\repo:...}}` is authoritative (chosen over doubling the braces, unreadable in a document *about* the syntax, and over an HTML-comment wrapper, since skills are also read as plain markdown); the metasyntax heuristic silences **the warning only** for `<name>` or `...`, leaving the text verbatim — what a documentation example wants — and fixes every existing document with no edit. A real key cannot look like metasyntax, so no lookup is needed to be sure.

## 3. The repo scan stopped at a fixed depth of 4

A `<root>/<program>/<area>/<repo>` workspace put clones one level too deep: ~160 repositories invisible, every `{{repo:<key>}}` citing one unusable, and the failure named no depth so the limit had to be guessed.

`search_depth` in `.cartographer.yaml`, **per client not per root** (per-root would turn `search_roots` into a list of objects). Default stays **4** — raising it for everyone would slow every resolution to accommodate one layout — maximum **8**, because the scan runs on every unresolved placeholder. Above the maximum it is **clamped, not rejected**: a config value that stops a sync is worse than one adjusted loudly. The not-found message names the depth searched, the maximum and the setting.

## 4. `--map` needed one flag per exact directory

58 directories, 58 flags. Now longest-prefix at **segment boundaries** (`a/b` never covers `a/bc`), with exact match as the degenerate case and `.` as a legal catch-all. **The matched prefix is replaced, not appended to**: the destination is a map and the write path caps concept depth at three segments, so mirroring a deep source tree cannot work — that is `--dir-as-concept`'s job. A duplicate source is an error rather than the later flag silently winning, a `--map` matching nothing warns, and `--dry-run` names the flag behind every destination.

The portability inputs became a struct: `materializeForProviders` already took `searchRoots` and `paths` positionally, and a third positional argument in a seven-argument call is how the next bug gets written.

## Tests

`TestParseFrontmatter_MultiLineFlowList` (the reported example, single-line regression, trailing comma, quoted bracket, and that keys *after* the list still parse), the unclosed-list line number, and the round trip to the single-line form. `TestValidate_UnparseableFrontmatterNamesPathKeyAndLine`. `TestExpandPlaceholders_LiteralAndMetasyntax`, whose key assertion is a **warning count**, since the complaint was a count. `TestBuildImportPlan_MapPrefixMatching` with six cases including the boundary case and the still-an-error unmapped case.

One existing contract test moved its "empty entry" case from a trailing comma to an interior one, since the former is now valid YAML.

## Docs

`docs/data-plane.md` §Frontmatter value forms, `docs/sync.md` §Writing a placeholder literally and how deep the repo scan goes, `docs/configurator.md` on `--map` resolution. `D162` in `docs/decisions/data-plane.md`.

## Release impact

Mostly additive. One behaviour change: **a `--map` that previously matched one directory now matches its subtree**, so an import relying on subdirectories falling through to `--default-map` routes them differently — `--dry-run` is the check.

## Verification

`make vet`, `make test` (23 packages), `make smoke-http`, `make e2e` (12/12) and `make test-install` all green locally; `gofmt -l` clean.

Closes #183
