### PR TITLE
feat(client): per-provider KB binding model and `cartographer client` (D169)

### DIFF
--- a/cmd/cartographer/client.go
+++ b/cmd/cartographer/client.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/BeppeTemp/cartographer/internal/clientconfig"
+	"github.com/BeppeTemp/cartographer/internal/configurator"
+)
+
+// bindingNotYetEnforcedNote is printed by every command in this group that
+// changes a binding. The binding model (D169) is persisted here, but nothing
+// projects artifacts through it until the filtered projection lands: saying so
+// once per mutation is cheaper than a user concluding the feature is broken.
+const bindingNotYetEnforcedNote = "note: bindings are recorded but not yet enforced during sync"
+
+// cmdClient manages the per-provider KB binding (D169): which Knowledge Bases
+// each connected agent client may receive. Every subcommand here works
+// offline — it reads and writes .cartographer.yaml only and never contacts the
+// server, so configuring a machine does not require the network.
+func cmdClient(args []string) int {
+	if len(args) == 0 {
+		printClientUsage(os.Stderr)
+		return 2
+	}
+
+	dir, err := clientconfig.TargetDir()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		return 2
+	}
+	cfg, err := clientconfig.Load(dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: no client config found in %s (run `cartographer connect` first): %v\n", dir, err)
+		return 2
+	}
+
+	switch args[0] {
+	case "list":
+		return clientList(cfg, args[1:])
+	case "show":
+		return clientShow(cfg, args[1:])
+	case "bind":
+		return clientBind(dir, cfg, args[1:])
+	case "unbind":
+		return clientUnbind(dir, cfg, args[1:])
+	case "reset":
+		return clientReset(dir, cfg, args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "Error: unknown subcommand %q\n", args[0])
+		printClientUsage(os.Stderr)
+		return 2
+	}
+}
+
+func printClientUsage(w *os.File) {
+	fmt.Fprintln(w, "Usage: cartographer client list")
+	fmt.Fprintln(w, "       cartographer client show <provider>")
+	fmt.Fprintln(w, "       cartographer client bind <provider> <kb>[,<kb>...]")
+	fmt.Fprintln(w, "       cartographer client unbind <provider> <kb>[,<kb>...]")
+	fmt.Fprintln(w, "       cartographer client reset <provider>")
+}
+
+// bindingOrigin renders where a provider's KB list came from. It is the one
+// piece of information that makes `client list` actionable: the same list of
+// names means "declared" or "everything the server happens to mount today"
+// depending on this column.
+func bindingOrigin(explicit bool) string {
+	if explicit {
+		return "explicit"
+	}
+	return "default (all known)"
+}
+
+// formatKBList renders a resolved binding, distinguishing an explicitly empty
+// one from an unset default. "none" is a configured state, not an error.
+func formatKBList(kbs []string) string {
+	if len(kbs) == 0 {
+		return "none"
+	}
+	return strings.Join(kbs, ", ")
+}
+
+func clientList(cfg *clientconfig.Config, args []string) int {
+	if len(args) != 0 {
+		printClientUsage(os.Stderr)
+		return 2
+	}
+	if len(cfg.Agents) == 0 {
+		fmt.Println("no agent connected (run `cartographer connect`)")
+		return 0
+	}
+	fmt.Printf("%-12s %-22s %s\n", "PROVIDER", "ORIGIN", "KBS")
+	for _, p := range cfg.Agents {
+		kbs, explicit := cfg.BoundKBs(p)
+		fmt.Printf("%-12s %-22s %s\n", p, bindingOrigin(explicit), formatKBList(kbs))
+	}
+	return 0
+}
+
+func clientShow(cfg *clientconfig.Config, args []string) int {
+	if len(args) != 1 {
+		printClientUsage(os.Stderr)
+		return 2
+	}
+	provider := args[0]
+	if code := requireConnected(cfg, provider); code != 0 {
+		return code
+	}
+
+	kbs, explicit := cfg.BoundKBs(provider)
+	fmt.Printf("provider   %s\n", provider)
+	fmt.Printf("origin     %s\n", bindingOrigin(explicit))
+	fmt.Printf("bound      %s\n", formatKBList(kbs))
+
+	// What a provider does NOT receive is the half a binding is declared for,
+	// and it cannot be derived from the line above without the known set.
+	bound := make(map[string]bool, len(kbs))
+	for _, kb := range kbs {
+		bound[kb] = true
+	}
+	var unbound []string
+	for _, kb := range cfg.KnownKBs {
+		if !bound[kb] {
+			unbound = append(unbound, kb)
+		}
+	}
+	sort.Strings(unbound)
+	fmt.Printf("not bound  %s\n", formatKBList(unbound))
+	return 0
+}
+
+func clientBind(dir string, cfg *clientconfig.Config, args []string) int {
+	provider, kbs, code := parseBindArgs(cfg, args)
+	if code != 0 {
+		return code
+	}
+
+	_, wasExplicit := cfg.BoundKBs(provider)
+	for _, kb := range kbs {
+		if err := cfg.Bind(provider, kb); err != nil {
+			fmt.Fprintln(os.Stderr, "Error:", err)
+			return 2
+		}
+	}
+	if code := saveClientConfig(dir, cfg); code != 0 {
+		return code
+	}
+
+	// Creating the first binding flips the provider from "receives every known
+	// KB" to "receives only these": that is a reduction in what it gets, and
+	// stating it is the difference between a deliberate change and a surprise.
+	if !wasExplicit {
+		fmt.Printf("%s now receives only the KBs bound to it (it previously received every known KB)\n", provider)
+	}
+	// A KB absent from the cached set is not an error: it may be mounted later,
+	// and this command must keep working with no server reachable.
+	known := make(map[string]bool, len(cfg.KnownKBs))
+	for _, kb := range cfg.KnownKBs {
+		known[kb] = true
+	}
+	for _, kb := range kbs {
+		if !known[kb] {
+			fmt.Fprintf(os.Stderr, "warning: KB %q is not among the KBs the server last advertised\n", kb)
+		}
+	}
+
+	bound, _ := cfg.BoundKBs(provider)
+	fmt.Printf("%s bound to %s\n", provider, formatKBList(bound))
+	fmt.Println("run `cartographer sync` to apply")
+	fmt.Println(bindingNotYetEnforcedNote)
+	return 0
+}
+
+func clientUnbind(dir string, cfg *clientconfig.Config, args []string) int {
+	provider, kbs, code := parseBindArgs(cfg, args)
+	if code != 0 {
+		return code
+	}
+
+	for _, kb := range kbs {
+		if err := cfg.Unbind(provider, kb); err != nil {
+			fmt.Fprintln(os.Stderr, "Error:", err)
+			return 2
+		}
+	}
+	if code := saveClientConfig(dir, cfg); code != 0 {
+		return code
+	}
+
+	bound, explicit := cfg.BoundKBs(provider)
+	fmt.Printf("%s bound to %s\n", provider, formatKBList(bound))
+	if explicit && len(bound) == 0 {
+		// Deleting the entry here would silently restore "every known KB",
+		// which is the opposite of what removing the last KB asks for.
+		fmt.Printf("%s is now bound to no KBs; run `cartographer client reset %s` to return it to the default\n", provider, provider)
+	}
+	fmt.Println("run `cartographer sync` to apply")
+	fmt.Println(bindingNotYetEnforcedNote)
+	return 0
+}
+
+func clientReset(dir string, cfg *clientconfig.Config, args []string) int {
+	if len(args) != 1 {
+		printClientUsage(os.Stderr)
+		return 2
+	}
+	provider := args[0]
+	if code := requireConnected(cfg, provider); code != 0 {
+		return code
+	}
+
+	cfg.ResetBinding(provider)
+	if code := saveClientConfig(dir, cfg); code != 0 {
+		return code
+	}
+	fmt.Printf("%s returned to the default: every known KB\n", provider)
+	fmt.Println("run `cartographer sync` to apply")
+	fmt.Println(bindingNotYetEnforcedNote)
+	return 0
+}
+
+// parseBindArgs validates the "<provider> <kb>[,<kb>...]" shape shared by bind
+// and unbind.
+func parseBindArgs(cfg *clientconfig.Config, args []string) (provider string, kbs []string, code int) {
+	if len(args) != 2 {
+		printClientUsage(os.Stderr)
+		return "", nil, 2
+	}
+	provider = args[0]
+	if code := requireConnected(cfg, provider); code != 0 {
+		return "", nil, code
+	}
+	for _, kb := range strings.Split(args[1], ",") {
+		kb = strings.TrimSpace(kb)
+		if kb == "" {
+			fmt.Fprintf(os.Stderr, "Error: empty KB name in %q\n", args[1])
+			return "", nil, 2
+		}
+		kbs = append(kbs, kb)
+	}
+	return provider, kbs, 0
+}
+
+// requireConnected rejects a provider that is unknown or not connected. A
+// binding for a provider nobody connected would never be read, so recording it
+// silently would be worse than refusing it.
+func requireConnected(cfg *clientconfig.Config, provider string) int {
+	if !isKnownProvider(provider) {
+		fmt.Fprintf(os.Stderr, "Error: unknown provider %q (valid: %s)\n", provider, strings.Join(knownProviderNames(), ", "))
+		return 2
+	}
+	if !cfg.HasAgent(provider) {
+		fmt.Fprintf(os.Stderr, "Error: %s is not connected (connected: %s)\n", provider, formatKBList(cfg.Agents))
+		return 2
+	}
+	return 0
+}
+
+func isKnownProvider(name string) bool {
+	_, ok := configurator.Lookup(configurator.Provider(name))
+	return ok
+}
+
+func knownProviderNames() []string {
+	descriptors := configurator.Providers()
+	names := make([]string, 0, len(descriptors))
+	for _, d := range descriptors {
+		names = append(names, string(d.Provider))
+	}
+	sort.Strings(names)
+	return names
+}
+
+func saveClientConfig(dir string, cfg *clientconfig.Config) int {
+	if err := clientconfig.Save(dir, cfg); err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		return 2
+	}
+	return 0
+}

--- a/cmd/cartographer/client_test.go
+++ b/cmd/cartographer/client_test.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/BeppeTemp/cartographer/internal/clientconfig"
+)
+
+// writeClientCfg installs a .cartographer.yaml in a temporary HOME, which is
+// what clientconfig.TargetDir resolves, and returns that directory.
+func writeClientCfg(t *testing.T, agents, knownKBs []string, clients map[string]clientconfig.ClientBinding) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := clientconfig.Default()
+	cfg.ServerURL = "http://localhost:39273/mcp"
+	cfg.Agents = agents
+	cfg.KnownKBs = knownKBs
+	cfg.Clients = clients
+	if err := clientconfig.Save(home, cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	return home
+}
+
+func loadClientCfg(t *testing.T, dir string) *clientconfig.Config {
+	t.Helper()
+	cfg, err := clientconfig.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	return cfg
+}
+
+func TestCmdClientListReportsOrigin(t *testing.T) {
+	writeClientCfg(t,
+		[]string{"claude", "codex"},
+		[]string{"alpha", "beta"},
+		map[string]clientconfig.ClientBinding{"claude": {KBs: []string{"alpha"}}},
+	)
+
+	out := withStdout(t, func() {
+		if code := cmdClient([]string{"list"}); code != 0 {
+			t.Errorf("cmdClient list = %d, want 0", code)
+		}
+	})
+
+	for _, want := range []string{"claude", "explicit", "alpha", "codex", "default (all known)", "alpha, beta"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("list output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestCmdClientShowListsUnboundKBs(t *testing.T) {
+	writeClientCfg(t,
+		[]string{"claude"},
+		[]string{"alpha", "beta", "gamma"},
+		map[string]clientconfig.ClientBinding{"claude": {KBs: []string{"beta"}}},
+	)
+
+	out := withStdout(t, func() {
+		if code := cmdClient([]string{"show", "claude"}); code != 0 {
+			t.Errorf("cmdClient show = %d, want 0", code)
+		}
+	})
+
+	if !strings.Contains(out, "bound      beta") {
+		t.Errorf("show output missing the bound KB:\n%s", out)
+	}
+	if !strings.Contains(out, "not bound  alpha, gamma") {
+		t.Errorf("show output missing the unbound KBs:\n%s", out)
+	}
+}
+
+// TestCmdClientBindAnnouncesTheReduction: creating the first binding narrows
+// what a provider receives, and the output must say so — otherwise the change
+// reads as additive.
+func TestCmdClientBindAnnouncesTheReduction(t *testing.T) {
+	dir := writeClientCfg(t, []string{"claude"}, []string{"alpha", "beta"}, nil)
+
+	out := withStdout(t, func() {
+		if code := cmdClient([]string{"bind", "claude", "alpha"}); code != 0 {
+			t.Errorf("cmdClient bind = %d, want 0", code)
+		}
+	})
+
+	if !strings.Contains(out, "now receives only the KBs bound to it") {
+		t.Errorf("bind did not announce the reduction:\n%s", out)
+	}
+	if !strings.Contains(out, "run `cartographer sync` to apply") {
+		t.Errorf("bind did not tell the user to sync:\n%s", out)
+	}
+	if !strings.Contains(out, bindingNotYetEnforcedNote) {
+		t.Errorf("bind did not state that bindings are not yet enforced:\n%s", out)
+	}
+
+	cfg := loadClientCfg(t, dir)
+	if kbs, explicit := cfg.BoundKBs("claude"); !explicit || strings.Join(kbs, ",") != "alpha" {
+		t.Errorf("persisted binding = %v explicit=%v, want [alpha] explicit=true", kbs, explicit)
+	}
+
+	// A second bind on an already-explicit provider must not repeat the notice.
+	out = withStdout(t, func() {
+		cmdClient([]string{"bind", "claude", "beta"})
+	})
+	if strings.Contains(out, "now receives only the KBs bound to it") {
+		t.Errorf("the reduction notice repeated on an already-bound provider:\n%s", out)
+	}
+}
+
+// TestCmdClientBindWarnsOnUnadvertisedKB: binding a KB the server has not
+// advertised is deliberately allowed — it may be mounted later — but warned.
+func TestCmdClientBindWarnsOnUnadvertisedKB(t *testing.T) {
+	dir := writeClientCfg(t, []string{"claude"}, []string{"alpha"}, nil)
+
+	errOut := withStderr(t, func() {
+		if code := cmdClient([]string{"bind", "claude", "not-yet-mounted"}); code != 0 {
+			t.Errorf("cmdClient bind = %d, want 0 (an unadvertised KB is not an error)", code)
+		}
+	})
+
+	if !strings.Contains(errOut, "not among the KBs the server last advertised") {
+		t.Errorf("expected a warning on stderr, got:\n%s", errOut)
+	}
+	cfg := loadClientCfg(t, dir)
+	if kbs, _ := cfg.BoundKBs("claude"); strings.Join(kbs, ",") != "not-yet-mounted" {
+		t.Errorf("the binding was not persisted: %v", kbs)
+	}
+}
+
+// TestCmdClientUnbindLastKeepsTheEntry: removing the last KB must mean "no
+// KBs", never a silent return to "every known KB".
+func TestCmdClientUnbindLastKeepsTheEntry(t *testing.T) {
+	dir := writeClientCfg(t,
+		[]string{"claude"},
+		[]string{"alpha", "beta"},
+		map[string]clientconfig.ClientBinding{"claude": {KBs: []string{"alpha"}}},
+	)
+
+	out := withStdout(t, func() {
+		if code := cmdClient([]string{"unbind", "claude", "alpha"}); code != 0 {
+			t.Errorf("cmdClient unbind = %d, want 0", code)
+		}
+	})
+
+	if !strings.Contains(out, "bound to none") {
+		t.Errorf("unbind output should report an empty binding:\n%s", out)
+	}
+	if !strings.Contains(out, "client reset claude") {
+		t.Errorf("unbind should point at reset as the way back to the default:\n%s", out)
+	}
+
+	cfg := loadClientCfg(t, dir)
+	if kbs, explicit := cfg.BoundKBs("claude"); !explicit || len(kbs) != 0 {
+		t.Errorf("persisted binding = %v explicit=%v, want [] explicit=true", kbs, explicit)
+	}
+}
+
+func TestCmdClientResetReturnsToDefault(t *testing.T) {
+	dir := writeClientCfg(t,
+		[]string{"claude"},
+		[]string{"alpha", "beta"},
+		map[string]clientconfig.ClientBinding{"claude": {KBs: []string{"alpha"}}},
+	)
+
+	out := withStdout(t, func() {
+		if code := cmdClient([]string{"reset", "claude"}); code != 0 {
+			t.Errorf("cmdClient reset = %d, want 0", code)
+		}
+	})
+	if !strings.Contains(out, "every known KB") {
+		t.Errorf("reset output missing the default description:\n%s", out)
+	}
+
+	cfg := loadClientCfg(t, dir)
+	if kbs, explicit := cfg.BoundKBs("claude"); explicit || strings.Join(kbs, ",") != "alpha,beta" {
+		t.Errorf("persisted binding = %v explicit=%v, want the default", kbs, explicit)
+	}
+}
+
+func TestCmdClientRejectsBadProviders(t *testing.T) {
+	writeClientCfg(t, []string{"claude"}, []string{"alpha"}, nil)
+
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"unknown provider", []string{"bind", "nonesuch", "alpha"}, "unknown provider"},
+		{"provider not connected", []string{"bind", "codex", "alpha"}, "is not connected"},
+		{"empty KB name", []string{"bind", "claude", "alpha,,beta"}, "empty KB name"},
+		{"unknown subcommand", []string{"frobnicate"}, "unknown subcommand"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errOut := withStderr(t, func() {
+				if code := cmdClient(tc.args); code != 2 {
+					t.Errorf("cmdClient %v = %d, want 2", tc.args, code)
+				}
+			})
+			if !strings.Contains(errOut, tc.want) {
+				t.Errorf("stderr missing %q:\n%s", tc.want, errOut)
+			}
+		})
+	}
+}
+
+// TestCmdClientMutationsDoNotTouchKnownKBs: the binding commands are the only
+// writers of `clients`, and must never rewrite the server-owned cache.
+func TestCmdClientMutationsDoNotTouchKnownKBs(t *testing.T) {
+	dir := writeClientCfg(t, []string{"claude"}, []string{"alpha", "beta"}, nil)
+
+	withStdout(t, func() {
+		cmdClient([]string{"bind", "claude", "alpha"})
+	})
+
+	cfg := loadClientCfg(t, dir)
+	if strings.Join(cfg.KnownKBs, ",") != "alpha,beta" {
+		t.Errorf("KnownKBs = %v, want the untouched cache [alpha beta]", cfg.KnownKBs)
+	}
+}

--- a/cmd/cartographer/clientsync.go
+++ b/cmd/cartographer/clientsync.go
@@ -71,7 +71,7 @@ func fetchMergedManifest(cfg *clientconfig.Config) (provisioning.Manifest, error
 	if err != nil {
 		return provisioning.Manifest{}, fmt.Errorf("health: %w", err)
 	}
-	targets, err := resolveKBTargets(health, cfg.KBs)
+	targets, err := resolveKBTargets(health, cfg.KnownKBs)
 	if err != nil {
 		return provisioning.Manifest{}, err
 	}

--- a/cmd/cartographer/connect.go
+++ b/cmd/cartographer/connect.go
@@ -565,7 +565,7 @@ func doConnect(opts connectOptions) (connectResult, error) {
 	if err != nil {
 		return connectResult{}, err
 	}
-	if _, err := removeMCPEntries(opts.Name, existing.KBs, opts.Providers, opts.Dir, opts.Auth, opts.TokenEnv, opts.DryRun); err != nil {
+	if _, err := removeMCPEntries(opts.Name, existing.KnownKBs, opts.Providers, opts.Dir, opts.Auth, opts.TokenEnv, opts.DryRun); err != nil {
 		return connectResult{}, err
 	}
 	configsWritten, configWarnings, err := applyMCPEntries(entries, opts.Providers, opts.Dir, opts.Auth, opts.TokenEnv, opts.DryRun)
@@ -585,11 +585,11 @@ func doConnect(opts connectOptions) (connectResult, error) {
 	}
 
 	// 2. Materialize skills via sync_pull (best-effort: a deferred sync is not fatal).
-	pullKBs := existing.KBs
+	pullKBs := existing.KnownKBs
 	if healthErr == nil {
 		pullKBs = kbs
 	}
-	pullCfg := &clientconfig.Config{ServerURL: opts.ServerURL, ServerName: opts.Name, Auth: opts.Auth, TokenEnv: opts.TokenEnv, KBs: pullKBs, SigningKeys: existing.SigningKeys}
+	pullCfg := &clientconfig.Config{ServerURL: opts.ServerURL, ServerName: opts.Name, Auth: opts.Auth, TokenEnv: opts.TokenEnv, KnownKBs: pullKBs, SigningKeys: existing.SigningKeys}
 
 	// The MCP-entry lines report what was emitted, not what was asked for:
 	// entries is built from the client config alone, so keeping it when no
@@ -614,7 +614,7 @@ func doConnect(opts connectOptions) (connectResult, error) {
 	// 3. Persist .cartographer.yaml.
 	existing.ServerURL, existing.ServerName, existing.Auth, existing.TokenEnv, existing.Trust = opts.ServerURL, opts.Name, opts.Auth, opts.TokenEnv, opts.Trust
 	if healthErr == nil {
-		existing.KBs = kbs
+		existing.KnownKBs = kbs
 	}
 	for _, p := range opts.Providers {
 		existing.AddAgent(p)

--- a/cmd/cartographer/disconnect.go
+++ b/cmd/cartographer/disconnect.go
@@ -128,7 +128,7 @@ func doDisconnect(opts disconnectOptions) (disconnectResult, error) {
 	for _, p := range opts.Providers {
 		pr := disconnectProviderResult{Provider: p}
 
-		removed, err := removeMCPEntries(cfg.ServerName, cfg.KBs, []string{p}, opts.Dir, cfg.Auth, cfg.TokenEnv, opts.DryRun)
+		removed, err := removeMCPEntries(cfg.ServerName, cfg.KnownKBs, []string{p}, opts.Dir, cfg.Auth, cfg.TokenEnv, opts.DryRun)
 		if err != nil {
 			return disconnectResult{}, fmt.Errorf("remove config for %s: %w", p, err)
 		}

--- a/cmd/cartographer/doctor.go
+++ b/cmd/cartographer/doctor.go
@@ -367,7 +367,7 @@ func checkManagedFiles(dir string, providers []string, lockFile provisioning.Loc
 // match the KBs recorded in .cartographer.yaml. An entry for a KB no longer
 // mounted keeps pointing an agent at something that is gone.
 func checkMCPEntries(dir string, cfg *clientconfig.Config, providers []string) []doctorFinding {
-	entries, err := entriesForKBs(cfg.ServerName, cfg.ServerURL, cfg.KBs)
+	entries, err := entriesForKBs(cfg.ServerName, cfg.ServerURL, cfg.KnownKBs)
 	if err != nil {
 		return []doctorFinding{{
 			Check: "mcp-entries", Severity: doctorError, Path: filepath.Join(dir, clientconfig.FileName),

--- a/cmd/cartographer/main.go
+++ b/cmd/cartographer/main.go
@@ -30,6 +30,7 @@ var subcommands = []subcommand{
 	{"Client", "sync", "Synchronize agent clients"},
 	{"Client", "reconnect", "Rebuild an agent client's configuration from scratch"},
 	{"Client", "approve", "Approve or revoke a third-party MCP descriptor"},
+	{"Client", "client", "Manage which KBs each agent client receives"},
 	{"Server", "serve", "Run the MCP server"},
 	{"Server", "service", "Manage the native server service"},
 	{"Server", "upgrade-repair", "Repair the native service and provider sync after an upgrade"},
@@ -64,6 +65,7 @@ var (
 	doctorFn        = cmdDoctor
 	reindexFn       = cmdReindex
 	auditFn         = cmdAudit
+	clientFn        = cmdClient
 )
 
 func main() {
@@ -125,6 +127,8 @@ func run(args []string) int {
 		return doctorFn(rest)
 	case "reindex":
 		return reindexFn(rest)
+	case "client":
+		return clientFn(rest)
 	default:
 		fmt.Fprintf(os.Stderr, "Error: unknown command %q", cmd)
 		if suggestion := commandSuggestion(cmd); suggestion != "" {

--- a/cmd/cartographer/multikb_test.go
+++ b/cmd/cartographer/multikb_test.go
@@ -73,8 +73,8 @@ func TestDoConnect_PerKBEntries_AllProviders(t *testing.T) {
 		t.Fatalf("MCPEntries = %q, want %q", got, want)
 	}
 	cfg, err := clientconfig.Load(dir)
-	if err != nil || strings.Join(cfg.KBs, ",") != "alpha,beta,gamma" {
-		t.Fatalf("persisted KBs = %v, err=%v", cfg.KBs, err)
+	if err != nil || strings.Join(cfg.KnownKBs, ",") != "alpha,beta,gamma" {
+		t.Fatalf("persisted KBs = %v, err=%v", cfg.KnownKBs, err)
 	}
 	for _, provider := range providers {
 		r, err := configurator.Emit(&configurator.ServerConfig{Name: "placeholder"}, configurator.Provider(provider))
@@ -244,11 +244,11 @@ func TestCmdSync_ReconcilesOneToManyAndBack(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 
-	cfg := &clientconfig.Config{ServerURL: srv.URL + "/mcp", ServerName: "wiki", TokenEnv: "TOKEN", Agents: []string{"claude"}, KBs: []string{"alpha"}, Trust: true}
+	cfg := &clientconfig.Config{ServerURL: srv.URL + "/mcp", ServerName: "wiki", TokenEnv: "TOKEN", Agents: []string{"claude"}, KnownKBs: []string{"alpha"}, Trust: true}
 	if err := clientconfig.Save(dir, cfg); err != nil {
 		t.Fatal(err)
 	}
-	bare, _ := entriesForKBs("wiki", cfg.ServerURL, cfg.KBs)
+	bare, _ := entriesForKBs("wiki", cfg.ServerURL, cfg.KnownKBs)
 	if _, _, err := applyMCPEntries(bare, cfg.Agents, dir, false, "", false); err != nil {
 		t.Fatal(err)
 	}
@@ -261,8 +261,8 @@ func TestCmdSync_ReconcilesOneToManyAndBack(t *testing.T) {
 		t.Fatalf("1→2 entries = %s, err=%v", data, err)
 	}
 	updated, err := clientconfig.Load(dir)
-	if err != nil || strings.Join(updated.KBs, ",") != "alpha,beta" {
-		t.Fatalf("1→2 persisted KBs = %v, err=%v", updated.KBs, err)
+	if err != nil || strings.Join(updated.KnownKBs, ",") != "alpha,beta" {
+		t.Fatalf("1→2 persisted KBs = %v, err=%v", updated.KnownKBs, err)
 	}
 
 	// A fresh server instance is enough to model a KB disappearing while
@@ -284,11 +284,11 @@ func TestCmdSync_ReconcilesOneToManyAndBack(t *testing.T) {
 
 func TestDoDisconnect_RemovesPersistedPerKBEntries(t *testing.T) {
 	dir := t.TempDir()
-	cfg := &clientconfig.Config{ServerURL: "https://example.test/mcp", ServerName: "wiki", Agents: []string{"claude"}, KBs: []string{"alpha", "beta"}, Trust: true}
+	cfg := &clientconfig.Config{ServerURL: "https://example.test/mcp", ServerName: "wiki", Agents: []string{"claude"}, KnownKBs: []string{"alpha", "beta"}, Trust: true}
 	if err := clientconfig.Save(dir, cfg); err != nil {
 		t.Fatal(err)
 	}
-	entries, _ := entriesForKBs("wiki", cfg.ServerURL, cfg.KBs)
+	entries, _ := entriesForKBs("wiki", cfg.ServerURL, cfg.KnownKBs)
 	if _, _, err := applyMCPEntries(entries, cfg.Agents, dir, false, "", false); err != nil {
 		t.Fatal(err)
 	}
@@ -307,11 +307,11 @@ func TestDoDisconnect_RemovesPersistedPerKBEntries(t *testing.T) {
 func TestCmdSync_ServerDownKeepsMCPEntriesAndKBs(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
-	cfg := &clientconfig.Config{ServerURL: "http://127.0.0.1:1/mcp", ServerName: "wiki", Agents: []string{"claude"}, KBs: []string{"alpha", "beta"}, Trust: true}
+	cfg := &clientconfig.Config{ServerURL: "http://127.0.0.1:1/mcp", ServerName: "wiki", Agents: []string{"claude"}, KnownKBs: []string{"alpha", "beta"}, Trust: true}
 	if err := clientconfig.Save(dir, cfg); err != nil {
 		t.Fatal(err)
 	}
-	entries, _ := entriesForKBs("wiki", cfg.ServerURL, cfg.KBs)
+	entries, _ := entriesForKBs("wiki", cfg.ServerURL, cfg.KnownKBs)
 	if _, _, err := applyMCPEntries(entries, cfg.Agents, dir, false, "", false); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/cartographer/reindex.go
+++ b/cmd/cartographer/reindex.go
@@ -45,7 +45,7 @@ func cmdReindex(args []string) int {
 			cfg = loaded
 		}
 	}
-	selected := cfg.KBs
+	selected := cfg.KnownKBs
 	if *kbFlag != "" {
 		selected = []string{*kbFlag}
 	}

--- a/cmd/cartographer/sync.go
+++ b/cmd/cartographer/sync.go
@@ -92,7 +92,7 @@ func runSync(dir string, cfg *clientconfig.Config, opts syncOptions) (syncResult
 		if err != nil {
 			return syncResult{}, err
 		}
-		if _, err := removeMCPEntries(cfg.ServerName, cfg.KBs, cfg.Agents, dir, cfg.Auth, cfg.TokenEnv, opts.DryRun); err != nil {
+		if _, err := removeMCPEntries(cfg.ServerName, cfg.KnownKBs, cfg.Agents, dir, cfg.Auth, cfg.TokenEnv, opts.DryRun); err != nil {
 			return syncResult{}, err
 		}
 		_, warnings, err := applyMCPEntries(entries, cfg.Agents, dir, cfg.Auth, cfg.TokenEnv, opts.DryRun)
@@ -107,7 +107,7 @@ func runSync(dir string, cfg *clientconfig.Config, opts syncOptions) (syncResult
 		}
 		printMCPEntryLines(cfg.Agents, entryNames(entries), opts.DryRun)
 		if !opts.DryRun {
-			cfg.KBs = kbs
+			cfg.KnownKBs = kbs
 			if err := clientconfig.Save(dir, cfg); err != nil {
 				return syncResult{}, err
 			}

--- a/cmd/cartographer/toolprefix_client_test.go
+++ b/cmd/cartographer/toolprefix_client_test.go
@@ -160,7 +160,7 @@ func TestFetchMergedManifest_QualifiesSyncPullPerKB(t *testing.T) {
 	})
 	defer srv.Close()
 
-	cfg := &clientconfig.Config{ServerURL: srv.URL + "/mcp", KBs: []string{"alpha", "beta"}}
+	cfg := &clientconfig.Config{ServerURL: srv.URL + "/mcp", KnownKBs: []string{"alpha", "beta"}}
 	if _, err := fetchMergedManifest(cfg); err != nil {
 		t.Fatalf("fetchMergedManifest: %v", err)
 	}
@@ -177,7 +177,7 @@ func TestCmdReindex_QualifiesReindexPerKB(t *testing.T) {
 
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
-	cfg := &clientconfig.Config{ServerURL: srv.URL + "/mcp", KBs: []string{"alpha", "beta"}}
+	cfg := &clientconfig.Config{ServerURL: srv.URL + "/mcp", KnownKBs: []string{"alpha", "beta"}}
 	if err := clientconfig.Save(dir, cfg); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/cartographer/tui.go
+++ b/cmd/cartographer/tui.go
@@ -203,7 +203,7 @@ func buildRows(dir string) []dashboardAgent {
 	var kbs []string
 	if cfg, err := clientconfig.Load(dir); err == nil {
 		serverName = cfg.ServerName
-		kbs = cfg.KBs
+		kbs = cfg.KnownKBs
 		for _, a := range cfg.Agents {
 			connected[a] = true
 		}

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -60,10 +60,11 @@ configuration. With one mounted KB (or an older single-KB server that omits
 `kbs`) it keeps the compatible single entry, `<server_name>`, pointed at the
 bare `/mcp` URL. With two or more KBs it writes one entry per KB, named
 `<server_name>-<kb>` and pointed at `/mcp?kb=<kb>`, and records that KB list in
-`.cartographer.yaml`. `sync` repeats the enumeration: it adds new entries,
-removes entries for disappeared KBs, and performs the bare↔suffixed rename on
-one-to-many transitions. If the server cannot be reached, it leaves the MCP
-entries and `kbs` list untouched and warns; run `sync` again once it is up.
+`.cartographer.yaml` (`known_kbs`). `sync` repeats the enumeration: it adds new
+entries, removes entries for disappeared KBs, and performs the bare↔suffixed
+rename on one-to-many transitions. If the server cannot be reached, it leaves
+the MCP entries and `known_kbs` untouched and warns; run `sync` again once it is
+up.
 
 **Kiro and flat tool namespaces (D102).** Kiro's MCP tool namespace is flat across servers, unlike
 Claude Code/Codex/OpenCode which namespace per server: writing 2+ MCP entries for `kiro` (i.e.
@@ -146,7 +147,7 @@ managed artifacts registered for that provider in the lockfile (`provisioning.Pr
 managed files, never untracked ones), then removes the provider from the lockfile and from
 `.cartographer.yaml`. If the lockfile ends up with no providers it is removed; `.cartographer.yaml`,
 on the other hand, is **never deleted** (D64): with zero agents it stays on disk with `agents: []`,
-preserving `server_url`/`server_name`/`auth`/`token_env`/`trust`/`kbs` as defaults for the next
+preserving `server_url`/`server_name`/`auth`/`token_env`/`trust`/`known_kbs`/`clients` as defaults for the next
 `connect` (a disconnect→connect restarts from the previous server, not from `http://localhost:39273/mcp`).
 
 ```bash
@@ -672,10 +673,45 @@ server_name: cartographer  # name under which the server is registered in the MC
 auth: false
 token_env: CARTOGRAPHER_TOKENS
 agents: [claude, opencode]
-kbs: []          # mounted KB names discovered by connect/sync; empty = bare single-KB endpoint
+known_kbs: []    # mounted KB names discovered by connect/sync; empty = bare single-KB endpoint
+clients:         # per-provider KB binding (D169); absent provider = every known KB
+  claude:
+    kbs: [homelab]
 search_roots: ["~/Documents"]   # where repoindex.Scan looks for git clones for {{repo:<key>}} (D75)
 paths: {}                       # manual name -> path mapping for {{path:<name>}} (and an override for {{repo:<key>}}, D75)
 ```
+
+`known_kbs` is server-owned: `connect` and `sync` overwrite it wholesale with
+what `/health` advertises. `clients` is user-owned and is never written by them
+— it is maintained with `cartographer client` (below). The legacy `kbs` key
+written before D169 is still read and is migrated to `known_kbs` on the next
+write.
+
+### `cartographer client`
+
+Declares which Knowledge Bases each connected provider may receive. Every
+subcommand works offline: it reads and writes `.cartographer.yaml` only and
+never contacts the server, so a KB name that is not currently advertised is a
+warning, not a failure.
+
+| Command | Effect |
+|---|---|
+| `client list` | one row per connected provider: resolved KBs and the origin of the answer (`explicit` / `default (all known)`) |
+| `client show <provider>` | that provider's bound KBs, its origin, and the known KBs it is **not** bound to |
+| `client bind <provider> <kb>[,<kb>...]` | adds; creating the first binding narrows the provider from "every known KB" to only those listed, and the output says so |
+| `client unbind <provider> <kb>[,<kb>...]` | removes; removing the last KB leaves the provider bound to **no** KBs |
+| `client reset <provider>` | deletes the binding, returning the provider to the default |
+
+Three states, resolved only through `clientconfig.Config.BoundKBs` and never by
+testing a list for emptiness: **no entry** means every known KB (today's
+behaviour, so an upgrade never strips artifacts from an already connected
+client); **an entry holding an empty list** means no KBs; **an entry holding
+names** means those. `default-deny` is what declaring an entry buys, not a
+global mode — an operator who wants it everywhere declares a binding per
+provider.
+
+`bind`, `unbind` and `reset` save the configuration and stop: they never
+trigger a sync, and print `run cartographer sync to apply`.
 
 `status` and `sync` read this file (via `internal/clientconfig`): without `.cartographer.yaml` they
 fail with exit 2, suggesting `connect` first (`cartographer resolve` is the exception:

--- a/docs/decisions/client-configurator.md
+++ b/docs/decisions/client-configurator.md
@@ -642,3 +642,62 @@ the whole fix.
 **Consequences.** Additive: one new flag, one changed `doctor` message, one new optional lockfile
 field that older clients must ignore. The round trip — finding → `--repair-hashes` → finding
 gone — is covered by a single test, so the loop cannot regress.
+
+---
+
+<a id="d169"></a>
+## D169 — Per-provider KB binding: a user-owned preference beside a server-owned cache
+
+**Decision.** `.cartographer.yaml` gains two independent keys. `known_kbs` is the
+cache of the KB names the server advertised at the last successful
+`connect`/`sync`, overwritten wholesale on every run. `clients.<provider>.kbs` is
+the per-provider binding, declared by the user with the new `cartographer
+client` subcommand (`list`/`show`/`bind`/`unbind`/`reset`) and never written by
+`connect` or `sync`. `Config.BoundKBs(provider)` is the single resolver, and it
+also reports whether the answer was explicit.
+
+**Rationale.**
+
+- **The two meanings needed two keys.** The pre-existing `kbs` key looked like a
+  preference and behaved like a cache: `runSync` and `doConnect` assigned it the
+  full advertised list on every run, so anything a user wrote there survived
+  exactly until the next sync. Renaming it to `known_kbs` makes its ownership
+  legible, and the binding gets a key nothing else writes.
+- **Three states, one resolver.** An absent entry, an entry holding an empty
+  list, and an entry holding names are distinct: every known KB, no KB, and
+  those. A nil slice is never a wildcard. `BoundKBs` is the only place the rule
+  lives, so a caller cannot re-derive it by testing a list for emptiness — the
+  mistake that would silently give an intentionally empty binding full access.
+- **Default is compatible, not deny.** A provider with no entry keeps receiving
+  every known KB. Global default-deny would have stripped artifacts from every
+  already-connected client on upgrade, turning a new feature into an outage;
+  declaring an entry is what buys default-deny, one provider at a time.
+- **`unbind` of the last KB leaves the entry.** Deleting it would restore "every
+  known KB" — the opposite of what removing the last KB asks for. `reset` is the
+  explicit way back, and the command says so.
+- **Configuration is offline.** `client` never contacts the server: a KB absent
+  from `known_kbs` is a warning, because it may be mounted later and configuring
+  a machine must not require the network. For the same reason the commands save
+  and stop rather than triggering a sync — a configuration command that writes
+  into provider directories is the side effect this work exists to remove.
+- **Provider validation lives in the command, not the package.**
+  `internal/clientconfig` stays a data package with no knowledge of providers,
+  matching how `Agents` is already handled; `cmd/cartographer/client.go` owns
+  the `configurator.Lookup` check and the "valid providers" message.
+- **The binding is a projection, not an authorization boundary**, and is
+  documented as such. Per-KB scoped tokens exist server-side, but a per-provider
+  token env var would not isolate a process that shares the user, the filesystem
+  and the environment: it can read the other client's configuration. The binding
+  controls what a client is *given*, not what it *could* request.
+
+**Deviation from the plan.** The plan kept `Config.KBs` as a read-only Go alias
+of `KnownKBs`. It was removed instead: two Go fields that can diverge are the
+bug class being fixed, the field is internal, and every caller was migrated in
+the same change. The *on-disk* `kbs` key — the alias that matters for existing
+files — is still read, and is replaced by `known_kbs` on the first write.
+
+**Consequences.** Additive and backward compatible on disk: a pre-D169 file
+loads unchanged and is migrated on its next write. No projection behaviour
+changes here — bindings are recorded and not yet enforced, which the mutating
+commands state in their own output so the feature is not mistaken for active
+isolation. Enforcement is the filtered projection that follows.

--- a/internal/clientconfig/clientconfig.go
+++ b/internal/clientconfig/clientconfig.go
@@ -26,8 +26,22 @@ type Config struct {
 	ServerName string   `yaml:"server_name"`
 	Auth       bool     `yaml:"auth"`
 	TokenEnv   string   `yaml:"token_env"`
-	Agents     []string `yaml:"agents"`        // connected provider names, e.g. ["claude", "opencode"]
-	KBs        []string `yaml:"kbs,omitempty"` // optional: KB names to sync (empty = server default single-KB endpoint)
+	Agents     []string `yaml:"agents"` // connected provider names, e.g. ["claude", "opencode"]
+
+	// KnownKBs caches the KB names the server advertised at the last
+	// successful connect/sync. It is SERVER-owned: every sync overwrites it
+	// wholesale (see cmd/cartographer's runSync). It is not a user
+	// preference — that is Clients below. Persisted as `known_kbs`; the
+	// legacy `kbs` key written before D169 is still read by Load, and is no
+	// longer written by Save.
+	KnownKBs []string `yaml:"known_kbs,omitempty"`
+
+	// Clients is the per-provider KB binding (D169): which KBs each connected
+	// provider may receive. USER-owned — never written by connect/sync.
+	// Always resolve it through BoundKBs, never by reading the map directly:
+	// an absent entry, an entry holding an empty list, and an entry holding
+	// names are three distinct states, and a nil slice never means "every KB".
+	Clients map[string]ClientBinding `yaml:"clients,omitempty"`
 
 	// Trust records the persistent, per-server decision made at connect time:
 	// when true, kb:-sourced provisioning artifacts (skill/agent/hook/instructions)
@@ -74,10 +88,24 @@ type MCPApproval struct {
 	ApprovedAt  time.Time `yaml:"approved_at"`
 }
 
+// ClientBinding is one provider's declared KB set (D169). An entry that exists
+// carrying an empty KBs list means "no KBs", not "every KB": returning a
+// provider to the default requires deleting the entry (ResetBinding), which is
+// why Unbind of the last name leaves the entry in place.
+type ClientBinding struct {
+	KBs []string `yaml:"kbs"`
+}
+
 // yamlConfig mirrors Config for YAML (de)serialization. Trust is a *bool here
 // (unlike Config.Trust, a plain bool) so Load can tell an absent `trust` key
 // (nil, defaults to true) apart from an explicit `trust: false` written by a
 // user who revoked it.
+//
+// KnownKBs is a *[]string for the same reason (D169): an absent `known_kbs`
+// key falls back to the legacy `kbs` alias, while `known_kbs: []` is a
+// deliberately empty cache and must win over a stale `kbs` left behind by a
+// pre-D169 client. KBs itself is read-only — Save never emits it again, so the
+// first write after the upgrade completes the migration.
 type yamlConfig struct {
 	ServerURL    string                            `yaml:"server_url"`
 	ServerName   string                            `yaml:"server_name"`
@@ -85,6 +113,8 @@ type yamlConfig struct {
 	TokenEnv     string                            `yaml:"token_env"`
 	Agents       []string                          `yaml:"agents"`
 	KBs          []string                          `yaml:"kbs,omitempty"`
+	KnownKBs     *[]string                         `yaml:"known_kbs,omitempty"`
+	Clients      map[string]ClientBinding          `yaml:"clients,omitempty"`
 	Trust        *bool                             `yaml:"trust,omitempty"`
 	SearchRoots  []string                          `yaml:"search_roots,omitempty"`
 	SearchDepth  int                               `yaml:"search_depth,omitempty"`
@@ -143,7 +173,7 @@ func Load(dir string) (*Config, error) {
 	if err := yaml.Unmarshal(data, &extra); err != nil {
 		return nil, fmt.Errorf("clientconfig: parse extras %s: %w", Path(dir), err)
 	}
-	for _, key := range []string{"server_url", "server_name", "auth", "token_env", "agents", "kbs", "trust", "search_roots", "paths", "signing_keys", "mcp_approvals"} {
+	for _, key := range []string{"server_url", "server_name", "auth", "token_env", "agents", "kbs", "known_kbs", "clients", "trust", "search_roots", "paths", "signing_keys", "mcp_approvals"} {
 		delete(extra, key)
 	}
 	cfg := Config{
@@ -152,7 +182,8 @@ func Load(dir string) (*Config, error) {
 		Auth:         y.Auth,
 		TokenEnv:     y.TokenEnv,
 		Agents:       y.Agents,
-		KBs:          y.KBs,
+		KnownKBs:     y.KBs, // legacy alias; overridden below when known_kbs is present
+		Clients:      y.Clients,
 		Trust:        true, // absent `trust` key defaults to true, see yamlConfig doc
 		SearchRoots:  y.SearchRoots,
 		SearchDepth:  y.SearchDepth,
@@ -160,6 +191,11 @@ func Load(dir string) (*Config, error) {
 		SigningKeys:  y.SigningKeys,
 		MCPApprovals: y.MCPApprovals,
 		Extra:        extra,
+	}
+	if y.KnownKBs != nil {
+		// Present — including present and empty — always wins over the legacy
+		// `kbs` alias (D169).
+		cfg.KnownKBs = *y.KnownKBs
 	}
 	if y.Trust != nil {
 		cfg.Trust = *y.Trust
@@ -183,7 +219,8 @@ func Save(dir string, cfg *Config) error {
 		Auth:         cfg.Auth,
 		TokenEnv:     cfg.TokenEnv,
 		Agents:       cfg.Agents,
-		KBs:          cfg.KBs,
+		KnownKBs:     &cfg.KnownKBs, // always emitted; the legacy `kbs` key is not written again (D169)
+		Clients:      cfg.Clients,
 		Trust:        &cfg.Trust,
 		SearchRoots:  cfg.SearchRoots,
 		Paths:        cfg.Paths,
@@ -301,6 +338,86 @@ func (c *Config) HasAgent(name string) bool {
 func (c *Config) AddAgent(name string) {
 	if !c.HasAgent(name) {
 		c.Agents = append(c.Agents, name)
+	}
+}
+
+// BoundKBs resolves which KBs a provider may receive (D169), and reports
+// whether that answer comes from an explicit binding or from the default.
+//
+// This is the ONLY place the default is resolved: no caller may re-derive it
+// by testing Clients or a returned slice for emptiness, because an explicit
+// binding holding no KBs and an absent binding return the same empty slice and
+// mean opposite things. A provider with no entry receives every known KB —
+// today's behaviour, so an upgrade never strips artifacts from an already
+// connected client; default-deny is what declaring an entry buys.
+//
+// The returned slice is a copy: mutating it cannot corrupt the config.
+func (c *Config) BoundKBs(provider string) (kbs []string, explicit bool) {
+	if binding, ok := c.Clients[provider]; ok {
+		return append([]string(nil), binding.KBs...), true
+	}
+	return append([]string(nil), c.KnownKBs...), false
+}
+
+// Bind adds kb to provider's binding, creating the binding if the provider had
+// none — which converts it from "receives every known KB" to "receives only
+// this one". Callers must say so in their output. Adding a KB that is already
+// bound is a no-op.
+//
+// A kb absent from KnownKBs is deliberately NOT an error: the KB may be mounted
+// later, and configuring must not require a reachable server. Callers that can
+// check report it as a warning.
+func (c *Config) Bind(provider, kb string) error {
+	if provider == "" || provider != strings.TrimSpace(provider) {
+		return fmt.Errorf("clientconfig: invalid provider name %q", provider)
+	}
+	if kb == "" || kb != strings.TrimSpace(kb) {
+		return fmt.Errorf("clientconfig: invalid KB name %q", kb)
+	}
+	if c.Clients == nil {
+		c.Clients = make(map[string]ClientBinding)
+	}
+	binding := c.Clients[provider]
+	for _, existing := range binding.KBs {
+		if existing == kb {
+			return nil
+		}
+	}
+	binding.KBs = append(binding.KBs, kb)
+	c.Clients[provider] = binding
+	return nil
+}
+
+// Unbind removes kb from provider's binding. Removing the last name leaves the
+// entry in place holding an empty list — "no KBs" — because deleting it would
+// silently restore "receives every known KB". ResetBinding is the explicit way
+// back. Unbinding a pair that is not bound is a silent no-op, matching
+// RevokeMCP.
+func (c *Config) Unbind(provider, kb string) error {
+	if provider == "" || kb == "" {
+		return fmt.Errorf("clientconfig: invalid unbind (provider %q, kb %q)", provider, kb)
+	}
+	binding, ok := c.Clients[provider]
+	if !ok {
+		return nil
+	}
+	kept := make([]string, 0, len(binding.KBs))
+	for _, existing := range binding.KBs {
+		if existing != kb {
+			kept = append(kept, existing)
+		}
+	}
+	binding.KBs = kept
+	c.Clients[provider] = binding
+	return nil
+}
+
+// ResetBinding deletes provider's binding, returning it to the default (every
+// known KB). Missing entries are a no-op.
+func (c *Config) ResetBinding(provider string) {
+	delete(c.Clients, provider)
+	if len(c.Clients) == 0 {
+		c.Clients = nil
 	}
 }
 

--- a/internal/clientconfig/clientconfig_test.go
+++ b/internal/clientconfig/clientconfig_test.go
@@ -58,7 +58,7 @@ func TestSaveAndLoad_RoundTrip(t *testing.T) {
 	cfg.AddAgent("claude")
 	cfg.AddAgent("opencode")
 	cfg.Auth = true
-	cfg.KBs = []string{"homelab"}
+	cfg.KnownKBs = []string{"homelab"}
 
 	if err := clientconfig.Save(dir, cfg); err != nil {
 		t.Fatalf("Save: %v", err)
@@ -81,8 +81,8 @@ func TestSaveAndLoad_RoundTrip(t *testing.T) {
 	if len(loaded.Agents) != 2 || !loaded.HasAgent("claude") || !loaded.HasAgent("opencode") {
 		t.Errorf("Agents round-trip mismatch: %v", loaded.Agents)
 	}
-	if len(loaded.KBs) != 1 || loaded.KBs[0] != "homelab" {
-		t.Errorf("KBs round-trip mismatch: %v", loaded.KBs)
+	if len(loaded.KnownKBs) != 1 || loaded.KnownKBs[0] != "homelab" {
+		t.Errorf("KBs round-trip mismatch: %v", loaded.KnownKBs)
 	}
 }
 
@@ -249,5 +249,216 @@ func TestTargetDir(t *testing.T) {
 	realHome, _ := os.UserHomeDir()
 	if home != realHome {
 		t.Errorf("TargetDir() = %q, want home %q", home, realHome)
+	}
+}
+
+// --- D169: per-provider KB binding ---
+
+// TestBoundKBsThreeStates pins the rule no caller may re-derive: an absent
+// entry, an entry holding an empty list and an entry holding names are three
+// distinct states, and only the first one means "every known KB".
+func TestBoundKBsThreeStates(t *testing.T) {
+	cfg := clientconfig.Default()
+	cfg.KnownKBs = []string{"alpha", "beta"}
+	cfg.Clients = map[string]clientconfig.ClientBinding{
+		"codex":    {KBs: []string{"beta"}},
+		"opencode": {KBs: nil},
+	}
+
+	if kbs, explicit := cfg.BoundKBs("claude"); explicit || strings.Join(kbs, ",") != "alpha,beta" {
+		t.Errorf("no entry: got %v explicit=%v, want [alpha beta] explicit=false", kbs, explicit)
+	}
+	if kbs, explicit := cfg.BoundKBs("codex"); !explicit || strings.Join(kbs, ",") != "beta" {
+		t.Errorf("named entry: got %v explicit=%v, want [beta] explicit=true", kbs, explicit)
+	}
+	if kbs, explicit := cfg.BoundKBs("opencode"); !explicit || len(kbs) != 0 {
+		t.Errorf("empty entry: got %v explicit=%v, want [] explicit=true", kbs, explicit)
+	}
+}
+
+// TestBoundKBsReturnsCopy: a caller mutating the result must not corrupt the
+// config it was resolved from.
+func TestBoundKBsReturnsCopy(t *testing.T) {
+	cfg := clientconfig.Default()
+	cfg.KnownKBs = []string{"alpha"}
+	kbs, _ := cfg.BoundKBs("claude")
+	kbs[0] = "mutated"
+	if cfg.KnownKBs[0] != "alpha" {
+		t.Errorf("KnownKBs = %v, want the original [alpha]", cfg.KnownKBs)
+	}
+}
+
+func TestBindUnbindReset(t *testing.T) {
+	cfg := clientconfig.Default()
+	cfg.KnownKBs = []string{"alpha", "beta"}
+
+	if err := cfg.Bind("claude", "alpha"); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	// Binding the first KB converts the provider from "all known" to "only this".
+	if kbs, explicit := cfg.BoundKBs("claude"); !explicit || strings.Join(kbs, ",") != "alpha" {
+		t.Fatalf("after Bind: %v explicit=%v", kbs, explicit)
+	}
+	if err := cfg.Bind("claude", "alpha"); err != nil {
+		t.Fatalf("Bind (repeat): %v", err)
+	}
+	if kbs, _ := cfg.BoundKBs("claude"); len(kbs) != 1 {
+		t.Errorf("re-binding the same KB duplicated it: %v", kbs)
+	}
+
+	// Unbinding the last KB must leave the entry, not restore the default.
+	if err := cfg.Unbind("claude", "alpha"); err != nil {
+		t.Fatalf("Unbind: %v", err)
+	}
+	if kbs, explicit := cfg.BoundKBs("claude"); !explicit || len(kbs) != 0 {
+		t.Fatalf("after Unbind of the last KB: %v explicit=%v, want [] explicit=true", kbs, explicit)
+	}
+
+	// Reset is the only way back to the default.
+	cfg.ResetBinding("claude")
+	if kbs, explicit := cfg.BoundKBs("claude"); explicit || strings.Join(kbs, ",") != "alpha,beta" {
+		t.Fatalf("after ResetBinding: %v explicit=%v", kbs, explicit)
+	}
+}
+
+func TestUnbindUnknownPairIsNoOp(t *testing.T) {
+	cfg := clientconfig.Default()
+	if err := cfg.Unbind("claude", "missing"); err != nil {
+		t.Fatalf("Unbind of an unbound pair: %v", err)
+	}
+	if _, explicit := cfg.BoundKBs("claude"); explicit {
+		t.Error("Unbind created an entry for a provider that had none")
+	}
+}
+
+func TestBindRejectsEmptyNames(t *testing.T) {
+	cfg := clientconfig.Default()
+	if err := cfg.Bind("", "alpha"); err == nil {
+		t.Error("Bind with an empty provider should fail")
+	}
+	if err := cfg.Bind("claude", " "); err == nil {
+		t.Error("Bind with a blank KB name should fail")
+	}
+}
+
+// TestLoadMigratesLegacyKBsKey: a config written before D169 keeps its cached
+// KB list, now under the typed KnownKBs field.
+func TestLoadMigratesLegacyKBsKey(t *testing.T) {
+	dir := t.TempDir()
+	writeConfigFile(t, dir, "server_url: http://localhost:39273/mcp\nkbs:\n  - alpha\n  - beta\n")
+
+	cfg, err := clientconfig.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if strings.Join(cfg.KnownKBs, ",") != "alpha,beta" {
+		t.Errorf("KnownKBs = %v, want [alpha beta]", cfg.KnownKBs)
+	}
+}
+
+// TestLoadKnownKBsWinsOverLegacyAlias: `known_kbs: []` is a deliberately empty
+// cache and must beat a stale `kbs` left by a pre-D169 client. Testing the
+// empty case specifically is the point — a non-empty one would also pass with
+// a plain "prefer non-empty" implementation.
+func TestLoadKnownKBsWinsOverLegacyAlias(t *testing.T) {
+	dir := t.TempDir()
+	writeConfigFile(t, dir, "server_url: http://localhost:39273/mcp\nkbs:\n  - stale\nknown_kbs: []\n")
+
+	cfg, err := clientconfig.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.KnownKBs) != 0 {
+		t.Errorf("KnownKBs = %v, want empty (known_kbs: [] must win over kbs)", cfg.KnownKBs)
+	}
+}
+
+// TestSaveWritesKnownKBsNotLegacyAlias asserts on the BYTES on disk, not on a
+// reloaded struct: a field omitted from Save's marshalled struct round-trips
+// correctly through Extra while every programmatic change to it is silently
+// lost, so only the file proves persistence.
+func TestSaveWritesKnownKBsNotLegacyAlias(t *testing.T) {
+	dir := t.TempDir()
+	writeConfigFile(t, dir, "server_url: http://localhost:39273/mcp\nkbs:\n  - alpha\ncustom_key: keep-me\n")
+
+	cfg, err := clientconfig.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if err := cfg.Bind("claude", "alpha"); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	if err := clientconfig.Save(dir, cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	data, err := os.ReadFile(clientconfig.Path(dir))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	raw := string(data)
+	if !strings.Contains(raw, "known_kbs:") {
+		t.Errorf("known_kbs missing from the written file:\n%s", raw)
+	}
+	if strings.Contains(raw, "\nkbs:") {
+		t.Errorf("the legacy kbs key was written again:\n%s", raw)
+	}
+	if !strings.Contains(raw, "clients:") {
+		t.Errorf("clients missing from the written file:\n%s", raw)
+	}
+	if !strings.Contains(raw, "custom_key: keep-me") {
+		t.Errorf("unknown key lost across the write:\n%s", raw)
+	}
+
+	reloaded, err := clientconfig.Load(dir)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if kbs, explicit := reloaded.BoundKBs("claude"); !explicit || strings.Join(kbs, ",") != "alpha" {
+		t.Errorf("binding did not survive the round trip: %v explicit=%v", kbs, explicit)
+	}
+}
+
+func writeConfigFile(t *testing.T, dir, body string) {
+	t.Helper()
+	if err := os.WriteFile(clientconfig.Path(dir), []byte(body), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+// TestSyncStyleSaveKeepsBindings simulates what runSync does after reconciling
+// with /health — overwrite the server-owned cache, then Save — and asserts the
+// user-owned bindings survive it. This is the regression the whole split of
+// known_kbs from clients exists to prevent.
+func TestSyncStyleSaveKeepsBindings(t *testing.T) {
+	dir := t.TempDir()
+	cfg := clientconfig.Default()
+	cfg.Agents = []string{"claude"}
+	cfg.KnownKBs = []string{"alpha"}
+	if err := cfg.Bind("claude", "alpha"); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	if err := clientconfig.Save(dir, cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	reloaded, err := clientconfig.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	reloaded.KnownKBs = []string{"alpha", "beta", "gamma"} // what runSync assigns
+	if err := clientconfig.Save(dir, reloaded); err != nil {
+		t.Fatalf("Save after sync: %v", err)
+	}
+
+	final, err := clientconfig.Load(dir)
+	if err != nil {
+		t.Fatalf("Load after sync: %v", err)
+	}
+	if strings.Join(final.KnownKBs, ",") != "alpha,beta,gamma" {
+		t.Errorf("KnownKBs = %v, want the refreshed cache", final.KnownKBs)
+	}
+	if kbs, explicit := final.BoundKBs("claude"); !explicit || strings.Join(kbs, ",") != "alpha" {
+		t.Errorf("binding = %v explicit=%v, want [alpha] explicit=true — the sync overwrote it", kbs, explicit)
 	}
 }


### PR DESCRIPTION
`.cartographer.yaml` carried a single `kbs` key that looked like a user
preference but behaved like a cache: `runSync` (`sync.go:110`) and `doConnect`
(`connect.go:617`) overwrote it with the full list `/health` advertised, so
anything written there survived until the next sync. There was no way to declare
which KBs a given provider may receive — every connected provider received the
artifacts of every mounted KB.

## What changes

Two keys instead of one:

- `known_kbs` — the server-owned cache, still overwritten on every run;
- `clients.<provider>.kbs` — the user-owned binding, written only by the new
  `cartographer client` subcommand and never by `connect`/`sync`.

`Config.BoundKBs(provider)` is the single resolver and reports whether the
answer was explicit. Three distinct states, and a nil slice is never a wildcard:

| State | Meaning |
|---|---|
| no entry | every known KB — today's behaviour, so an upgrade strips nothing from a connected client |
| entry with an empty list | no KBs |
| entry with names | those |

`unbind` of the last KB therefore keeps the entry; `client reset` is the
explicit way back to the default.

New subcommand: `cartographer client list|show|bind|unbind|reset`. Every one of
them works offline — a KB absent from `known_kbs` is a warning, not a failure,
because it may be mounted later. They save and stop rather than triggering a
sync.

## What does not change

No projection behaviour. Bindings are recorded and not yet enforced, which the
mutating commands state in their own output so the feature is not mistaken for
active isolation. Enforcement is #207.

The legacy on-disk `kbs` key is still read and migrated to `known_kbs` on the
first write, so a pre-D169 config loads unchanged.

## Deviation from the plan

The plan kept `Config.KBs` as a read-only Go alias of `KnownKBs`. It was removed
instead: two Go fields that can diverge are the bug class being fixed, the field
is internal, and every caller was migrated in the same change. The on-disk alias
— the one that matters for existing files — is unaffected. Recorded in the D169
entry.

## Verification

`make fmt && make vet && make test` green. 17 new tests, including the one that
asserts on the **bytes** written by `Save` (a field omitted from the marshalled
struct round-trips through `Extra` while every programmatic change to it is
silently lost, so only the file proves persistence) and one that simulates what
`runSync` does — overwrite `known_kbs`, then `Save` — and asserts the bindings
survive it.

Closes #206
