### PR TITLE
feat(sync): refuse a cross-KB artifact collision instead of resolving it silently (D171)

### DIFF
--- a/cmd/cartographer/client.go
+++ b/cmd/cartographer/client.go
@@ -169,9 +169,32 @@ func clientBind(dir string, cfg *clientconfig.Config, args []string) int {
 
 	bound, _ := cfg.BoundKBs(provider)
 	fmt.Printf("%s bound to %s\n", provider, formatKBList(bound))
+	warnProviderCollisions(cfg, provider, bound)
 	fmt.Println("run `cartographer sync` to apply")
 	fmt.Println(bindingNotYetEnforcedNote)
 	return 0
+}
+
+// warnProviderCollisions reports, best-effort, a cross-KB collision the new
+// binding just created (D171). Discovering it here is worth a round trip: the
+// alternative is finding out at the next sync, which refuses to run.
+//
+// An unreachable server is not a failure. Configuring a machine must not
+// require the network, so the command says the check was skipped and why, and
+// the sync-time refusal remains the backstop.
+func warnProviderCollisions(cfg *clientconfig.Config, provider string, bound []string) {
+	if len(bound) < 2 {
+		return // one KB cannot collide with itself
+	}
+	candidates, err := fetchCandidates(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "note: could not check for cross-KB collisions (%v); `cartographer sync` will check again\n", err)
+		return
+	}
+	for _, c := range collisionsForProvider(candidates, bound) {
+		fmt.Fprintf(os.Stderr, "warning: %s/%s is claimed by %s — `cartographer sync` will refuse until one of them renames it\n",
+			c.Kind, c.Name, strings.Join(c.Sources, ", "))
+	}
 }
 
 func clientUnbind(dir string, cfg *clientconfig.Config, args []string) int {

--- a/cmd/cartographer/clientsync.go
+++ b/cmd/cartographer/clientsync.go
@@ -57,23 +57,49 @@ func resolveToken(cfg *clientconfig.Config) string {
 	return os.Getenv(cfg.TokenEnv)
 }
 
-// fetchMergedManifest connects to cfg.ServerURL, discovers the live per-KB
+// fetchMergedManifest fetches every KB's artifacts and merges them into one
+// verified provisioning.Manifest, applying the same precedence rule (KB source
+// wins over bundle) BuildManifest applies server-side for one KB.
+//
+// The merge is strict (D171): two KBs claiming the same kind+name is an error,
+// not the alphabetical coin flip preferArtifact would otherwise perform. It is
+// deliberately evaluated here, before anything is materialized, so a collision
+// stops the sync instead of silently deciding which KB an agent reads.
+func fetchMergedManifest(cfg *clientconfig.Config) (provisioning.Manifest, error) {
+	all, err := fetchCandidates(cfg)
+	if err != nil {
+		return provisioning.Manifest{}, err
+	}
+	merged, err := provisioning.MergeArtifactsStrict(all)
+	if err != nil {
+		return provisioning.Manifest{}, err
+	}
+	pins, err := pinnedPublicKeys(cfg)
+	if err != nil {
+		return provisioning.Manifest{}, err
+	}
+	return provisioning.VerifiedManifest(merged, pins)
+}
+
+// fetchCandidates connects to cfg.ServerURL, discovers the live per-KB
 // tool-name prefixes from /health (D120: resolveKBTargets), and calls
 // sync_pull — qualified with each target's advertised prefix — once per KB
-// target (cfg.KBs, or the server's default single-KB endpoint when empty),
-// decoding each artifact's in-memory file contents (base64) and merging
-// everything into a single provisioning.Manifest via
-// provisioning.MergeArtifacts — the same precedence rule (KB source wins over
-// bundle) BuildManifest applies server-side for one KB.
-func fetchMergedManifest(cfg *clientconfig.Config) (provisioning.Manifest, error) {
+// target (cfg.KnownKBs, or the server's default single-KB endpoint when empty),
+// decoding each artifact's in-memory file contents (base64).
+//
+// It returns the artifacts UNMERGED, each still carrying the source it came
+// from, so a caller can decide what to do with a kind+name several KBs claim
+// (fetchMergedManifest refuses it; collisionsForProvider reports only the ones
+// a given provider would actually be exposed to).
+func fetchCandidates(cfg *clientconfig.Config) ([]provisioning.Artifact, error) {
 	token := resolveToken(cfg)
 	health, err := client.New(cfg.ServerURL, token).Health(probeTimeout)
 	if err != nil {
-		return provisioning.Manifest{}, fmt.Errorf("health: %w", err)
+		return nil, fmt.Errorf("health: %w", err)
 	}
 	targets, err := resolveKBTargets(health, cfg.KnownKBs)
 	if err != nil {
-		return provisioning.Manifest{}, err
+		return nil, err
 	}
 
 	var all []provisioning.Artifact
@@ -84,26 +110,26 @@ func fetchMergedManifest(cfg *clientconfig.Config) (provisioning.Manifest, error
 		raw, err := callTool(c, target, "sync_pull", map[string]any{})
 		if err != nil {
 			if target.Name == "" {
-				return provisioning.Manifest{}, fmt.Errorf("sync_pull: %w", err)
+				return nil, fmt.Errorf("sync_pull: %w", err)
 			}
-			return provisioning.Manifest{}, fmt.Errorf("sync_pull (kb=%s): %w", target.Name, err)
+			return nil, fmt.Errorf("sync_pull (kb=%s): %w", target.Name, err)
 		}
 
 		var pm pulledManifestJSON
 		if err := json.Unmarshal(raw, &pm); err != nil {
-			return provisioning.Manifest{}, fmt.Errorf("sync_pull: decode response: %w", err)
+			return nil, fmt.Errorf("sync_pull: decode response: %w", err)
 		}
 		for _, pa := range pm.Artifacts {
 			files := make([]provisioning.ArtifactFile, len(pa.Files))
 			for i, pf := range pa.Files {
 				data, err := base64.StdEncoding.DecodeString(pf.ContentB64)
 				if err != nil {
-					return provisioning.Manifest{}, fmt.Errorf("sync_pull: decode file %s/%s/%s: %w", pa.Kind, pa.Name, pf.Path, err)
+					return nil, fmt.Errorf("sync_pull: decode file %s/%s/%s: %w", pa.Kind, pa.Name, pf.Path, err)
 				}
 				files[i] = provisioning.ArtifactFile{Path: pf.Path, Content: data, Executable: pf.Executable}
 			}
 			if got := provisioning.ContentHashFiles(files); got != pa.ContentHash {
-				return provisioning.Manifest{}, fmt.Errorf("sync_pull: content hash mismatch for %s/%s", pa.Kind, pa.Name)
+				return nil, fmt.Errorf("sync_pull: content hash mismatch for %s/%s", pa.Kind, pa.Name)
 			}
 			a := provisioning.Artifact{
 				Kind: pa.Kind, Name: pa.Name, Source: pa.Source, Version: pa.Version,
@@ -111,18 +137,39 @@ func fetchMergedManifest(cfg *clientconfig.Config) (provisioning.Manifest, error
 			}
 			key := a.Kind + "\x00" + a.Name + "\x00" + a.Source
 			if previous, exists := seen[key]; exists && !sameSignature(previous.Signature, a.Signature) {
-				return provisioning.Manifest{}, fmt.Errorf("sync_pull: conflicting signatures for %s/%s", a.Kind, a.Name)
+				return nil, fmt.Errorf("sync_pull: conflicting signatures for %s/%s", a.Kind, a.Name)
 			}
 			seen[key] = a
 			all = append(all, a)
 		}
 	}
 
-	pins, err := pinnedPublicKeys(cfg)
-	if err != nil {
-		return provisioning.Manifest{}, err
+	return all, nil
+}
+
+// collisionsForProvider narrows DetectCollisions to the ones a single provider
+// would actually be exposed to: a kind+name is only a problem for it when two
+// or more of the KBs bound to *it* claim the name. Two colliding KBs bound to
+// two different providers are not a conflict, and reporting them as one would
+// train an operator to ignore the warning.
+func collisionsForProvider(candidates []provisioning.Artifact, boundKBs []string) []provisioning.Collision {
+	bound := make(map[string]bool, len(boundKBs))
+	for _, kb := range boundKBs {
+		bound["kb:"+kb] = true
 	}
-	return provisioning.VerifiedManifest(provisioning.MergeArtifacts(all), pins)
+	var out []provisioning.Collision
+	for _, c := range provisioning.DetectCollisions(candidates) {
+		var claiming []string
+		for _, source := range c.Sources {
+			if bound[source] {
+				claiming = append(claiming, source)
+			}
+		}
+		if len(claiming) >= 2 {
+			out = append(out, provisioning.Collision{Kind: c.Kind, Name: c.Name, Sources: claiming})
+		}
+	}
+	return out
 }
 
 func sameSignature(a, b *artifactsig.Signature) bool {

--- a/cmd/cartographer/clientsync_test.go
+++ b/cmd/cartographer/clientsync_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -586,5 +587,143 @@ func TestPrintApplySummary_DryRunSpeaksInTheConditional(t *testing.T) {
 	}
 	if strings.Contains(real, "would ") {
 		t.Errorf("real run output = %q, must not be conditional", real)
+	}
+}
+
+// --- D171: cross-KB collisions ---
+
+// syncPullPayload renders the sync_pull response for one KB exposing a single
+// skill of the given name, with the content hash the client recomputes and
+// verifies (fetchCandidates).
+func syncPullPayload(t *testing.T, kb, skillName string) string {
+	t.Helper()
+	files := []provisioning.ArtifactFile{{Path: "SKILL.md", Content: []byte("# " + skillName + " from " + kb)}}
+	body, err := json.Marshal(map[string]any{
+		"revision": "rev-" + kb,
+		"artifacts": []map[string]any{{
+			"kind": "skill", "name": skillName, "source": "kb:" + kb,
+			"content_hash": provisioning.ContentHashFiles(files),
+			"files": []map[string]any{{
+				"path":        "SKILL.md",
+				"content_b64": base64.StdEncoding.EncodeToString(files[0].Content),
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return string(body)
+}
+
+// TestFetchMergedManifestRefusesCrossKBCollision: two KBs claiming one skill
+// must stop the sync, not be resolved by alphabetical source.
+func TestFetchMergedManifestRefusesCrossKBCollision(t *testing.T) {
+	srv := prefixAwareMCPServer(t, map[string]string{"one": "", "two": ""}, "sync_pull", func(kb string) string {
+		return syncPullPayload(t, kb, "shared")
+	})
+	defer srv.Close()
+
+	cfg := &clientconfig.Config{ServerURL: srv.URL + "/mcp", KnownKBs: []string{"one", "two"}}
+	_, err := fetchMergedManifest(cfg)
+	if err == nil {
+		t.Fatal("fetchMergedManifest accepted a cross-KB collision")
+	}
+	var ce *provisioning.CollisionError
+	if !errors.As(err, &ce) {
+		t.Fatalf("error = %T (%v), want *provisioning.CollisionError", err, err)
+	}
+	for _, want := range []string{"skill/shared", "kb:one", "kb:two"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("report missing %q:\n%s", want, err)
+		}
+	}
+}
+
+// TestFetchMergedManifestAcceptsDistinctNames guards the negative: the strict
+// merge must not reject an ordinary two-KB deployment.
+func TestFetchMergedManifestAcceptsDistinctNames(t *testing.T) {
+	srv := prefixAwareMCPServer(t, map[string]string{"one": "", "two": ""}, "sync_pull", func(kb string) string {
+		return syncPullPayload(t, kb, "skill-"+kb)
+	})
+	defer srv.Close()
+
+	cfg := &clientconfig.Config{ServerURL: srv.URL + "/mcp", KnownKBs: []string{"one", "two"}}
+	m, err := fetchMergedManifest(cfg)
+	if err != nil {
+		t.Fatalf("fetchMergedManifest: %v", err)
+	}
+	if len(m.Artifacts) != 2 {
+		t.Errorf("artifacts = %d, want 2", len(m.Artifacts))
+	}
+}
+
+// TestSyncFailsBeforeMaterializing: after a refused merge, nothing on disk
+// changed. The lockfile is the load-bearing assertion — a partially applied
+// provider is exactly what the refusal exists to prevent.
+func TestSyncFailsBeforeMaterializing(t *testing.T) {
+	srv := prefixAwareMCPServer(t, map[string]string{"one": "", "two": ""}, "sync_pull", func(kb string) string {
+		return syncPullPayload(t, kb, "shared")
+	})
+	defer srv.Close()
+
+	dir := t.TempDir()
+	cfg := &clientconfig.Config{
+		ServerURL: srv.URL + "/mcp", ServerName: "cartographer",
+		Agents: []string{"claude"}, KnownKBs: []string{"one", "two"}, Trust: true,
+	}
+	if err := clientconfig.Save(dir, cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if _, err := runSync(dir, cfg, syncOptions{}); err == nil {
+		t.Fatal("runSync succeeded despite a cross-KB collision")
+	}
+
+	// What D171 guarantees: no artifact is materialized and no lockfile is
+	// written, so no provider ends up holding one KB's copy of a name two KBs
+	// claim.
+	if _, err := os.Stat(lockFilePath(dir)); !os.IsNotExist(err) {
+		t.Errorf("a lockfile was written despite the refused merge (err=%v)", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".claude", "skills", "shared")); !os.IsNotExist(err) {
+		t.Error("the colliding skill was materialized despite the refused merge")
+	}
+
+	// Known limitation, pinned deliberately: runSync writes the providers' MCP
+	// entries BEFORE fetching the manifest (sync.go, removeMCPEntries/
+	// applyMCPEntries ahead of fetchMergedManifest), so a refused merge still
+	// leaves them rewritten. Reordering that is D172's subject, not this one.
+	// When D172 lands this assertion flips, and it should — it is here so the
+	// change is deliberate rather than silent.
+	if _, err := os.Stat(filepath.Join(dir, ".claude.json")); os.IsNotExist(err) {
+		t.Error("MCP entries were not written: D172 reordered runSync — update this assertion and the D171 note")
+	}
+}
+
+func TestCollisionsForProvider(t *testing.T) {
+	candidates := []provisioning.Artifact{
+		{Kind: "skill", Name: "shared", Source: "kb:one"},
+		{Kind: "skill", Name: "shared", Source: "kb:two"},
+		{Kind: "skill", Name: "solo", Source: "kb:three"},
+	}
+
+	cases := []struct {
+		name  string
+		bound []string
+		want  int
+	}{
+		{"both colliding KBs bound", []string{"one", "two"}, 1},
+		{"only one of them bound", []string{"one", "three"}, 0},
+		{"neither bound", []string{"three"}, 0},
+		{"no KB bound", nil, 0},
+		{"a superset still reports it once", []string{"one", "two", "three"}, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := collisionsForProvider(candidates, tc.bound)
+			if len(got) != tc.want {
+				t.Errorf("collisionsForProvider(%v) = %+v, want %d", tc.bound, got, tc.want)
+			}
+		})
 	}
 }

--- a/cmd/cartographer/doctor.go
+++ b/cmd/cartographer/doctor.go
@@ -183,6 +183,7 @@ func runDoctor(dir, only string) doctorReport {
 		findings = append(findings, checkTriggerCoverage(dir, providers)...)
 		findings = append(findings, checkSymlinkedDestinations(dir, providers)...)
 		findings = append(findings, checkCapabilities(dir, cfg)...)
+		findings = append(findings, checkKBCollisions(dir, cfg, providers)...)
 	}
 
 	sortDoctorFindings(findings)
@@ -578,6 +579,35 @@ func checkServer(dir string, cfg *clientconfig.Config, providers []string) []doc
 			Message: fmt.Sprintf("version skew: client %s ≠ server %s", version, facts.Version),
 			Fix:     fix,
 		})
+	}
+	return out
+}
+
+// checkKBCollisions: two KBs bound to the same provider claiming one kind+name
+// (D171). `sync` refuses outright when this happens, so finding it here is the
+// difference between a diagnosis and a mystery — the sync error names the
+// collision but a machine that has not synced since the binding changed shows
+// no symptom at all.
+//
+// Silent when the server is unreachable: a missing signal is not evidence that
+// nothing collides. Reported per provider, because two colliding KBs bound to
+// different providers are not a conflict.
+func checkKBCollisions(dir string, cfg *clientconfig.Config, providers []string) []doctorFinding {
+	candidates, err := fetchCandidates(cfg)
+	if err != nil {
+		return nil
+	}
+	configPath := filepath.Join(dir, clientconfig.FileName)
+	var out []doctorFinding
+	for _, p := range providers {
+		bound, _ := cfg.BoundKBs(p)
+		for _, c := range collisionsForProvider(candidates, bound) {
+			out = append(out, doctorFinding{
+				Check: "kb-collisions", Severity: doctorError, Path: configPath,
+				Message: fmt.Sprintf("%s: %s/%s is claimed by %s — sync refuses to run", p, c.Kind, c.Name, strings.Join(c.Sources, ", ")),
+				Fix:     fmt.Sprintf("rename the artifact in all but one of those KBs, or cartographer client unbind %s <kb>", p),
+			})
+		}
 	}
 	return out
 }

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -299,7 +299,7 @@ refresh. Every finding names a real path on this machine and the command that fi
 `reconnect`, `connect`, `service sync-timer install`), because a diagnosis nobody can act on is
 noise and a doctor that silently fixes things is a doctor nobody can predict.
 
-The eight checks:
+The checks:
 
 | Check | What it looks at |
 |---|---|
@@ -313,6 +313,7 @@ The eight checks:
 | `trigger` | every connected provider has a session hook, or the scheduled trigger is installed (D140) |
 | `capability` | every per-KB gate the server advertises on `/health` is on, and no KB was mounted by discovery rather than by a `kbs[]` entry (D151). Info severity: it names the setting that would change it |
 | `symlink` | no managed destination directory is a symlink — provisioning refuses to write through one, so the artifacts it would hold are not installed (D148) |
+| `kb-collisions` | no two KBs bound to the same provider claim one `kind`+`name` (D171). `sync` refuses outright when they do, so a machine that has not synced since the binding changed would otherwise show no symptom. Silent when the server is unreachable |
 
 **Severities.** `error` — something is broken now (a managed file missing, a hook firing twice);
 `warning` — something is stale or suboptimal (v1 lockfile, no trigger for a hook-less provider, a

--- a/docs/decisions/sync-provisioning.md
+++ b/docs/decisions/sync-provisioning.md
@@ -781,3 +781,57 @@ one line each. Nothing was rewritten N−1 times, so the fix belongs in the prin
 **Consequences.** The steering block changes content on clients that cannot receive agents — the
 false sentence disappears — so those clients rewrite the block once on the next sync, which is the
 normal drift path. New KB-side directive; no config migration.
+
+---
+
+<a id="d171"></a>
+## D171 — A cross-KB collision is an error, not an alphabetical tie-break
+
+**Decision.** `provisioning.DetectCollisions` reports every `kind`+`name` claimed
+by two or more distinct `kb:` sources, and `MergeArtifactsStrict` turns that into
+a `*CollisionError` naming the kind, the name and the claiming KBs. The client
+merges through the strict variant (`fetchMergedManifest`), so a collision stops
+the sync before anything is materialized. `MergeArtifacts` keeps its tolerant
+behaviour for `BuildManifest`. `cartographer client bind` warns when a new
+binding creates a collision, and `doctor` gains a `kb-collisions` check.
+
+**Rationale.**
+
+- **The silent resolution was unstable, not just undocumented.**
+  `MergeArtifacts` deduplicates on `kind+name` *without* the source, and
+  `preferArtifact` picked the alphabetically first `kb:` source. Nothing recorded
+  that a second copy existed. Worse, unmounting the winning KB makes the losing
+  one appear: the content an agent reads changes with no artifact, no hash and no
+  revision having changed in the KB anyone was looking at.
+- **Error, not warning.** A warning about an artifact the agent then actually
+  loads is worse than a failed sync, because at that point the wrong answer is
+  silent. The failure names both KBs and the remedy, which is a rename.
+- **KB-over-bundle stays.** It is deliberate — a KB may override a bundled skill
+  — and unambiguous, because the bundle is single. Only KB↔KB became an error.
+- **Two functions, not a flag.** `BuildManifest` merges one KB plus the bundle,
+  where the case cannot arise; giving it a strictness parameter would add a
+  branch nobody can reach. `MergeArtifactsStrict` is the client's entry point and
+  the tolerant one keeps its callers.
+- **`fetchMergedManifest` split into `fetchCandidates` + merge.** The per-KB
+  responses have to survive the pull for the collision to be attributable at all,
+  and the same unmerged candidates are what `client bind` and `doctor` filter per
+  provider. This is also the seam the filtered projection needs.
+- **Per provider, not globally.** Two colliding KBs bound to two different
+  providers are not a conflict. `collisionsForProvider` narrows a collision to
+  the KBs bound to one provider, so the warning does not train an operator to
+  ignore it.
+- **`client bind` stays offline.** The collision check needs the server, so it is
+  best-effort: unreachable means "check skipped", not a failed command.
+  Configuring a machine must not require the network, and the sync-time refusal
+  is the backstop.
+
+**Known limitation, deliberately not fixed here.** `runSync` writes the
+providers' MCP entries *before* fetching the manifest, so a refused merge still
+leaves those rewritten. Only artifacts and the lockfile are protected. Reordering
+the sync is a separate change; a test pins the current behaviour so that when the
+reorder lands it fails loudly instead of changing silently.
+
+**Consequences.** A deployment with two colliding KBs — working today, silently
+and arbitrarily — starts failing its sync with a report and a remedy. That is the
+intent. Everything else is unchanged: single-KB clients and clients whose KBs
+have distinct artifact names never reach the new code path.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -86,7 +86,7 @@ On the stdio transport, the server emits `notifications/skills/list_changed` aft
 
 When client and server don't share a filesystem (`internal/client`, `internal/clientconfig`, `cmd/cartographer/clientsync.go`):
 
-1. the client calls `sync_pull` (once per KB configured in `.cartographer.yaml`) and merges the manifests with `provisioning.MergeArtifacts`;
+1. the client calls `sync_pull` (once per KB in `known_kbs`) and merges the manifests with `provisioning.MergeArtifactsStrict`, which refuses a `kind`+`name` claimed by two KBs (§Dedup and collisions);
 2. it reconstructs each artifact hash from received paths, bytes and executable modes, then verifies any detached signature against the local KB pin;
 3. `Apply` materializes/prunes and writes the v2 lockfile;
 4. pruning remains managed-only.
@@ -369,7 +369,8 @@ silently dropped, so no provider ever runs a command different from the approved
 
 ## Implementation choices
 
-- **Dedup by `kind`+`name`**: a skill present both in the bundle and in a KB is materialized only once; precedence KB > bundle, and among multiple KBs by alphabetical `source`. The manifest holds exactly one artifact per `kind`+`name`.
+- **Dedup by `kind`+`name`**: a skill present both in the bundle and in a KB is materialized only once, with the KB winning. The manifest holds exactly one artifact per `kind`+`name`.
+- **Cross-KB collisions are refused, not resolved** (D171). Two KBs claiming the same `kind`+`name` is an error: `MergeArtifactsStrict` — what the client uses — fails with a report naming the kind, the name and the claiming KBs, before anything is materialized. `MergeArtifacts` stays tolerant and keeps the alphabetical `source` tie-break; the server builds a manifest from one KB plus the bundle, where the case cannot arise. `cartographer client bind` warns when a new binding creates one, and `doctor`'s `kb-collisions` check reports it per provider.
 - Lockfile: `<base-dir>/.cartographer-sync.lock.json` (v2 multi-provider).
 - Pruning is per tracked file, not per whole directory.
 

--- a/internal/provisioning/provisioning.go
+++ b/internal/provisioning/provisioning.go
@@ -847,9 +847,98 @@ func MergeArtifacts(artifacts []Artifact) Manifest {
 	}
 }
 
+// Collision is one kind+name claimed by two or more KBs (D171). Sources are the
+// full source strings ("kb:<name>"), sorted, so a report is deterministic.
+type Collision struct {
+	Kind    string
+	Name    string
+	Sources []string
+}
+
+// DetectCollisions reports every kind+name claimed by two or more distinct KBs.
+//
+// The bundle never participates: a kind+name held by one KB and by the bundle is
+// the deliberate override MergeArtifacts resolves in the KB's favour, and the
+// bundle is single, so that choice is unambiguous. Two KBs are a different
+// matter — preferArtifact picks the alphabetically first source, silently, and
+// nothing downstream records that the other copy ever existed. Worse, the choice
+// is unstable: unmounting the winning KB makes the losing one appear, changing
+// what an agent reads with nothing announcing it.
+//
+// The same source appearing twice is not a collision. That is the ordinary
+// shape of the client's merge, where every per-KB sync_pull response carries the
+// same bundled artifacts.
+func DetectCollisions(artifacts []Artifact) []Collision {
+	sourcesByKey := make(map[string]map[string]bool)
+	for _, a := range artifacts {
+		if !strings.HasPrefix(a.Source, "kb:") {
+			continue
+		}
+		k := a.Kind + "\x00" + a.Name
+		if sourcesByKey[k] == nil {
+			sourcesByKey[k] = make(map[string]bool)
+		}
+		sourcesByKey[k][a.Source] = true
+	}
+
+	var out []Collision
+	for key, sources := range sourcesByKey {
+		if len(sources) < 2 {
+			continue
+		}
+		kind, name, _ := strings.Cut(key, "\x00")
+		names := make([]string, 0, len(sources))
+		for source := range sources {
+			names = append(names, source)
+		}
+		sort.Strings(names)
+		out = append(out, Collision{Kind: kind, Name: name, Sources: names})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Kind != out[j].Kind {
+			return out[i].Kind < out[j].Kind
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+// CollisionError reports the collisions that stopped a merge. It renders as a
+// multi-line report rather than one line: a caller printing "Error: <err>" must
+// still produce something an operator can act on without a second command.
+type CollisionError struct {
+	Collisions []Collision
+}
+
+func (e *CollisionError) Error() string {
+	var sb strings.Builder
+	sb.WriteString("the same artifact is claimed by more than one KB:\n")
+	for _, c := range e.Collisions {
+		fmt.Fprintf(&sb, "  %s/%s: claimed by %s\n", c.Kind, c.Name, strings.Join(c.Sources, ", "))
+	}
+	sb.WriteString("rename the artifact in all but one of those KBs, or stop binding them to the same client")
+	return sb.String()
+}
+
+// MergeArtifactsStrict is MergeArtifacts with the KB↔KB collision turned into
+// an error instead of an alphabetical coin flip. It is what the client uses:
+// a warning about an artifact the agent then actually loads is worse than a
+// failed sync, because at that point the wrong answer is silent.
+//
+// BuildManifest keeps using MergeArtifacts: server-side a manifest is built for
+// one KB plus the bundle, where a KB↔KB collision cannot arise by construction.
+func MergeArtifactsStrict(artifacts []Artifact) (Manifest, error) {
+	if collisions := DetectCollisions(artifacts); len(collisions) > 0 {
+		return Manifest{}, &CollisionError{Collisions: collisions}
+	}
+	return MergeArtifacts(artifacts), nil
+}
+
 // preferArtifact chooses, between two artifacts with the same kind+name, the one
 // that wins in materialization. The KB ("kb:*") beats the bundle; for the same
-// source type, the choice is deterministic by alphabetical source.
+// source type, the choice is deterministic by alphabetical source. Between two
+// KBs this is a silent, unstable choice, which is why the client merges through
+// MergeArtifactsStrict and never reaches this branch (D171).
 func preferArtifact(a, b Artifact) Artifact {
 	aKB := strings.HasPrefix(a.Source, "kb:")
 	bKB := strings.HasPrefix(b.Source, "kb:")

--- a/internal/provisioning/provisioning_test.go
+++ b/internal/provisioning/provisioning_test.go
@@ -2,6 +2,7 @@ package provisioning_test
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1123,5 +1124,142 @@ func TestApply_RefusesSymlinkedSkillDirAndKeepsGoing(t *testing.T) {
 		if e.Name == "linked" {
 			t.Errorf("a refused artifact must not enter the lockfile: %+v", e)
 		}
+	}
+}
+
+// --- D171: cross-KB collisions ---
+
+func TestDetectCollisions(t *testing.T) {
+	cases := []struct {
+		name      string
+		artifacts []provisioning.Artifact
+		want      []provisioning.Collision
+	}{
+		{
+			name: "no collision",
+			artifacts: []provisioning.Artifact{
+				{Kind: "skill", Name: "alpha", Source: "kb:one"},
+				{Kind: "skill", Name: "beta", Source: "kb:two"},
+			},
+		},
+		{
+			name: "kb versus bundle is a deliberate override, not a collision",
+			artifacts: []provisioning.Artifact{
+				{Kind: "skill", Name: "alpha", Source: "bundle"},
+				{Kind: "skill", Name: "alpha", Source: "kb:one"},
+			},
+		},
+		{
+			name: "the same bundled artifact repeated across per-KB pulls",
+			artifacts: []provisioning.Artifact{
+				{Kind: "skill", Name: "alpha", Source: "bundle"},
+				{Kind: "skill", Name: "alpha", Source: "bundle"},
+			},
+		},
+		{
+			name: "the same artifact twice from one KB",
+			artifacts: []provisioning.Artifact{
+				{Kind: "skill", Name: "alpha", Source: "kb:one"},
+				{Kind: "skill", Name: "alpha", Source: "kb:one"},
+			},
+		},
+		{
+			name: "two KBs claim one skill",
+			artifacts: []provisioning.Artifact{
+				{Kind: "skill", Name: "alpha", Source: "kb:two"},
+				{Kind: "skill", Name: "alpha", Source: "kb:one"},
+			},
+			want: []provisioning.Collision{{Kind: "skill", Name: "alpha", Sources: []string{"kb:one", "kb:two"}}},
+		},
+		{
+			name: "collisions on several kinds are all reported, in order",
+			artifacts: []provisioning.Artifact{
+				{Kind: "hook", Name: "h", Source: "kb:one"},
+				{Kind: "hook", Name: "h", Source: "kb:two"},
+				{Kind: "agent", Name: "a", Source: "kb:one"},
+				{Kind: "agent", Name: "a", Source: "kb:two"},
+			},
+			want: []provisioning.Collision{
+				{Kind: "agent", Name: "a", Sources: []string{"kb:one", "kb:two"}},
+				{Kind: "hook", Name: "h", Sources: []string{"kb:one", "kb:two"}},
+			},
+		},
+		{
+			name: "three KBs claim one name",
+			artifacts: []provisioning.Artifact{
+				{Kind: "skill", Name: "alpha", Source: "kb:c"},
+				{Kind: "skill", Name: "alpha", Source: "kb:a"},
+				{Kind: "skill", Name: "alpha", Source: "kb:b"},
+				{Kind: "skill", Name: "alpha", Source: "bundle"},
+			},
+			want: []provisioning.Collision{{Kind: "skill", Name: "alpha", Sources: []string{"kb:a", "kb:b", "kb:c"}}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := provisioning.DetectCollisions(tc.artifacts)
+			if len(got) != len(tc.want) {
+				t.Fatalf("DetectCollisions = %+v, want %+v", got, tc.want)
+			}
+			for i := range got {
+				if got[i].Kind != tc.want[i].Kind || got[i].Name != tc.want[i].Name ||
+					strings.Join(got[i].Sources, ",") != strings.Join(tc.want[i].Sources, ",") {
+					t.Errorf("collision %d = %+v, want %+v", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestMergeArtifactsStrict(t *testing.T) {
+	clean := []provisioning.Artifact{
+		{Kind: "skill", Name: "alpha", Source: "bundle", ContentHash: "h1"},
+		{Kind: "skill", Name: "alpha", Source: "kb:one", ContentHash: "h2"},
+	}
+	m, err := provisioning.MergeArtifactsStrict(clean)
+	if err != nil {
+		t.Fatalf("MergeArtifactsStrict on a KB/bundle override: %v", err)
+	}
+	// The KB must still win: strictness targets KB↔KB only.
+	if len(m.Artifacts) != 1 || m.Artifacts[0].Source != "kb:one" {
+		t.Errorf("merged = %+v, want the single kb:one artifact", m.Artifacts)
+	}
+	if m.Revision != provisioning.MergeArtifacts(clean).Revision {
+		t.Error("strict merge produced a different revision than the tolerant one")
+	}
+
+	colliding := []provisioning.Artifact{
+		{Kind: "skill", Name: "alpha", Source: "kb:one", ContentHash: "h1"},
+		{Kind: "skill", Name: "alpha", Source: "kb:two", ContentHash: "h2"},
+	}
+	if _, err := provisioning.MergeArtifactsStrict(colliding); err == nil {
+		t.Fatal("MergeArtifactsStrict accepted a KB↔KB collision")
+	} else {
+		var ce *provisioning.CollisionError
+		if !errors.As(err, &ce) {
+			t.Fatalf("error = %T, want *CollisionError", err)
+		}
+		msg := ce.Error()
+		for _, want := range []string{"skill/alpha", "kb:one", "kb:two", "rename"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("collision report missing %q:\n%s", want, msg)
+			}
+		}
+	}
+}
+
+// TestMergeArtifactsStaysTolerant: BuildManifest merges one KB plus the bundle,
+// where a KB↔KB collision cannot arise, and must keep its existing behaviour.
+func TestMergeArtifactsStaysTolerant(t *testing.T) {
+	m := provisioning.MergeArtifacts([]provisioning.Artifact{
+		{Kind: "skill", Name: "alpha", Source: "kb:two", ContentHash: "h2"},
+		{Kind: "skill", Name: "alpha", Source: "kb:one", ContentHash: "h1"},
+	})
+	if len(m.Artifacts) != 1 {
+		t.Fatalf("MergeArtifacts = %+v, want one artifact", m.Artifacts)
+	}
+	if m.Artifacts[0].Source != "kb:one" {
+		t.Errorf("source = %q, want the alphabetically first kb:one", m.Artifacts[0].Source)
 	}
 }


### PR DESCRIPTION
`MergeArtifacts` deduplicates on `kind+name` **without** the source
(`provisioning.go:816`), and `preferArtifact` (`:853`) resolved a tie between two
KBs by picking the alphabetically first one — with no output, no warning and no
trace in the lockfile. The client materialized one KB's artifact and the other
simply disappeared.

The unstable half is worse than the silent half: unmounting the **winning** KB
makes the losing one appear, so what an agent reads changes with no artifact, no
hash and no revision having changed in the KB anyone was looking at.

## What changes

- `DetectCollisions` reports every `kind+name` claimed by two or more distinct
  `kb:` sources. The bundle never participates — a KB overriding a bundled skill
  is deliberate and unambiguous — and the same source twice is not a collision,
  which is the ordinary shape of the client's merge.
- `MergeArtifactsStrict` fails with a `*CollisionError` rendering a multi-line
  report: kind, name, claiming KBs, and the remedy. The client merges through it;
  `BuildManifest` keeps the tolerant `MergeArtifacts`, since server-side a
  manifest is built from one KB plus the bundle and the case cannot arise.
- `fetchMergedManifest` is split into `fetchCandidates` + merge, so the per-KB
  sources survive the pull and a collision stays attributable.
- `collisionsForProvider` narrows a collision to the KBs bound to **one**
  provider: two colliding KBs bound to different providers are not a conflict,
  and reporting them as one would train an operator to ignore the warning. It
  feeds a best-effort warning in `client bind` (unreachable server means "check
  skipped", never a failed command — configuring must not require the network)
  and a new `kb-collisions` check in `doctor`.

## Known limitation, pinned by a test

`runSync` writes the providers' MCP entries **before** fetching the manifest, so
a refused merge still leaves those rewritten. Only artifacts and the lockfile are
protected here. Reordering the sync is #209; a test asserts the current behaviour
so that when the reorder lands it fails loudly instead of changing silently.

## Verification

`make fmt && make vet && make test` green. New tests cover the seven-case
collision table (including the three shapes that must **not** be collisions),
the strict merge preserving KB-over-bundle and its revision, the tolerant merge
staying tolerant, a two-KB fake server whose sync is refused with nothing
materialized and no lockfile, a two-KB server with distinct names that still
succeeds, and `collisionsForProvider` across five binding shapes.

Closes #208
