### PR TITLE
feat(sync): project only a provider's bound KBs, selecting before the merge (D170)

### DIFF
--- a/cmd/cartographer/client.go
+++ b/cmd/cartographer/client.go
@@ -186,12 +186,12 @@ func warnProviderCollisions(cfg *clientconfig.Config, provider string, bound []s
 	if len(bound) < 2 {
 		return // one KB cannot collide with itself
 	}
-	candidates, err := fetchCandidates(cfg)
+	candidates, err := fetchCandidates(cfg, bound)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "note: could not check for cross-KB collisions (%v); `cartographer sync` will check again\n", err)
 		return
 	}
-	for _, c := range collisionsForProvider(candidates, bound) {
+	for _, c := range collisionsForProvider(candidates.forKBs(bound), bound) {
 		fmt.Fprintf(os.Stderr, "warning: %s/%s is claimed by %s — `cartographer sync` will refuse until one of them renames it\n",
 			c.Kind, c.Name, strings.Join(c.Sources, ", "))
 	}

--- a/cmd/cartographer/clientsync.go
+++ b/cmd/cartographer/clientsync.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/BeppeTemp/cartographer/internal/agents"
@@ -57,6 +58,155 @@ func resolveToken(cfg *clientconfig.Config) string {
 	return os.Getenv(cfg.TokenEnv)
 }
 
+// candidateSet holds the sync_pull responses UNMERGED, one entry per KB, which
+// is what makes a per-provider projection possible (D170): the selection has to
+// happen on these responses, before any client-side merge, because
+// MergeArtifacts discards candidates and the server has already merged
+// KB-over-bundle inside each single-KB pull.
+//
+// Bare holds the response of a nameless endpoint — a server that advertises no
+// KB metadata, or one asked before any KB name was known. No binding can name
+// it, so it is handled separately rather than filed under an invented key.
+type candidateSet struct {
+	Named   map[string][]provisioning.Artifact
+	Bare    []provisioning.Artifact
+	HasBare bool
+}
+
+// all returns every candidate, in a deterministic order.
+func (cs candidateSet) all() []provisioning.Artifact {
+	out := append([]provisioning.Artifact(nil), cs.Bare...)
+	names := make([]string, 0, len(cs.Named))
+	for name := range cs.Named {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		out = append(out, cs.Named[name]...)
+	}
+	return out
+}
+
+// forKBs concatenates the responses of the named KBs, in a deterministic order.
+// A name with no response contributes nothing — it is not an error here: the
+// caller validated the binding against /health before pulling.
+func (cs candidateSet) forKBs(names []string) []provisioning.Artifact {
+	sorted := append([]string(nil), names...)
+	sort.Strings(sorted)
+	var out []provisioning.Artifact
+	for _, name := range sorted {
+		out = append(out, cs.Named[name]...)
+	}
+	return out
+}
+
+// forProvider returns the candidates one provider may receive.
+//
+// The bare endpoint is the one case bindings cannot express: there is no KB
+// name to match, so every provider receives it, exactly as before D170 — a
+// missing signal is not a reason to starve a client on a legacy or first-run
+// server. The single exception is a provider explicitly bound to NO KBs, where
+// the operator's declaration is unambiguous and is honoured.
+func (cs candidateSet) forProvider(cfg *clientconfig.Config, provider string) []provisioning.Artifact {
+	bound, explicit := cfg.BoundKBs(provider)
+	if cs.HasBare {
+		if explicit && len(bound) == 0 {
+			return nil
+		}
+		return cs.Bare
+	}
+	return provisioning.SelectForSources(cs.forKBs(bound), bound)
+}
+
+// boundKBUnion is the set of KBs that must actually be pulled: the union of
+// every connected provider's binding. A known KB nobody is bound to is not
+// fetched at all.
+//
+// requiredBy maps each name to the providers that ask for it, so a stale
+// binding can be reported with the provider that holds it rather than as an
+// anonymous configuration error. anyDefault reports whether at least one
+// provider has no explicit binding, which is what distinguishes "nothing is
+// bound" from "nothing is known yet".
+func boundKBUnion(cfg *clientconfig.Config, providers []string) (names []string, requiredBy map[string][]string, anyDefault bool) {
+	requiredBy = make(map[string][]string)
+	for _, p := range providers {
+		bound, explicit := cfg.BoundKBs(p)
+		if !explicit {
+			anyDefault = true
+		}
+		for _, kb := range bound {
+			if _, seen := requiredBy[kb]; !seen {
+				names = append(names, kb)
+			}
+			requiredBy[kb] = append(requiredBy[kb], p)
+		}
+	}
+	sort.Strings(names)
+	return names, requiredBy, anyDefault
+}
+
+// manifestsForProviders returns, per provider, the manifest it may receive:
+// the candidates of its bound KBs, selected by source, merged strictly (so a
+// cross-KB collision inside THAT provider's set stops the sync, D171) and
+// signature-verified.
+//
+// Every KB is pulled once for all providers; the split happens afterwards.
+// Verification pins are applied per provider only because VerifiedManifest
+// takes a manifest — the work is over the same artifacts either way, and an
+// artifact's verification result cannot differ between providers.
+func manifestsForProviders(cfg *clientconfig.Config, providers []string) (map[string]provisioning.Manifest, error) {
+	out := make(map[string]provisioning.Manifest, len(providers))
+
+	union, requiredBy, anyDefault := boundKBUnion(cfg, providers)
+	if len(union) == 0 && !anyDefault {
+		// Every provider is explicitly bound to no KBs: there is nothing to
+		// pull, and asking the server would only invite an error about a
+		// selection nobody made.
+		for _, p := range providers {
+			out[p] = provisioning.MergeArtifacts(nil)
+		}
+		return out, nil
+	}
+
+	cs, err := fetchCandidates(cfg, union)
+	if err != nil {
+		return nil, annotateStaleBinding(err, requiredBy)
+	}
+	if cs.HasBare {
+		fmt.Fprintln(os.Stderr, "warning: the server does not identify its KBs by name, so per-client KB bindings cannot be applied; every connected client receives everything it serves")
+	}
+
+	pins, err := pinnedPublicKeys(cfg)
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range providers {
+		merged, err := provisioning.MergeArtifactsStrict(cs.forProvider(cfg, p))
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", p, err)
+		}
+		verified, err := provisioning.VerifiedManifest(merged, pins)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", p, err)
+		}
+		out[p] = verified
+	}
+	return out, nil
+}
+
+// annotateStaleBinding appends the providers that require a KB the server no
+// longer advertises. resolveKBTargets already names the KB; without this the
+// operator still has to guess which client's binding to fix.
+func annotateStaleBinding(err error, requiredBy map[string][]string) error {
+	for kb, providers := range requiredBy {
+		if strings.Contains(err.Error(), strconv.Quote(kb)) {
+			sort.Strings(providers)
+			return fmt.Errorf("%w (required by: %s)", err, strings.Join(providers, ", "))
+		}
+	}
+	return err
+}
+
 // fetchMergedManifest fetches every KB's artifacts and merges them into one
 // verified provisioning.Manifest, applying the same precedence rule (KB source
 // wins over bundle) BuildManifest applies server-side for one KB.
@@ -66,11 +216,11 @@ func resolveToken(cfg *clientconfig.Config) string {
 // deliberately evaluated here, before anything is materialized, so a collision
 // stops the sync instead of silently deciding which KB an agent reads.
 func fetchMergedManifest(cfg *clientconfig.Config) (provisioning.Manifest, error) {
-	all, err := fetchCandidates(cfg)
+	cs, err := fetchCandidates(cfg, cfg.KnownKBs)
 	if err != nil {
 		return provisioning.Manifest{}, err
 	}
-	merged, err := provisioning.MergeArtifactsStrict(all)
+	merged, err := provisioning.MergeArtifactsStrict(cs.all())
 	if err != nil {
 		return provisioning.Manifest{}, err
 	}
@@ -91,18 +241,18 @@ func fetchMergedManifest(cfg *clientconfig.Config) (provisioning.Manifest, error
 // from, so a caller can decide what to do with a kind+name several KBs claim
 // (fetchMergedManifest refuses it; collisionsForProvider reports only the ones
 // a given provider would actually be exposed to).
-func fetchCandidates(cfg *clientconfig.Config) ([]provisioning.Artifact, error) {
+func fetchCandidates(cfg *clientconfig.Config, kbNames []string) (candidateSet, error) {
+	cs := candidateSet{Named: make(map[string][]provisioning.Artifact)}
 	token := resolveToken(cfg)
 	health, err := client.New(cfg.ServerURL, token).Health(probeTimeout)
 	if err != nil {
-		return nil, fmt.Errorf("health: %w", err)
+		return cs, fmt.Errorf("health: %w", err)
 	}
-	targets, err := resolveKBTargets(health, cfg.KnownKBs)
+	targets, err := resolveKBTargets(health, kbNames)
 	if err != nil {
-		return nil, err
+		return cs, err
 	}
 
-	var all []provisioning.Artifact
 	seen := make(map[string]provisioning.Artifact)
 
 	for _, target := range targets {
@@ -110,26 +260,26 @@ func fetchCandidates(cfg *clientconfig.Config) ([]provisioning.Artifact, error) 
 		raw, err := callTool(c, target, "sync_pull", map[string]any{})
 		if err != nil {
 			if target.Name == "" {
-				return nil, fmt.Errorf("sync_pull: %w", err)
+				return cs, fmt.Errorf("sync_pull: %w", err)
 			}
-			return nil, fmt.Errorf("sync_pull (kb=%s): %w", target.Name, err)
+			return cs, fmt.Errorf("sync_pull (kb=%s): %w", target.Name, err)
 		}
 
 		var pm pulledManifestJSON
 		if err := json.Unmarshal(raw, &pm); err != nil {
-			return nil, fmt.Errorf("sync_pull: decode response: %w", err)
+			return cs, fmt.Errorf("sync_pull: decode response: %w", err)
 		}
 		for _, pa := range pm.Artifacts {
 			files := make([]provisioning.ArtifactFile, len(pa.Files))
 			for i, pf := range pa.Files {
 				data, err := base64.StdEncoding.DecodeString(pf.ContentB64)
 				if err != nil {
-					return nil, fmt.Errorf("sync_pull: decode file %s/%s/%s: %w", pa.Kind, pa.Name, pf.Path, err)
+					return cs, fmt.Errorf("sync_pull: decode file %s/%s/%s: %w", pa.Kind, pa.Name, pf.Path, err)
 				}
 				files[i] = provisioning.ArtifactFile{Path: pf.Path, Content: data, Executable: pf.Executable}
 			}
 			if got := provisioning.ContentHashFiles(files); got != pa.ContentHash {
-				return nil, fmt.Errorf("sync_pull: content hash mismatch for %s/%s", pa.Kind, pa.Name)
+				return cs, fmt.Errorf("sync_pull: content hash mismatch for %s/%s", pa.Kind, pa.Name)
 			}
 			a := provisioning.Artifact{
 				Kind: pa.Kind, Name: pa.Name, Source: pa.Source, Version: pa.Version,
@@ -137,14 +287,29 @@ func fetchCandidates(cfg *clientconfig.Config) ([]provisioning.Artifact, error) 
 			}
 			key := a.Kind + "\x00" + a.Name + "\x00" + a.Source
 			if previous, exists := seen[key]; exists && !sameSignature(previous.Signature, a.Signature) {
-				return nil, fmt.Errorf("sync_pull: conflicting signatures for %s/%s", a.Kind, a.Name)
+				return cs, fmt.Errorf("sync_pull: conflicting signatures for %s/%s", a.Kind, a.Name)
 			}
 			seen[key] = a
-			all = append(all, a)
+			if target.Name == "" {
+				cs.Bare = append(cs.Bare, a)
+				cs.HasBare = true
+			} else {
+				cs.Named[target.Name] = append(cs.Named[target.Name], a)
+			}
+		}
+		// A KB that answered with no artifacts at all still counts as answered:
+		// without this, a provider bound only to it would fall through the
+		// "nothing was pulled" branch instead of correctly receiving nothing.
+		if target.Name != "" {
+			if _, ok := cs.Named[target.Name]; !ok {
+				cs.Named[target.Name] = nil
+			}
+		} else {
+			cs.HasBare = true
 		}
 	}
 
-	return all, nil
+	return cs, nil
 }
 
 // collisionsForProvider narrows DetectCollisions to the ones a single provider
@@ -193,7 +358,20 @@ func pinnedPublicKeys(cfg *clientconfig.Config) (map[string][]ed25519.PublicKey,
 	return pins, nil
 }
 
-// materializeForProviders applies manifest m for each provider in providers,
+// uniformManifests is the pre-D170 shape — every provider receiving the same
+// manifest — kept for callers that legitimately have one: `reconnect`, which
+// rebuilds from what the client already holds, and tests that do not exercise
+// bindings. Production sync/connect paths build the map from the bindings via
+// manifestsForProviders instead.
+func uniformManifests(m provisioning.Manifest, providers []string) map[string]provisioning.Manifest {
+	out := make(map[string]provisioning.Manifest, len(providers))
+	for _, p := range providers {
+		out[p] = m
+	}
+	return out
+}
+
+// materializeForProviders applies each provider's own manifest (D170),
 // persisting a single v2 LockFile at <targetDir>/.cartographer-sync.lock.json (one
 // Lock entry per provider), stamped with serverVersion — the version of the
 // server this state was materialized against (D142). An empty serverVersion
@@ -217,7 +395,7 @@ type portabilityOptions struct {
 	Paths       map[string]string
 }
 
-func materializeForProviders(m provisioning.Manifest, providers []string, targetDir, serverVersion string, autoTrust, dryRun, noHeal bool, portability portabilityOptions, approvalHashes ...map[string]string) (map[string]provisioning.AppliedResult, error) {
+func materializeForProviders(manifests map[string]provisioning.Manifest, providers []string, targetDir, serverVersion string, autoTrust, dryRun, noHeal bool, portability portabilityOptions, approvalHashes ...map[string]string) (map[string]provisioning.AppliedResult, error) {
 	lockPath := lockFilePath(targetDir)
 	lockFile, err := provisioning.ReadLockFile(lockPath)
 	if err != nil {
@@ -239,7 +417,10 @@ func materializeForProviders(m provisioning.Manifest, providers []string, target
 			return nil, err
 		}
 		baseDirs[p] = baseDir
-		if err := provisioning.PreflightStdioMCP(m, provisioning.ApplyOptions{Provider: configurator.Provider(p), BaseDir: baseDir, AutoTrust: autoTrust, ApprovedMCP: approvedMCP}); err != nil {
+		// Preflight the provider's OWN view: validating the whole candidate set
+		// would fail a sync over a local command belonging to a KB this
+		// provider is not even bound to (D170).
+		if err := provisioning.PreflightStdioMCP(manifests[p], provisioning.ApplyOptions{Provider: configurator.Provider(p), BaseDir: baseDir, AutoTrust: autoTrust, ApprovedMCP: approvedMCP}); err != nil {
 			return nil, err
 		}
 	}
@@ -263,7 +444,7 @@ func materializeForProviders(m provisioning.Manifest, providers []string, target
 		// unsupported kinds (e.g. hook outside Claude Code, or agent outside
 		// Claude Code/OpenCode — D55) are neither drift nor pending, they
 		// simply don't concern it.
-		applied, err := provisioning.Apply(provisioning.FilterForProvider(m, configurator.Provider(p)), opts)
+		applied, err := provisioning.Apply(provisioning.FilterForProvider(manifests[p], configurator.Provider(p)), opts)
 		if err != nil {
 			return nil, fmt.Errorf("apply %s: %w", p, err)
 		}

--- a/cmd/cartographer/clientsync_test.go
+++ b/cmd/cartographer/clientsync_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -156,7 +157,7 @@ func TestFetchMergedManifestVerifiesPinnedSignatureAndRejectsTampering(t *testin
 	}
 
 	target := t.TempDir()
-	if _, err := materializeForProviders(m, []string{"claude"}, target, "", false, false, false, portabilityOptions{}); err != nil {
+	if _, err := materializeForProviders(uniformManifests(m, []string{"claude"}), []string{"claude"}, target, "", false, false, false, portabilityOptions{}); err != nil {
 		t.Fatalf("materialize valid manifest: %v", err)
 	}
 	lockPath := filepath.Join(target, provisioning.LockFileName)
@@ -192,7 +193,7 @@ func TestFetchMergedManifestVerifiesPinnedSignatureAndRejectsTampering(t *testin
 			fetched, fetchErr := fetchMergedManifest(cfg)
 			srv.Close()
 			if fetchErr == nil {
-				_, fetchErr = materializeForProviders(fetched, []string{"claude"}, target, "", false, false, false, portabilityOptions{})
+				_, fetchErr = materializeForProviders(uniformManifests(fetched, []string{"claude"}), []string{"claude"}, target, "", false, false, false, portabilityOptions{})
 			}
 			if fetchErr == nil {
 				t.Fatal("tampered sync unexpectedly succeeded")
@@ -283,7 +284,7 @@ func TestAuthorizationDoesNotSetSigned(t *testing.T) {
 	if m.Artifacts[0].Signed {
 		t.Fatal("test fixture must be unsigned")
 	}
-	if _, err := materializeForProviders(m, []string{"claude"}, t.TempDir(), "", true, true, false, portabilityOptions{}); err != nil {
+	if _, err := materializeForProviders(uniformManifests(m, []string{"claude"}), []string{"claude"}, t.TempDir(), "", true, true, false, portabilityOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	if m.Artifacts[0].Signed {
@@ -295,7 +296,7 @@ func TestMaterializeForProviders_TrustAvoidsNeedsApproval(t *testing.T) {
 	dir := t.TempDir()
 	m := kbSkillManifest()
 
-	results, err := materializeForProviders(m, []string{"claude"}, dir, "", true, true /* dryRun */, false, portabilityOptions{})
+	results, err := materializeForProviders(uniformManifests(m, []string{"claude"}), []string{"claude"}, dir, "", true, true /* dryRun */, false, portabilityOptions{})
 	if err != nil {
 		t.Fatalf("materializeForProviders: %v", err)
 	}
@@ -312,7 +313,7 @@ func TestMaterializeForProviders_NoTrustNeedsApproval(t *testing.T) {
 	dir := t.TempDir()
 	m := kbSkillManifest()
 
-	results, err := materializeForProviders(m, []string{"claude"}, dir, "", false, true /* dryRun */, false, portabilityOptions{})
+	results, err := materializeForProviders(uniformManifests(m, []string{"claude"}), []string{"claude"}, dir, "", false, true /* dryRun */, false, portabilityOptions{})
 	if err != nil {
 		t.Fatalf("materializeForProviders: %v", err)
 	}
@@ -353,7 +354,7 @@ func TestMaterializeForProviders_Instructions_ClaudeEKiro(t *testing.T) {
 	dir := t.TempDir()
 	m := instructionsManifest("homelab", "Contenuto di imprinting per homelab.\n")
 
-	results, err := materializeForProviders(m, []string{"claude", "kiro"}, dir, "", true, false /* dryRun */, false, portabilityOptions{})
+	results, err := materializeForProviders(uniformManifests(m, []string{"claude", "kiro"}), []string{"claude", "kiro"}, dir, "", true, false /* dryRun */, false, portabilityOptions{})
 	if err != nil {
 		t.Fatalf("materializeForProviders: %v", err)
 	}
@@ -476,7 +477,7 @@ func TestMaterializeForProviders_StdioPreflightIsAtomic(t *testing.T) {
 		Kind: "mcp", Name: "missing", Source: "kb:kb", Signed: true,
 		ContentHash: provisioning.ContentHashFiles([]provisioning.ArtifactFile{file}), Files: []provisioning.ArtifactFile{file},
 	}}}
-	_, err := materializeForProviders(m, []string{"claude", "codex"}, dir, "", false, false, false, portabilityOptions{})
+	_, err := materializeForProviders(uniformManifests(m, []string{"claude", "codex"}), []string{"claude", "codex"}, dir, "", false, false, false, portabilityOptions{})
 	if err == nil || !strings.Contains(err.Error(), "not found on PATH") || !strings.Contains(err.Error(), "for claude") {
 		t.Fatalf("preflight error = %v", err)
 	}
@@ -498,7 +499,7 @@ func TestMaterializeForProviders_PerProviderBaseDir(t *testing.T) {
 	t.Setenv("HERMES_HOME", hermesHome)
 
 	m := kbSkillManifest()
-	if _, err := materializeForProviders(m, []string{"claude", "hermes"}, dir, "", true, false /* dryRun */, false, portabilityOptions{}); err != nil {
+	if _, err := materializeForProviders(uniformManifests(m, []string{"claude", "hermes"}), []string{"claude", "hermes"}, dir, "", true, false /* dryRun */, false, portabilityOptions{}); err != nil {
 		t.Fatalf("materializeForProviders: %v", err)
 	}
 
@@ -546,7 +547,7 @@ func TestMaterializeForProviders_PerProviderBaseDir(t *testing.T) {
 // fallback to the home directory (D141).
 func TestMaterializeForProviders_MissingProviderBaseDir(t *testing.T) {
 	t.Setenv("HERMES_HOME", "")
-	_, err := materializeForProviders(kbSkillManifest(), []string{"hermes"}, t.TempDir(), "", true, false, false, portabilityOptions{})
+	_, err := materializeForProviders(uniformManifests(kbSkillManifest(), []string{"hermes"}), []string{"hermes"}, t.TempDir(), "", true, false, false, portabilityOptions{})
 	if err == nil {
 		t.Fatal("materializeForProviders succeeded with $HERMES_HOME unset")
 	}
@@ -725,5 +726,178 @@ func TestCollisionsForProvider(t *testing.T) {
 				t.Errorf("collisionsForProvider(%v) = %+v, want %d", tc.bound, got, tc.want)
 			}
 		})
+	}
+}
+
+// --- D170: per-provider projection ---
+
+// TestManifestsForProvidersIsolatesBoundKBs is the acceptance test of the whole
+// feature: two providers bound to different KBs receive different artifacts and
+// different revisions, and neither sees the other's KB.
+func TestManifestsForProvidersIsolatesBoundKBs(t *testing.T) {
+	srv := prefixAwareMCPServer(t, map[string]string{"one": "", "two": ""}, "sync_pull", func(kb string) string {
+		return syncPullPayload(t, kb, "skill-"+kb)
+	})
+	defer srv.Close()
+
+	cfg := &clientconfig.Config{
+		ServerURL: srv.URL + "/mcp", KnownKBs: []string{"one", "two"},
+		Agents: []string{"claude", "codex"},
+		Clients: map[string]clientconfig.ClientBinding{
+			"claude": {KBs: []string{"one"}},
+			"codex":  {KBs: []string{"two"}},
+		},
+	}
+	manifests, err := manifestsForProviders(cfg, cfg.Agents)
+	if err != nil {
+		t.Fatalf("manifestsForProviders: %v", err)
+	}
+
+	names := func(p string) []string {
+		var out []string
+		for _, a := range manifests[p].Artifacts {
+			out = append(out, a.Name+"@"+a.Source)
+		}
+		sort.Strings(out)
+		return out
+	}
+	if got := strings.Join(names("claude"), ","); got != "skill-one@kb:one" {
+		t.Errorf("claude received %q, want only skill-one@kb:one", got)
+	}
+	if got := strings.Join(names("codex"), ","); got != "skill-two@kb:two" {
+		t.Errorf("codex received %q, want only skill-two@kb:two", got)
+	}
+	if manifests["claude"].Revision == manifests["codex"].Revision {
+		t.Error("providers with different bindings share a revision")
+	}
+}
+
+// TestManifestsForProvidersDefaultIsEveryKnownKB: a provider with no binding
+// keeps today's behaviour, so an upgrade strips nothing.
+func TestManifestsForProvidersDefaultIsEveryKnownKB(t *testing.T) {
+	srv := prefixAwareMCPServer(t, map[string]string{"one": "", "two": ""}, "sync_pull", func(kb string) string {
+		return syncPullPayload(t, kb, "skill-"+kb)
+	})
+	defer srv.Close()
+
+	cfg := &clientconfig.Config{
+		ServerURL: srv.URL + "/mcp", KnownKBs: []string{"one", "two"}, Agents: []string{"claude"},
+	}
+	manifests, err := manifestsForProviders(cfg, cfg.Agents)
+	if err != nil {
+		t.Fatalf("manifestsForProviders: %v", err)
+	}
+	if len(manifests["claude"].Artifacts) != 2 {
+		t.Errorf("claude received %d artifacts, want both KBs", len(manifests["claude"].Artifacts))
+	}
+}
+
+// TestManifestsForProvidersEmptyBindingPullsNothing: an explicit empty binding
+// is a configured state, and it must not even reach the server.
+func TestManifestsForProvidersEmptyBindingPullsNothing(t *testing.T) {
+	cfg := &clientconfig.Config{
+		ServerURL: "http://127.0.0.1:1/mcp", // would fail if contacted
+		KnownKBs:  []string{"one"}, Agents: []string{"claude"},
+		Clients: map[string]clientconfig.ClientBinding{"claude": {KBs: nil}},
+	}
+	manifests, err := manifestsForProviders(cfg, cfg.Agents)
+	if err != nil {
+		t.Fatalf("manifestsForProviders: %v", err)
+	}
+	if len(manifests["claude"].Artifacts) != 0 {
+		t.Errorf("claude received %d artifacts, want none", len(manifests["claude"].Artifacts))
+	}
+}
+
+// TestManifestsForProvidersNamesTheStaleBinding: the error must say which
+// client holds the binding, not only which KB disappeared.
+func TestManifestsForProvidersNamesTheStaleBinding(t *testing.T) {
+	srv := prefixAwareMCPServer(t, map[string]string{"one": ""}, "sync_pull", func(kb string) string {
+		return syncPullPayload(t, kb, "skill-one")
+	})
+	defer srv.Close()
+
+	cfg := &clientconfig.Config{
+		ServerURL: srv.URL + "/mcp", KnownKBs: []string{"one"}, Agents: []string{"claude"},
+		Clients: map[string]clientconfig.ClientBinding{"claude": {KBs: []string{"gone"}}},
+	}
+	_, err := manifestsForProviders(cfg, cfg.Agents)
+	if err == nil {
+		t.Fatal("a binding to an unadvertised KB was accepted")
+	}
+	for _, want := range []string{`"gone"`, "claude"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error missing %q: %v", want, err)
+		}
+	}
+}
+
+// TestUnbindingRemovesItsArtifacts: the prune does the work, provided the
+// manifest shrank. This is the "dissociate and the files go" acceptance case.
+func TestUnbindingRemovesItsArtifacts(t *testing.T) {
+	srv := prefixAwareMCPServer(t, map[string]string{"one": "", "two": ""}, "sync_pull", func(kb string) string {
+		return syncPullPayload(t, kb, "skill-"+kb)
+	})
+	defer srv.Close()
+
+	dir := t.TempDir()
+	cfg := &clientconfig.Config{
+		ServerURL: srv.URL + "/mcp", KnownKBs: []string{"one", "two"},
+		Agents: []string{"claude"}, Trust: true,
+	}
+
+	both, err := manifestsForProviders(cfg, cfg.Agents)
+	if err != nil {
+		t.Fatalf("manifestsForProviders: %v", err)
+	}
+	if _, err := materializeForProviders(both, cfg.Agents, dir, "", true, false, false, portabilityOptions{}); err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	twoPath := filepath.Join(dir, ".claude", "skills", "skill-two", "SKILL.md")
+	if _, err := os.Stat(twoPath); err != nil {
+		t.Fatalf("skill-two was not materialized: %v", err)
+	}
+
+	// Bind claude to kb "one" only, then sync again.
+	if err := cfg.Bind("claude", "one"); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	narrowed, err := manifestsForProviders(cfg, cfg.Agents)
+	if err != nil {
+		t.Fatalf("manifestsForProviders (narrowed): %v", err)
+	}
+	if _, err := materializeForProviders(narrowed, cfg.Agents, dir, "", true, false, false, portabilityOptions{}); err != nil {
+		t.Fatalf("materialize (narrowed): %v", err)
+	}
+	if _, err := os.Stat(twoPath); !os.IsNotExist(err) {
+		t.Errorf("skill-two survived the unbind (err=%v)", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".claude", "skills", "skill-one", "SKILL.md")); err != nil {
+		t.Errorf("skill-one was removed too: %v", err)
+	}
+}
+
+func TestSelectProviders(t *testing.T) {
+	agents := []string{"claude", "codex", "kiro"}
+	if got, err := selectProviders(agents, nil); err != nil || strings.Join(got, ",") != "claude,codex,kiro" {
+		t.Errorf("empty selection = %v (%v), want every agent", got, err)
+	}
+	// Order follows cfg.Agents, not the flag order, so output is stable.
+	if got, err := selectProviders(agents, []string{"kiro", "claude"}); err != nil || strings.Join(got, ",") != "claude,kiro" {
+		t.Errorf("selection = %v (%v), want claude,kiro", got, err)
+	}
+	if _, err := selectProviders(agents, []string{"opencode"}); err == nil {
+		t.Error("an unconnected provider was accepted")
+	}
+}
+
+func TestCommonRevision(t *testing.T) {
+	same := map[string]provisioning.Manifest{"a": {Revision: "r"}, "b": {Revision: "r"}}
+	if got := commonRevision(same, []string{"a", "b"}); got != "r" {
+		t.Errorf("commonRevision = %q, want r", got)
+	}
+	diff := map[string]provisioning.Manifest{"a": {Revision: "r1"}, "b": {Revision: "r2"}}
+	if got := commonRevision(diff, []string{"a", "b"}); got != "" {
+		t.Errorf("commonRevision = %q, want empty when providers diverge", got)
 	}
 }

--- a/cmd/cartographer/connect.go
+++ b/cmd/cartographer/connect.go
@@ -561,18 +561,18 @@ func doConnect(opts connectOptions) (connectResult, error) {
 	if healthErr != nil || !facts.Listed {
 		entryKBs = nil
 	}
-	entries, err := entriesForKBs(opts.Name, opts.ServerURL, entryKBs)
+	entriesByProvider, err := entriesByProviderForKBs(existing, opts.Providers, opts.Name, opts.ServerURL, entryKBs)
 	if err != nil {
 		return connectResult{}, err
 	}
 	if _, err := removeMCPEntries(opts.Name, existing.KnownKBs, opts.Providers, opts.Dir, opts.Auth, opts.TokenEnv, opts.DryRun); err != nil {
 		return connectResult{}, err
 	}
-	configsWritten, configWarnings, err := applyMCPEntries(entries, opts.Providers, opts.Dir, opts.Auth, opts.TokenEnv, opts.DryRun)
+	configsWritten, configWarnings, err := applyMCPEntries(entriesByProvider, opts.Providers, opts.Dir, opts.Auth, opts.TokenEnv, opts.DryRun)
 	if err != nil {
 		return connectResult{}, err
 	}
-	if w := kiroFlatNamespaceWarning(opts.Providers, entries, effectiveToolPrefixes(facts, healthErr), healthErr); w != "" {
+	if w := kiroFlatNamespaceWarning(opts.Providers, entriesByProvider, effectiveToolPrefixes(facts, healthErr), healthErr); w != "" {
 		configWarnings = append(configWarnings, w)
 	}
 
@@ -589,22 +589,24 @@ func doConnect(opts connectOptions) (connectResult, error) {
 	if healthErr == nil {
 		pullKBs = kbs
 	}
-	pullCfg := &clientconfig.Config{ServerURL: opts.ServerURL, ServerName: opts.Name, Auth: opts.Auth, TokenEnv: opts.TokenEnv, KnownKBs: pullKBs, SigningKeys: existing.SigningKeys}
+	// Clients travels with it: connecting a provider must not pull or
+	// materialize a KB it is not bound to (D170).
+	pullCfg := &clientconfig.Config{ServerURL: opts.ServerURL, ServerName: opts.Name, Auth: opts.Auth, TokenEnv: opts.TokenEnv, KnownKBs: pullKBs, Clients: existing.Clients, SigningKeys: existing.SigningKeys}
 
 	// The MCP-entry lines report what was emitted, not what was asked for:
 	// entries is built from the client config alone, so keeping it when no
 	// selected provider has an MCP emitter announces a write into a file the
 	// output cannot even name (D147).
-	mcpEntries := entryNames(entries)
+	mcpEntries := allEntryNames(entriesByProvider)
 	if len(providersManagingMCP(opts.Providers)) == 0 {
 		mcpEntries = nil
 	}
 	res := connectResult{Providers: opts.Providers, ConfigsWritten: configsWritten, MCPEntries: mcpEntries, Warnings: configWarnings}
-	if m, err := fetchMergedManifest(pullCfg); err != nil {
+	if manifests, err := manifestsForProviders(pullCfg, opts.Providers); err != nil {
 		res.Deferred = true
 		res.DeferredErr = err
 	} else {
-		applied, err := materializeForProviders(m, opts.Providers, opts.Dir, facts.Version, opts.Trust || opts.AutoTrust, opts.DryRun, false /* noHeal */, portabilityOptions{SearchRoots: existing.SearchRoots, SearchDepth: existing.SearchDepth, Paths: existing.Paths}, existing.ApprovedMCPHashes())
+		applied, err := materializeForProviders(manifests, opts.Providers, opts.Dir, facts.Version, opts.Trust || opts.AutoTrust, opts.DryRun, false /* noHeal */, portabilityOptions{SearchRoots: existing.SearchRoots, SearchDepth: existing.SearchDepth, Paths: existing.Paths}, existing.ApprovedMCPHashes())
 		if err != nil {
 			return connectResult{}, err
 		}

--- a/cmd/cartographer/doctor.go
+++ b/cmd/cartographer/doctor.go
@@ -184,6 +184,9 @@ func runDoctor(dir, only string) doctorReport {
 		findings = append(findings, checkSymlinkedDestinations(dir, providers)...)
 		findings = append(findings, checkCapabilities(dir, cfg)...)
 		findings = append(findings, checkKBCollisions(dir, cfg, providers)...)
+		if lockErr == nil {
+			findings = append(findings, checkUnboundResidues(dir, cfg, providers, lockFile)...)
+		}
 	}
 
 	sortDoctorFindings(findings)
@@ -368,7 +371,7 @@ func checkManagedFiles(dir string, providers []string, lockFile provisioning.Loc
 // match the KBs recorded in .cartographer.yaml. An entry for a KB no longer
 // mounted keeps pointing an agent at something that is gone.
 func checkMCPEntries(dir string, cfg *clientconfig.Config, providers []string) []doctorFinding {
-	entries, err := entriesForKBs(cfg.ServerName, cfg.ServerURL, cfg.KnownKBs)
+	entriesByProvider, err := entriesByProviderForKBs(cfg, providers, cfg.ServerName, cfg.ServerURL, cfg.KnownKBs)
 	if err != nil {
 		return []doctorFinding{{
 			Check: "mcp-entries", Severity: doctorError, Path: filepath.Join(dir, clientconfig.FileName),
@@ -376,13 +379,14 @@ func checkMCPEntries(dir string, cfg *clientconfig.Config, providers []string) [
 			Fix:     "cartographer reconnect",
 		}}
 	}
-	expected := map[string]bool{}
-	for _, name := range entryNames(entries) {
-		expected[name] = true
-	}
-
 	var out []doctorFinding
 	for _, p := range providers {
+		// Expected entries are per provider since D170: a provider bound to a
+		// subset must not be reported as missing the rest.
+		expected := map[string]bool{}
+		for _, name := range entryNames(entriesByProvider[p]) {
+			expected[name] = true
+		}
 		provider := configurator.Provider(p)
 		d, ok := configurator.Lookup(provider)
 		if !ok || !d.ManagesMCPConfig() {
@@ -583,6 +587,50 @@ func checkServer(dir string, cfg *clientconfig.Config, providers []string) []doc
 	return out
 }
 
+// checkUnboundResidues: a managed file whose source KB is no longer bound to
+// the provider holding it (D170). It survives a projection that predates an
+// unbind, or a hand-edited lockfile, and nothing else reports it: the prune only
+// removes what left the manifest, and after an unbind that provider's manifest
+// is not even fetched for that KB.
+//
+// An empty Source is NOT a finding: every lockfile written before D170 has one,
+// and unknown provenance is not wrong provenance. Reporting those would flag
+// every existing machine on upgrade.
+func checkUnboundResidues(dir string, cfg *clientconfig.Config, providers []string, lockFile provisioning.LockFile) []doctorFinding {
+	var out []doctorFinding
+	for _, p := range providers {
+		bound, explicit := cfg.BoundKBs(p)
+		if !explicit {
+			// Bound to every known KB: a residue can only come from a KB the
+			// server dropped, which checkMCPEntries already covers.
+			continue
+		}
+		allowed := make(map[string]bool, len(bound))
+		for _, kb := range bound {
+			allowed["kb:"+kb] = true
+		}
+		lock := lockFile.ForProvider(p)
+		baseDir := provisioning.LockBaseDir(lock, dir)
+		reported := make(map[string]bool)
+		for _, mf := range lock.Managed {
+			if mf.Source == "" || mf.Source == "bundle" || allowed[mf.Source] {
+				continue
+			}
+			key := mf.Kind + "\x00" + mf.Name
+			if reported[key] {
+				continue
+			}
+			reported[key] = true
+			out = append(out, doctorFinding{
+				Check: "unbound-residue", Severity: doctorError, Path: filepath.Join(baseDir, mf.Path),
+				Message: fmt.Sprintf("[%s] %s/%s comes from %s, which is not bound to this provider", p, mf.Kind, mf.Name, mf.Source),
+				Fix:     fmt.Sprintf("cartographer sync --client %s", p),
+			})
+		}
+	}
+	return out
+}
+
 // checkKBCollisions: two KBs bound to the same provider claiming one kind+name
 // (D171). `sync` refuses outright when this happens, so finding it here is the
 // difference between a diagnosis and a mystery — the sync error names the
@@ -593,7 +641,8 @@ func checkServer(dir string, cfg *clientconfig.Config, providers []string) []doc
 // nothing collides. Reported per provider, because two colliding KBs bound to
 // different providers are not a conflict.
 func checkKBCollisions(dir string, cfg *clientconfig.Config, providers []string) []doctorFinding {
-	candidates, err := fetchCandidates(cfg)
+	union, _, _ := boundKBUnion(cfg, providers)
+	candidates, err := fetchCandidates(cfg, union)
 	if err != nil {
 		return nil
 	}
@@ -601,7 +650,7 @@ func checkKBCollisions(dir string, cfg *clientconfig.Config, providers []string)
 	var out []doctorFinding
 	for _, p := range providers {
 		bound, _ := cfg.BoundKBs(p)
-		for _, c := range collisionsForProvider(candidates, bound) {
+		for _, c := range collisionsForProvider(candidates.forKBs(bound), bound) {
 			out = append(out, doctorFinding{
 				Check: "kb-collisions", Severity: doctorError, Path: configPath,
 				Message: fmt.Sprintf("%s: %s/%s is claimed by %s — sync refuses to run", p, c.Kind, c.Name, strings.Join(c.Sources, ", ")),

--- a/cmd/cartographer/doctor_test.go
+++ b/cmd/cartographer/doctor_test.go
@@ -508,3 +508,40 @@ func TestCheckCapabilities(t *testing.T) {
 		}
 	})
 }
+
+// --- D170: residues from an unbound KB ---
+
+func TestCheckUnboundResidues(t *testing.T) {
+	dir := t.TempDir()
+	managed := []provisioning.ManagedFile{
+		{Kind: "skill", Name: "kept", Path: "a", ContentHash: "h", Source: "kb:bound"},
+		{Kind: "skill", Name: "stale", Path: "b", ContentHash: "h", Source: "kb:gone"},
+		{Kind: "skill", Name: "bundled", Path: "c", ContentHash: "h", Source: "bundle"},
+		{Kind: "skill", Name: "legacy", Path: "d", ContentHash: "h"}, // pre-D170 lockfile
+	}
+	lockFile := provisioning.LockFile{Providers: map[string]provisioning.Lock{
+		"claude": {Provider: "claude", Managed: managed},
+	}}
+
+	t.Run("explicit binding reports only the unbound source", func(t *testing.T) {
+		cfg := &clientconfig.Config{Agents: []string{"claude"}, KnownKBs: []string{"bound"},
+			Clients: map[string]clientconfig.ClientBinding{"claude": {KBs: []string{"bound"}}}}
+		findings := checkUnboundResidues(dir, cfg, []string{"claude"}, lockFile)
+		if len(findings) != 1 {
+			t.Fatalf("findings = %+v, want exactly the kb:gone one", findings)
+		}
+		if !strings.Contains(findings[0].Message, "kb:gone") {
+			t.Errorf("finding = %q, want it to name kb:gone", findings[0].Message)
+		}
+		if !strings.Contains(findings[0].Fix, "--client claude") {
+			t.Errorf("fix = %q, want the per-client sync", findings[0].Fix)
+		}
+	})
+
+	t.Run("a provider on the default binding is never a residue", func(t *testing.T) {
+		cfg := &clientconfig.Config{Agents: []string{"claude"}, KnownKBs: []string{"bound"}}
+		if findings := checkUnboundResidues(dir, cfg, []string{"claude"}, lockFile); len(findings) != 0 {
+			t.Errorf("findings = %+v, want none for a default binding", findings)
+		}
+	})
+}

--- a/cmd/cartographer/multikb.go
+++ b/cmd/cartographer/multikb.go
@@ -194,10 +194,7 @@ func effectiveToolPrefixes(facts serverFacts, healthErr error) map[string]string
 // server, or one too old to advertise them — the warning stays unconditional and
 // says the prefixes could not be verified: a missing signal is not evidence that
 // everything is fine.
-func kiroFlatNamespaceWarning(providers []string, entries []mcpEntry, prefixes map[string]string, prefixErr error) string {
-	if len(entries) < 2 {
-		return ""
-	}
+func kiroFlatNamespaceWarning(providers []string, entriesByProvider map[string][]mcpEntry, prefixes map[string]string, prefixErr error) string {
 	var flat *configurator.Descriptor
 	for _, p := range providers {
 		if d, ok := configurator.Lookup(configurator.Provider(p)); ok && d.FlatToolNamespace {
@@ -206,6 +203,13 @@ func kiroFlatNamespaceWarning(providers []string, entries []mcpEntry, prefixes m
 		}
 	}
 	if flat == nil {
+		return ""
+	}
+	// Evaluated on that provider's own entries (D170): binding it to a single
+	// KB removes the flat-namespace conflict, and the warning must stop firing
+	// rather than describe entries it no longer holds.
+	entries := entriesByProvider[string(flat.Provider)]
+	if len(entries) < 2 {
 		return ""
 	}
 	remedies := "set kbs[].tool_prefix on them or mcp.tool_prefix_mode: kb-name (see docs/deployment.md §MCP tool-name prefix)"
@@ -273,19 +277,29 @@ func quoteAll(names []string) []string {
 	return out
 }
 
-// entriesForKBs implements D92's compatibility rule: a zero/one-KB server
-// keeps one bare entry; a multi-KB server gets one explicitly-scoped entry per
-// KB. url.URL is used rather than concatenation so an existing query survives.
-func entriesForKBs(baseName, serverURL string, kbs []string) ([]mcpEntry, error) {
-	if len(kbs) <= 1 {
+// entriesForKBs implements D92's compatibility rule, split across two inputs
+// since D170: the entry SHAPE comes from what the server mounts, the entry SET
+// from what the provider is bound to.
+//
+// Conflating them breaks the client. A bare /mcp auto-routes only when the
+// server mounts exactly one KB (mcpserver.MultiKBServer.Handler); with zero or
+// two or more it answers "kb parameter required". So a server with four KBs and
+// a client bound to one still needs an explicitly-scoped ?kb= entry, even
+// though that client's list has a single name.
+//
+// url.URL is used rather than concatenation so an existing query survives.
+func entriesForKBs(baseName, serverURL string, mounted, bound []string) ([]mcpEntry, error) {
+	if len(mounted) <= 1 {
+		// Nothing to select against: the server routes the bare endpoint, and
+		// no binding can name a KB the server does not identify.
 		return []mcpEntry{{Name: baseName, URL: serverURL}}, nil
 	}
 	u, err := url.Parse(serverURL)
 	if err != nil {
 		return nil, fmt.Errorf("parse server URL %q: %w", serverURL, err)
 	}
-	entries := make([]mcpEntry, 0, len(kbs))
-	for _, kb := range kbs {
+	entries := make([]mcpEntry, 0, len(bound))
+	for _, kb := range bound {
 		entryURL := *u
 		q := entryURL.Query()
 		q.Set("kb", kb)
@@ -312,6 +326,50 @@ func managedEntryNames(baseName string, kbs []string) []string {
 	return names
 }
 
+// entriesByProviderForKBs builds each provider's own entry set from its binding
+// (D170). A provider explicitly bound to NO KBs gets no entry at all — that is
+// the one case where an empty list is a declaration rather than an absence.
+func entriesByProviderForKBs(cfg *clientconfig.Config, providers []string, baseName, serverURL string, mounted []string) (map[string][]mcpEntry, error) {
+	out := make(map[string][]mcpEntry, len(providers))
+	for _, p := range providers {
+		bound, explicit := cfg.BoundKBs(p)
+		if !explicit {
+			// The default is "every KB the server currently mounts", so it
+			// resolves against the live discovery rather than the persisted
+			// cache: connect runs before that cache is refreshed, and a dry run
+			// never refreshes it at all.
+			bound = mounted
+		}
+		if explicit && len(bound) == 0 && len(mounted) > 1 {
+			out[p] = nil
+			continue
+		}
+		entries, err := entriesForKBs(baseName, serverURL, mounted, bound)
+		if err != nil {
+			return nil, err
+		}
+		out[p] = entries
+	}
+	return out, nil
+}
+
+// allEntryNames is the union of every provider's entry names, deduplicated and
+// sorted — what the summary lines report when they are not per provider.
+func allEntryNames(entriesByProvider map[string][]mcpEntry) []string {
+	seen := map[string]bool{}
+	var names []string
+	for _, entries := range entriesByProvider {
+		for _, e := range entries {
+			if !seen[e.Name] {
+				seen[e.Name] = true
+				names = append(names, e.Name)
+			}
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
 func entryNames(entries []mcpEntry) []string {
 	names := make([]string, 0, len(entries))
 	for _, entry := range entries {
@@ -320,16 +378,18 @@ func entryNames(entries []mcpEntry) []string {
 	return names
 }
 
-// applyMCPEntries emits all entries for each provider. Codex represents all
+// applyMCPEntries emits each provider's OWN entries (D170: a provider must not
+// hold an entry toward a KB it is not bound to). Codex represents all
 // Cartographer MCP entries in one marker-delimited TOML block, so its emitted
 // bodies are joined before Apply replaces that block. Returns the config paths
 // written plus the non-fatal warnings Apply collected (a header the provider
 // cannot represent, D69; a duplicate table adopted from a Codex rewrite, D99),
 // for the caller to render.
-func applyMCPEntries(entries []mcpEntry, providers []string, dir string, auth bool, tokenEnv string, dryRun bool) (written []string, warnings []string, err error) {
+func applyMCPEntries(entriesByProvider map[string][]mcpEntry, providers []string, dir string, auth bool, tokenEnv string, dryRun bool) (written []string, warnings []string, err error) {
 	written = make([]string, 0, len(providers))
 	seenPaths := map[string]bool{}
 	for _, provider := range providers {
+		entries := entriesByProvider[provider]
 		if !configurator.ManagesMCPConfig(configurator.Provider(provider)) {
 			// A provider whose MCP endpoints are configured outside
 			// Cartographer (D141, hermes: its config.yaml is rendered by its

--- a/cmd/cartographer/multikb_test.go
+++ b/cmd/cartographer/multikb_test.go
@@ -110,7 +110,7 @@ func TestKiroFlatNamespaceWarning(t *testing.T) {
 	oneUnprefixed := map[string]string{"alpha": "", "beta": "b", "gamma": "g"}
 
 	t.Run("two unprefixed KBs warn and are named", func(t *testing.T) {
-		w := kiroFlatNamespaceWarning([]string{"kiro"}, twoEntries, bothUnprefixed, nil)
+		w := kiroFlatNamespaceWarning([]string{"kiro"}, map[string][]mcpEntry{"kiro": twoEntries}, bothUnprefixed, nil)
 		if w == "" {
 			t.Fatal("expected a warning")
 		}
@@ -125,19 +125,19 @@ func TestKiroFlatNamespaceWarning(t *testing.T) {
 	})
 
 	t.Run("a single unprefixed KB is safe", func(t *testing.T) {
-		if w := kiroFlatNamespaceWarning([]string{"kiro"}, threeEntries, oneUnprefixed, nil); w != "" {
+		if w := kiroFlatNamespaceWarning([]string{"kiro"}, map[string][]mcpEntry{"kiro": threeEntries}, oneUnprefixed, nil); w != "" {
 			t.Errorf("expected silence with one unprefixed KB, got %q", w)
 		}
 	})
 
 	t.Run("all prefixed is silent", func(t *testing.T) {
-		if w := kiroFlatNamespaceWarning([]string{"kiro"}, twoEntries, bothPrefixed, nil); w != "" {
+		if w := kiroFlatNamespaceWarning([]string{"kiro"}, map[string][]mcpEntry{"kiro": twoEntries}, bothPrefixed, nil); w != "" {
 			t.Errorf("expected silence, got %q", w)
 		}
 	})
 
 	t.Run("unverifiable prefixes still warn, and say why", func(t *testing.T) {
-		w := kiroFlatNamespaceWarning([]string{"kiro"}, twoEntries, nil, errors.New("connection refused"))
+		w := kiroFlatNamespaceWarning([]string{"kiro"}, map[string][]mcpEntry{"kiro": twoEntries}, nil, errors.New("connection refused"))
 		if w == "" {
 			t.Fatal("expected a warning when the prefixes cannot be read")
 		}
@@ -147,13 +147,13 @@ func TestKiroFlatNamespaceWarning(t *testing.T) {
 	})
 
 	t.Run("a single entry is silent", func(t *testing.T) {
-		if w := kiroFlatNamespaceWarning([]string{"kiro"}, oneEntry, bothUnprefixed, nil); w != "" {
+		if w := kiroFlatNamespaceWarning([]string{"kiro"}, map[string][]mcpEntry{"kiro": oneEntry}, bothUnprefixed, nil); w != "" {
 			t.Errorf("expected no warning for a single entry, got %q", w)
 		}
 	})
 
 	t.Run("no flat-namespace provider is silent", func(t *testing.T) {
-		if w := kiroFlatNamespaceWarning([]string{"claude", "codex", "opencode"}, twoEntries, bothUnprefixed, nil); w != "" {
+		if w := kiroFlatNamespaceWarning([]string{"claude", "codex", "opencode"}, map[string][]mcpEntry{"kiro": twoEntries}, bothUnprefixed, nil); w != "" {
 			t.Errorf("expected no warning without a flat-namespace provider, got %q", w)
 		}
 	})
@@ -183,7 +183,7 @@ func TestDoConnect_Kiro_MultiKB_WarnsFlatNamespace(t *testing.T) {
 }
 
 func TestEntriesForKBs_SingleStaysBare(t *testing.T) {
-	entries, err := entriesForKBs("wiki", "https://example.test/mcp", []string{"only"})
+	entries, err := entriesForKBs("wiki", "https://example.test/mcp", []string{"only"}, []string{"only"})
 	if err != nil || len(entries) != 1 || entries[0].Name != "wiki" || entries[0].URL != "https://example.test/mcp" {
 		t.Fatalf("entriesForKBs = %+v, %v; want one bare entry", entries, err)
 	}
@@ -215,11 +215,11 @@ func TestDoConnect_SingleKB_BareEntry_AllProviders(t *testing.T) {
 
 func TestRemoveMCPEntries_RemovesEveryManagedEntry(t *testing.T) {
 	dir := t.TempDir()
-	entries, err := entriesForKBs("wiki", "https://example.test/mcp", []string{"a", "b"})
+	entries, err := entriesForKBs("wiki", "https://example.test/mcp", []string{"a", "b"}, []string{"a", "b"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := applyMCPEntries(entries, []string{"claude", "codex", "kiro", "opencode"}, dir, false, "", false); err != nil {
+	if _, _, err := applyMCPEntries(sameEntriesFor([]string{"claude", "codex", "kiro", "opencode"}, entries), []string{"claude", "codex", "kiro", "opencode"}, dir, false, "", false); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := removeMCPEntries("wiki", []string{"a", "b"}, []string{"claude", "codex", "kiro", "opencode"}, dir, false, "", false); err != nil {
@@ -248,8 +248,8 @@ func TestCmdSync_ReconcilesOneToManyAndBack(t *testing.T) {
 	if err := clientconfig.Save(dir, cfg); err != nil {
 		t.Fatal(err)
 	}
-	bare, _ := entriesForKBs("wiki", cfg.ServerURL, cfg.KnownKBs)
-	if _, _, err := applyMCPEntries(bare, cfg.Agents, dir, false, "", false); err != nil {
+	bare, _ := entriesForKBs("wiki", cfg.ServerURL, cfg.KnownKBs, cfg.KnownKBs)
+	if _, _, err := applyMCPEntries(sameEntriesFor(cfg.Agents, bare), cfg.Agents, dir, false, "", false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -288,8 +288,8 @@ func TestDoDisconnect_RemovesPersistedPerKBEntries(t *testing.T) {
 	if err := clientconfig.Save(dir, cfg); err != nil {
 		t.Fatal(err)
 	}
-	entries, _ := entriesForKBs("wiki", cfg.ServerURL, cfg.KnownKBs)
-	if _, _, err := applyMCPEntries(entries, cfg.Agents, dir, false, "", false); err != nil {
+	entries, _ := entriesForKBs("wiki", cfg.ServerURL, cfg.KnownKBs, cfg.KnownKBs)
+	if _, _, err := applyMCPEntries(sameEntriesFor(cfg.Agents, entries), cfg.Agents, dir, false, "", false); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := doDisconnect(disconnectOptions{Providers: []string{"claude"}, Dir: dir}); err != nil {
@@ -311,8 +311,8 @@ func TestCmdSync_ServerDownKeepsMCPEntriesAndKBs(t *testing.T) {
 	if err := clientconfig.Save(dir, cfg); err != nil {
 		t.Fatal(err)
 	}
-	entries, _ := entriesForKBs("wiki", cfg.ServerURL, cfg.KnownKBs)
-	if _, _, err := applyMCPEntries(entries, cfg.Agents, dir, false, "", false); err != nil {
+	entries, _ := entriesForKBs("wiki", cfg.ServerURL, cfg.KnownKBs, cfg.KnownKBs)
+	if _, _, err := applyMCPEntries(sameEntriesFor(cfg.Agents, entries), cfg.Agents, dir, false, "", false); err != nil {
 		t.Fatal(err)
 	}
 	beforeConfig, err := os.ReadFile(clientconfig.Path(dir))
@@ -486,5 +486,109 @@ func TestDoConnect_Hermes_MissingHome(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, ".cartographer.yaml")); !os.IsNotExist(err) {
 		t.Errorf("a failed connect persisted config anyway: %v", err)
+	}
+}
+
+// sameEntriesFor is the pre-D170 shape — every provider receiving the same MCP
+// entry set — for tests that do not exercise bindings.
+func sameEntriesFor(providers []string, entries []mcpEntry) map[string][]mcpEntry {
+	out := make(map[string][]mcpEntry, len(providers))
+	for _, p := range providers {
+		out[p] = entries
+	}
+	return out
+}
+
+// --- D170: entry shape vs entry set ---
+
+// TestEntriesForKBs_ShapeFromServerSetFromBinding pins the trap: bare /mcp
+// auto-routes only when the SERVER mounts one KB, so a client bound to one of
+// four still needs ?kb=. Deriving the shape from the binding's length would
+// hand that client a bare entry the server answers with 400.
+func TestEntriesForKBs_ShapeFromServerSetFromBinding(t *testing.T) {
+	cases := []struct {
+		name      string
+		mounted   []string
+		bound     []string
+		wantNames []string
+		wantQuery bool
+	}{
+		{
+			name:      "single-KB server: bare entry, whatever the binding says",
+			mounted:   []string{"only"},
+			bound:     []string{"only"},
+			wantNames: []string{"wiki"},
+		},
+		{
+			name:      "multi-KB server, bound to all: one entry per KB",
+			mounted:   []string{"a", "b"},
+			bound:     []string{"a", "b"},
+			wantNames: []string{"wiki-a", "wiki-b"},
+			wantQuery: true,
+		},
+		{
+			name:      "multi-KB server, bound to one: still a scoped entry",
+			mounted:   []string{"a", "b", "c", "d"},
+			bound:     []string{"b"},
+			wantNames: []string{"wiki-b"},
+			wantQuery: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entries, err := entriesForKBs("wiki", "https://example.test/mcp", tc.mounted, tc.bound)
+			if err != nil {
+				t.Fatalf("entriesForKBs: %v", err)
+			}
+			if got := strings.Join(entryNames(entries), ","); got != strings.Join(tc.wantNames, ",") {
+				t.Errorf("names = %q, want %q", got, strings.Join(tc.wantNames, ","))
+			}
+			for _, e := range entries {
+				if strings.Contains(e.URL, "kb=") != tc.wantQuery {
+					t.Errorf("URL %q: kb= present = %v, want %v", e.URL, !tc.wantQuery, tc.wantQuery)
+				}
+			}
+		})
+	}
+}
+
+// TestEntriesByProviderForKBs_EmptyBindingGetsNoEntry: a provider explicitly
+// bound to nothing must not be handed a way in.
+func TestEntriesByProviderForKBs_EmptyBindingGetsNoEntry(t *testing.T) {
+	cfg := &clientconfig.Config{
+		ServerName: "wiki", Agents: []string{"claude", "codex"},
+		KnownKBs: []string{"a", "b"},
+		Clients: map[string]clientconfig.ClientBinding{
+			"claude": {KBs: nil},
+			"codex":  {KBs: []string{"a"}},
+		},
+	}
+	byProvider, err := entriesByProviderForKBs(cfg, cfg.Agents, "wiki", "https://example.test/mcp", cfg.KnownKBs)
+	if err != nil {
+		t.Fatalf("entriesByProviderForKBs: %v", err)
+	}
+	if len(byProvider["claude"]) != 0 {
+		t.Errorf("claude got %+v, want no entry", byProvider["claude"])
+	}
+	if got := strings.Join(entryNames(byProvider["codex"]), ","); got != "wiki-a" {
+		t.Errorf("codex got %q, want wiki-a", got)
+	}
+}
+
+// TestManagedEntryNamesCoversEveryKnownKB pins the second trap: removal must be
+// driven by the union of known KBs, never by a provider's filtered binding, or
+// an unbound KB's entry is orphaned forever.
+func TestManagedEntryNamesCoversEveryKnownKB(t *testing.T) {
+	names := managedEntryNames("wiki", []string{"a", "b", "c"})
+	for _, want := range []string{"wiki", "wiki-a", "wiki-b", "wiki-c"} {
+		found := false
+		for _, n := range names {
+			if n == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("managedEntryNames missing %q: %v", want, names)
+		}
 	}
 }

--- a/cmd/cartographer/reconnect_test.go
+++ b/cmd/cartographer/reconnect_test.go
@@ -189,7 +189,7 @@ func TestMaterializeForProviders_RecordsServerVersion(t *testing.T) {
 	dir := t.TempDir()
 	m := kbSkillManifest()
 
-	if _, err := materializeForProviders(m, []string{"claude"}, dir, "1.4.0", true, false, false, portabilityOptions{}); err != nil {
+	if _, err := materializeForProviders(uniformManifests(m, []string{"claude"}), []string{"claude"}, dir, "1.4.0", true, false, false, portabilityOptions{}); err != nil {
 		t.Fatalf("materializeForProviders: %v", err)
 	}
 	lockFile, err := provisioning.ReadLockFile(lockFilePath(dir))
@@ -201,7 +201,7 @@ func TestMaterializeForProviders_RecordsServerVersion(t *testing.T) {
 	}
 
 	// An offline sync (empty version) must not erase the knowledge.
-	if _, err := materializeForProviders(m, []string{"claude"}, dir, "", true, false, false, portabilityOptions{}); err != nil {
+	if _, err := materializeForProviders(uniformManifests(m, []string{"claude"}), []string{"claude"}, dir, "", true, false, false, portabilityOptions{}); err != nil {
 		t.Fatalf("materializeForProviders offline: %v", err)
 	}
 	lockFile, err = provisioning.ReadLockFile(lockFilePath(dir))

--- a/cmd/cartographer/status.go
+++ b/cmd/cartographer/status.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -20,8 +21,8 @@ var (
 	statusHealthFn = func(cfg *clientconfig.Config) (*client.Health, error) {
 		return client.New(cfg.ServerURL, resolveToken(cfg)).Health(statusHealthTimeout)
 	}
-	statusManifestFn = fetchMergedManifest
-	statusServiceFn  = func() (service.Status, error) { return service.NewManager().Status("") }
+	statusManifestsFn = manifestsForProviders
+	statusServiceFn   = func() (service.Status, error) { return service.NewManager().Status("") }
 )
 
 // cmdStatus reports the sync status of every connected provider against the
@@ -94,6 +95,7 @@ func renderStatus(output string, s statusSnapshot, code int) int {
 		}
 		if p.State == "in_sync" {
 			fmt.Printf("[%s] in-sync (revision %s)\n", p.Name, p.Revision)
+			printBindingLine(p)
 			if p.Kinds != "" {
 				fmt.Printf("  %s\n", p.Kinds)
 			}
@@ -104,6 +106,7 @@ func renderStatus(output string, s statusSnapshot, code int) int {
 			continue
 		}
 		fmt.Printf("[%s] drift (manifest %s, lock %s)\n", p.Name, p.Revision, p.LockRevision)
+		printBindingLine(p)
 		if p.Kinds != "" {
 			fmt.Printf("  %s\n", p.Kinds)
 		}
@@ -167,4 +170,32 @@ func statusArtifactTrust(a statusArtifact) string {
 		return "verified"
 	}
 	return "needs_approval"
+}
+
+// printBindingLine reports which KBs a provider may receive and where that
+// answer came from, plus the per-KB breakdown of what it actually holds (D170).
+// The origin is not decoration: the same list of names means "declared" or
+// "whatever the server happens to mount today" depending on it.
+func printBindingLine(p providerStatus) {
+	if p.BindingOrigin == "" {
+		return
+	}
+	kbs := "none"
+	if len(p.BoundKBs) > 0 {
+		kbs = strings.Join(p.BoundKBs, ", ")
+	}
+	fmt.Printf("  kbs %s (%s)\n", kbs, p.BindingOrigin)
+	if len(p.KBCounts) == 0 {
+		return
+	}
+	sources := make([]string, 0, len(p.KBCounts))
+	for source := range p.KBCounts {
+		sources = append(sources, source)
+	}
+	sort.Strings(sources)
+	parts := make([]string, 0, len(sources))
+	for _, source := range sources {
+		parts = append(parts, fmt.Sprintf("%s %d", source, p.KBCounts[source]))
+	}
+	fmt.Printf("  from %s\n", strings.Join(parts, " · "))
 }

--- a/cmd/cartographer/status_snapshot.go
+++ b/cmd/cartographer/status_snapshot.go
@@ -45,6 +45,15 @@ type providerStatus struct {
 	// unknown (a lockfile written before D142). Shown next to the live
 	// version so a server change is inspectable without running a sync.
 	ServerVersion string `json:"materialized_server_version,omitempty"`
+	// BoundKBs and BindingOrigin describe which KBs this provider may receive
+	// and whether that was declared or defaulted (D170). Without them the same
+	// list of names means two different things and the reader cannot tell.
+	BoundKBs      []string `json:"bound_kbs,omitempty"`
+	BindingOrigin string   `json:"binding_origin,omitempty"`
+	// KBCounts breaks the materialized artifacts down by source KB, read from
+	// the lockfile's per-file Source (D170). Empty for a lockfile written
+	// before that field existed: unknown, not zero.
+	KBCounts map[string]int `json:"kb_counts,omitempty"`
 }
 
 type statusArtifact struct {
@@ -147,7 +156,13 @@ func snapshotForConfig(dir string, cfg *clientconfig.Config, includeService bool
 			s.KBs = append(s.KBs, kb.Name)
 		}
 	}
-	m, err := statusManifestFn(cfg)
+	connectedProviders := make([]string, 0, len(s.Providers))
+	for i := range s.Providers {
+		if s.Providers[i].Connected {
+			connectedProviders = append(connectedProviders, s.Providers[i].Name)
+		}
+	}
+	manifests, err := statusManifestsFn(cfg, connectedProviders)
 	if err != nil {
 		s.State = "unavailable"
 		e := classifyNetworkError(cfg.ServerURL, err)
@@ -159,7 +174,9 @@ func snapshotForConfig(dir string, cfg *clientconfig.Config, includeService bool
 		}
 		return s
 	}
-	s.Artifacts = len(m.Artifacts)
+	for _, p := range connectedProviders {
+		s.Artifacts += len(manifests[p].Artifacts)
+	}
 	lockFile, err := provisioning.ReadLockFile(lockFilePath(dir))
 	if err != nil {
 		s.State = "error"
@@ -170,7 +187,7 @@ func snapshotForConfig(dir string, cfg *clientconfig.Config, includeService bool
 		if !s.Providers[i].Connected {
 			continue
 		}
-		pm := provisioning.FilterForProvider(m, configurator.Provider(s.Providers[i].Name))
+		pm := provisioning.FilterForProvider(manifests[s.Providers[i].Name], configurator.Provider(s.Providers[i].Name))
 		d := provisioning.ComputeDiff(pm, lockFile.ForProvider(s.Providers[i].Name))
 		p := &s.Providers[i]
 		p.Revision = pm.Revision
@@ -181,6 +198,13 @@ func snapshotForConfig(dir string, cfg *clientconfig.Config, includeService bool
 		// deleted locally used to report in-sync.
 		lock := lockFile.ForProvider(p.Name)
 		p.ServerVersion = lock.ServerVersion
+		bound, explicit := cfg.BoundKBs(p.Name)
+		p.BoundKBs = bound
+		p.BindingOrigin = "default"
+		if explicit {
+			p.BindingOrigin = "explicit"
+		}
+		p.KBCounts = countBySource(lock)
 		p.Diverged = snapshotDiverged(provisioning.VerifyManaged(lock, configurator.Provider(p.Name), provisioning.LockBaseDir(lock, dir)))
 		if d.InSync && len(p.Diverged) == 0 {
 			p.State = "in_sync"
@@ -284,5 +308,30 @@ func snapshotMaterializedVersions(s statusSnapshot) []string {
 		out = append(out, p.ServerVersion)
 	}
 	sort.Strings(out)
+	return out
+}
+
+// countBySource groups a provider's managed files by the KB they came from
+// (D170). Entries with no Source — every lockfile written before it existed —
+// are omitted rather than bucketed under a made-up name: unknown provenance is
+// not the same as none, and inventing a bucket would misreport a whole machine
+// until its next sync.
+func countBySource(lock provisioning.Lock) map[string]int {
+	counted := make(map[string]bool)
+	out := make(map[string]int)
+	for _, mf := range lock.Managed {
+		if mf.Source == "" {
+			continue
+		}
+		key := mf.Kind + "\x00" + mf.Name
+		if counted[key] {
+			continue // one artifact, however many files it materialized
+		}
+		counted[key] = true
+		out[mf.Source]++
+	}
+	if len(out) == 0 {
+		return nil
+	}
 	return out
 }

--- a/cmd/cartographer/status_test.go
+++ b/cmd/cartographer/status_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/BeppeTemp/cartographer/internal/client"
 	"github.com/BeppeTemp/cartographer/internal/clientconfig"
+	"github.com/BeppeTemp/cartographer/internal/configurator"
 	"github.com/BeppeTemp/cartographer/internal/provisioning"
 	"github.com/BeppeTemp/cartographer/internal/service"
 )
@@ -66,23 +67,28 @@ func TestCmdStatus_VersionReport(t *testing.T) {
 			if err := clientconfig.Save(home, &clientconfig.Config{ServerURL: tc.serverURL, Agents: []string{"claude"}, Trust: true}); err != nil {
 				t.Fatalf("save config: %v", err)
 			}
+			// Since D170 the lock records the revision of the manifest a
+			// provider actually receives, so the fixture derives it from the
+			// same manifest it serves rather than hardcoding a matching pair.
+			served := provisioning.Manifest{Revision: "rev1"}
+			appliedRev := provisioning.FilterForProvider(served, configurator.ProviderClaudeCode).Revision
 			if err := provisioning.WriteLockFile(lockFilePath(home), provisioning.LockFile{Providers: map[string]provisioning.Lock{
-				"claude": {Provider: "claude", AppliedRevision: "rev1"},
+				"claude": {Provider: "claude", AppliedRevision: appliedRev},
 			}}); err != nil {
 				t.Fatalf("write lockfile: %v", err)
 			}
 
-			oldVersion, oldHealth, oldManifest, oldService := version, statusHealthFn, statusManifestFn, statusServiceFn
+			oldVersion, oldHealth, oldManifest, oldService := version, statusHealthFn, statusManifestsFn, statusServiceFn
 			version = tc.clientVersion
 			statusHealthFn = func(*clientconfig.Config) (*client.Health, error) {
 				return &client.Health{Version: tc.serverVersion}, nil
 			}
-			statusManifestFn = func(*clientconfig.Config) (provisioning.Manifest, error) {
-				return provisioning.Manifest{Revision: "rev1"}, nil
+			statusManifestsFn = func(_ *clientconfig.Config, providers []string) (map[string]provisioning.Manifest, error) {
+				return uniformManifests(served, providers), nil
 			}
 			statusServiceFn = func() (service.Status, error) { return service.Status{Installed: tc.serviceInstalled}, nil }
 			t.Cleanup(func() {
-				version, statusHealthFn, statusManifestFn, statusServiceFn = oldVersion, oldHealth, oldManifest, oldService
+				version, statusHealthFn, statusManifestsFn, statusServiceFn = oldVersion, oldHealth, oldManifest, oldService
 			})
 
 			out := withStdout(t, func() {
@@ -126,7 +132,12 @@ func TestStatus_OnDiskDriftExitsOne(t *testing.T) {
 	if err != nil {
 		t.Fatalf("hash skill dir: %v", err)
 	}
-	lock := provisioning.Lock{Provider: "claude", AppliedRevision: "rev1", Managed: []provisioning.ManagedFile{{
+	served := provisioning.Manifest{Revision: "rev1", Artifacts: []provisioning.Artifact{
+		{Kind: "skill", Name: "runbooks", Source: "kb:wiki", ContentHash: "source-hash", Signed: true},
+	}}
+	// D170: the lock carries the revision of the provider's own view.
+	appliedRev := provisioning.FilterForProvider(served, configurator.ProviderClaudeCode).Revision
+	lock := provisioning.Lock{Provider: "claude", AppliedRevision: appliedRev, Managed: []provisioning.ManagedFile{{
 		Kind: "skill", Name: "runbooks", Path: filepath.Join(".claude", "skills", "runbooks", "SKILL.md"),
 		ContentHash: "source-hash", MaterializedHash: onDisk,
 	}}}
@@ -134,17 +145,15 @@ func TestStatus_OnDiskDriftExitsOne(t *testing.T) {
 		t.Fatalf("write lockfile: %v", err)
 	}
 
-	oldVersion, oldHealth, oldManifest, oldService := version, statusHealthFn, statusManifestFn, statusServiceFn
+	oldVersion, oldHealth, oldManifest, oldService := version, statusHealthFn, statusManifestsFn, statusServiceFn
 	version = "v1.0.0"
 	statusHealthFn = func(*clientconfig.Config) (*client.Health, error) { return &client.Health{Version: "v1.0.0"}, nil }
-	statusManifestFn = func(*clientconfig.Config) (provisioning.Manifest, error) {
-		return provisioning.Manifest{Revision: "rev1", Artifacts: []provisioning.Artifact{
-			{Kind: "skill", Name: "runbooks", Source: "kb:wiki", ContentHash: "source-hash", Signed: true},
-		}}, nil
+	statusManifestsFn = func(_ *clientconfig.Config, providers []string) (map[string]provisioning.Manifest, error) {
+		return uniformManifests(served, providers), nil
 	}
 	statusServiceFn = func() (service.Status, error) { return service.Status{}, nil }
 	t.Cleanup(func() {
-		version, statusHealthFn, statusManifestFn, statusServiceFn = oldVersion, oldHealth, oldManifest, oldService
+		version, statusHealthFn, statusManifestsFn, statusServiceFn = oldVersion, oldHealth, oldManifest, oldService
 	})
 
 	// Untouched: in-sync.

--- a/cmd/cartographer/sync.go
+++ b/cmd/cartographer/sync.go
@@ -4,8 +4,10 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/BeppeTemp/cartographer/internal/clientconfig"
+	"github.com/BeppeTemp/cartographer/internal/provisioning"
 )
 
 // cmdSync re-fetches the manifest from the configured server (sync_pull) and
@@ -17,6 +19,8 @@ import (
 func cmdSync(args []string) int {
 	fs := flag.NewFlagSet("sync", flag.ExitOnError)
 	dryRun := fs.Bool("dry-run", false, "Print what would change without writing")
+	var clients repeatedString
+	fs.Var(&clients, "client", "Sync only this provider (repeatable); other providers are left untouched")
 	autoTrust := fs.Bool("auto-trust", false, "Trust KB-sourced skills without explicit signature (one-time override; see the persisted `trust` setting in .cartographer.yaml)")
 	noHeal := fs.Bool("no-heal", false, "Report locally modified managed artifacts instead of restoring them from the server")
 	fs.Parse(args)
@@ -36,7 +40,7 @@ func cmdSync(args []string) int {
 		return 0
 	}
 
-	if _, err := runSync(dir, cfg, syncOptions{DryRun: *dryRun, AutoTrust: *autoTrust, NoHeal: *noHeal}); err != nil {
+	if _, err := runSync(dir, cfg, syncOptions{DryRun: *dryRun, AutoTrust: *autoTrust, NoHeal: *noHeal, Clients: clients}); err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)
 		return 2
 	}
@@ -50,6 +54,11 @@ func cmdSync(args []string) int {
 type syncOptions struct {
 	DryRun    bool
 	AutoTrust bool
+	// Clients restricts the run to these providers (--client, repeatable).
+	// Empty means every connected provider. A provider left out is not
+	// touched at all: not its MCP entries, not its artifacts, not its entry in
+	// the lockfile (D170).
+	Clients []string
 	// NoHeal reports artifacts whose files diverged on disk instead of
 	// restoring them (D139). upgrade-repair never sets it: repairing is its
 	// entire purpose.
@@ -71,6 +80,11 @@ type syncResult struct {
 // nested cartographer process or duplicating configurator/approval/
 // signature/provisioning logic.
 func runSync(dir string, cfg *clientconfig.Config, opts syncOptions) (syncResult, error) {
+	targets, err := selectProviders(cfg.Agents, opts.Clients)
+	if err != nil {
+		return syncResult{}, err
+	}
+
 	// Reconcile the provider MCP entries from the mounted KB list before
 	// sync_pull. On an unreachable server no local entry or persisted KB list
 	// changes; fetchMergedManifest below then reports the ordinary sync error.
@@ -81,59 +95,125 @@ func runSync(dir string, cfg *clientconfig.Config, opts syncOptions) (syncResult
 	} else {
 		// The server that answers now may not be the one this client's state
 		// was materialized against (D142): say so once, then sync normally.
-		if notice := serverChangeNotice(dir, cfg.Agents, facts.Version); notice != "" {
+		if notice := serverChangeNotice(dir, targets, facts.Version); notice != "" {
 			fmt.Println(notice)
 		}
 		entryKBs := kbs
 		if !facts.Listed {
 			entryKBs = nil
 		}
-		entries, err := entriesForKBs(cfg.ServerName, cfg.ServerURL, entryKBs)
+		entriesByProvider, err := entriesByProviderForKBs(cfg, targets, cfg.ServerName, cfg.ServerURL, entryKBs)
 		if err != nil {
 			return syncResult{}, err
 		}
-		if _, err := removeMCPEntries(cfg.ServerName, cfg.KnownKBs, cfg.Agents, dir, cfg.Auth, cfg.TokenEnv, opts.DryRun); err != nil {
+		// removeMCPEntries is fed the UNION of every known KB, never a
+		// provider's filtered binding (D170): managedEntryNames derives the
+		// names this client may own from the list it is given, so passing the
+		// filtered one would orphan an unbound KB's entry forever. Only the
+		// targeted providers are touched — a provider skipped by --client keeps
+		// its entries untouched.
+		if _, err := removeMCPEntries(cfg.ServerName, cfg.KnownKBs, targets, dir, cfg.Auth, cfg.TokenEnv, opts.DryRun); err != nil {
 			return syncResult{}, err
 		}
-		_, warnings, err := applyMCPEntries(entries, cfg.Agents, dir, cfg.Auth, cfg.TokenEnv, opts.DryRun)
+		_, warnings, err := applyMCPEntries(entriesByProvider, targets, dir, cfg.Auth, cfg.TokenEnv, opts.DryRun)
 		if err != nil {
 			return syncResult{}, err
 		}
-		if w := kiroFlatNamespaceWarning(cfg.Agents, entries, effectiveToolPrefixes(facts, healthErr), healthErr); w != "" {
+		if w := kiroFlatNamespaceWarning(targets, entriesByProvider, effectiveToolPrefixes(facts, healthErr), healthErr); w != "" {
 			warnings = append(warnings, w)
 		}
 		for _, w := range warnings {
 			fmt.Fprintf(os.Stderr, "warning: %s\n", w)
 		}
-		printMCPEntryLines(cfg.Agents, entryNames(entries), opts.DryRun)
+		printMCPEntryLines(targets, allEntryNames(entriesByProvider), opts.DryRun)
+		// Refresh the in-memory cache unconditionally so the manifest pull
+		// below resolves default bindings against what the server mounts now;
+		// only the persistence is skipped on a dry run.
+		cfg.KnownKBs = kbs
 		if !opts.DryRun {
-			cfg.KnownKBs = kbs
 			if err := clientconfig.Save(dir, cfg); err != nil {
 				return syncResult{}, err
 			}
 		}
 	}
 
-	m, err := fetchMergedManifest(cfg)
+	manifests, err := manifestsForProviders(cfg, targets)
 	if err != nil {
 		return syncResult{}, err
 	}
 
 	// Do not write even the local bootstrap hook until the complete remote
 	// manifest has passed its content and signature checks.
-	if err := ensureBootstrapForProviders(cfg.Agents, dir, opts.DryRun); err != nil {
+	if err := ensureBootstrapForProviders(targets, dir, opts.DryRun); err != nil {
 		return syncResult{}, err
 	}
 
-	results, err := materializeForProviders(m, cfg.Agents, dir, facts.Version, cfg.Trust || opts.AutoTrust, opts.DryRun, opts.NoHeal, portabilityOptions{SearchRoots: cfg.SearchRoots, SearchDepth: cfg.SearchDepth, Paths: cfg.Paths}, cfg.ApprovedMCPHashes())
+	results, err := materializeForProviders(manifests, targets, dir, facts.Version, cfg.Trust || opts.AutoTrust, opts.DryRun, opts.NoHeal, portabilityOptions{SearchRoots: cfg.SearchRoots, SearchDepth: cfg.SearchDepth, Paths: cfg.Paths}, cfg.ApprovedMCPHashes())
 	if err != nil {
 		return syncResult{}, err
 	}
 	printApplySummary(dir, results, opts.DryRun)
-	if opts.DryRun {
-		fmt.Printf("would sync to revision %s\n", m.Revision)
-		return syncResult{Revision: m.Revision}, nil
+	printSyncRevisions(manifests, targets, opts.DryRun)
+	return syncResult{Revision: commonRevision(manifests, targets)}, nil
+}
+
+// selectProviders narrows cfg.Agents to the ones --client named, preserving
+// cfg.Agents' order so the output is stable. An empty selection means all.
+func selectProviders(agents []string, selected []string) ([]string, error) {
+	if len(selected) == 0 {
+		return agents, nil
 	}
-	fmt.Printf("synced to revision %s\n", m.Revision)
-	return syncResult{Revision: m.Revision}, nil
+	connected := make(map[string]bool, len(agents))
+	for _, a := range agents {
+		connected[a] = true
+	}
+	want := make(map[string]bool, len(selected))
+	for _, s := range selected {
+		if !connected[s] {
+			return nil, fmt.Errorf("provider %q is not connected (connected: %s)", s, strings.Join(agents, ", "))
+		}
+		want[s] = true
+	}
+	out := make([]string, 0, len(want))
+	for _, a := range agents {
+		if want[a] {
+			out = append(out, a)
+		}
+	}
+	return out, nil
+}
+
+// commonRevision returns the revision every targeted provider shares, or "" when
+// they differ. Bindings make a single machine-wide revision meaningless: two
+// providers receiving different KBs legitimately sit at different revisions.
+func commonRevision(manifests map[string]provisioning.Manifest, providers []string) string {
+	common := ""
+	for i, p := range providers {
+		rev := manifests[p].Revision
+		if i == 0 {
+			common = rev
+			continue
+		}
+		if rev != common {
+			return ""
+		}
+	}
+	return common
+}
+
+// printSyncRevisions reports one line when every provider agrees — the ordinary
+// case — and one line per provider when bindings made them diverge, so the
+// output never implies an agreement that does not exist.
+func printSyncRevisions(manifests map[string]provisioning.Manifest, providers []string, dryRun bool) {
+	verb := "synced to"
+	if dryRun {
+		verb = "would sync to"
+	}
+	if rev := commonRevision(manifests, providers); rev != "" || len(providers) <= 1 {
+		fmt.Printf("%s revision %s\n", verb, rev)
+		return
+	}
+	for _, p := range providers {
+		fmt.Printf("[%s] %s revision %s\n", p, verb, manifests[p].Revision)
+	}
 }

--- a/cmd/cartographer/tui.go
+++ b/cmd/cartographer/tui.go
@@ -201,10 +201,11 @@ func buildRows(dir string) []dashboardAgent {
 	connected := map[string]bool{}
 	serverName := "cartographer"
 	var kbs []string
-	if cfg, err := clientconfig.Load(dir); err == nil {
-		serverName = cfg.ServerName
-		kbs = cfg.KnownKBs
-		for _, a := range cfg.Agents {
+	loaded, _ := clientconfig.Load(dir)
+	if loaded != nil {
+		serverName = loaded.ServerName
+		kbs = loaded.KnownKBs
+		for _, a := range loaded.Agents {
 			connected[a] = true
 		}
 	}
@@ -214,7 +215,11 @@ func buildRows(dir string) []dashboardAgent {
 		row := dashboardAgent{Agent: a}
 		if connected[string(a.Provider)] {
 			row.Connected = true
-			row.MCPConfigState = mcpConfigStatus(dir, a.Provider, serverName, kbs)
+			bound := kbs
+			if loaded != nil {
+				bound, _ = loaded.BoundKBs(string(a.Provider))
+			}
+			row.MCPConfigState = mcpConfigStatus(dir, a.Provider, serverName, kbs, bound)
 			row.SkillStatus = "checking…"
 		} else {
 			row.SkillStatus = "not connected"
@@ -245,8 +250,10 @@ func hasConnectedAgent(rows []dashboardAgent) bool {
 // name this client may have *ever* owned (for safe removal across KB set
 // changes), which is not the same set as "currently expected" — a KB removed
 // from .cartographer.yaml should not keep counting toward in-sync/partial.
-func mcpConfigStatus(dir string, provider configurator.Provider, serverName string, kbs []string) mcpConfigState {
-	entries, err := entriesForKBs(serverName, "http://placeholder", kbs)
+// bound is the provider's own KB binding (D170): the expected entry set is its
+// own, not the machine's. mounted decides the entry shape.
+func mcpConfigStatus(dir string, provider configurator.Provider, serverName string, mounted, bound []string) mcpConfigState {
+	entries, err := entriesForKBs(serverName, "http://placeholder", mounted, bound)
 	if err != nil || len(entries) == 0 {
 		return mcpConfigMissing
 	}
@@ -388,7 +395,7 @@ func syncCmd(provider, dir string) tea.Cmd {
 		if err != nil {
 			return syncDoneMsg{provider: provider, err: err}
 		}
-		m, err := fetchMergedManifest(cfg)
+		manifests, err := manifestsForProviders(cfg, []string{provider})
 		if err != nil {
 			return syncDoneMsg{provider: provider, err: err}
 		}
@@ -396,7 +403,7 @@ func syncCmd(provider, dir string) tea.Cmd {
 		// leaves it empty, which preserves the previously recorded value
 		// instead of erasing it.
 		facts, _ := enumerateKBs(cfg.ServerURL, cfg.Auth, cfg.TokenEnv)
-		applied, err := materializeForProviders(m, []string{provider}, dir, facts.Version, cfg.Trust, false, false /* noHeal */, portabilityOptions{SearchRoots: cfg.SearchRoots, SearchDepth: cfg.SearchDepth, Paths: cfg.Paths}, cfg.ApprovedMCPHashes())
+		applied, err := materializeForProviders(manifests, []string{provider}, dir, facts.Version, cfg.Trust, false, false /* noHeal */, portabilityOptions{SearchRoots: cfg.SearchRoots, SearchDepth: cfg.SearchDepth, Paths: cfg.Paths}, cfg.ApprovedMCPHashes())
 		if err != nil {
 			return syncDoneMsg{provider: provider, err: err}
 		}

--- a/cmd/cartographer/tui_test.go
+++ b/cmd/cartographer/tui_test.go
@@ -778,7 +778,7 @@ func TestMCPConfigStatus_CodexTOML(t *testing.T) {
 	if err := os.WriteFile(tomlPath, []byte("model = \"gpt-5.5\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := mcpConfigStatus(dir, configurator.ProviderCodex, "cartographer", nil); got != mcpConfigMissing {
+	if got := mcpConfigStatus(dir, configurator.ProviderCodex, "cartographer", nil, nil); got != mcpConfigMissing {
 		t.Errorf("state = %v, want mcpConfigMissing: config.toml has no [mcp_servers.cartographer] table", got)
 	}
 
@@ -787,7 +787,7 @@ func TestMCPConfigStatus_CodexTOML(t *testing.T) {
 	if err := os.WriteFile(tomlPath, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := mcpConfigStatus(dir, configurator.ProviderCodex, "cartographer", nil); got != mcpConfigInSync {
+	if got := mcpConfigStatus(dir, configurator.ProviderCodex, "cartographer", nil, nil); got != mcpConfigInSync {
 		t.Errorf("state = %v, want mcpConfigInSync: config.toml declares [mcp_servers.cartographer]", got)
 	}
 }
@@ -806,14 +806,14 @@ func TestMCPConfigStatus_CodexTOML_MultiKB(t *testing.T) {
 	if err := os.WriteFile(tomlPath, []byte("model = \"gpt-5.5\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := mcpConfigStatus(dir, configurator.ProviderCodex, "cartographer", kbs); got != mcpConfigMissing {
+	if got := mcpConfigStatus(dir, configurator.ProviderCodex, "cartographer", kbs, kbs); got != mcpConfigMissing {
 		t.Errorf("none present: state = %v, want mcpConfigMissing", got)
 	}
 
 	if err := os.WriteFile(tomlPath, []byte("[mcp_servers.cartographer-alpha]\nurl = \"http://x\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := mcpConfigStatus(dir, configurator.ProviderCodex, "cartographer", kbs); got != mcpConfigPartial {
+	if got := mcpConfigStatus(dir, configurator.ProviderCodex, "cartographer", kbs, kbs); got != mcpConfigPartial {
 		t.Errorf("one of two present: state = %v, want mcpConfigPartial", got)
 	}
 
@@ -821,7 +821,7 @@ func TestMCPConfigStatus_CodexTOML_MultiKB(t *testing.T) {
 	if err := os.WriteFile(tomlPath, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := mcpConfigStatus(dir, configurator.ProviderCodex, "cartographer", kbs); got != mcpConfigInSync {
+	if got := mcpConfigStatus(dir, configurator.ProviderCodex, "cartographer", kbs, kbs); got != mcpConfigInSync {
 		t.Errorf("both present: state = %v, want mcpConfigInSync", got)
 	}
 }
@@ -842,10 +842,10 @@ func TestMCPConfigStatus_JSONProviders(t *testing.T) {
 	if err := os.WriteFile(full, []byte(`{"mcp":{"cartographer":{"type":"remote"}}}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := mcpConfigStatus(dir, configurator.ProviderOpenCode, "cartographer", nil); got != mcpConfigInSync {
+	if got := mcpConfigStatus(dir, configurator.ProviderOpenCode, "cartographer", nil, nil); got != mcpConfigInSync {
 		t.Errorf("state = %v, want mcpConfigInSync: opencode config declares the server under \"mcp\"", got)
 	}
-	if got := mcpConfigStatus(dir, configurator.ProviderOpenCode, "other", nil); got != mcpConfigMissing {
+	if got := mcpConfigStatus(dir, configurator.ProviderOpenCode, "other", nil, nil); got != mcpConfigMissing {
 		t.Errorf("state = %v, want mcpConfigMissing: server name not present", got)
 	}
 }
@@ -868,14 +868,14 @@ func TestMCPConfigStatus_JSONProviders_MultiKB(t *testing.T) {
 	if err := os.WriteFile(full, []byte(`{"mcp":{}}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := mcpConfigStatus(dir, configurator.ProviderOpenCode, "cartographer", kbs); got != mcpConfigMissing {
+	if got := mcpConfigStatus(dir, configurator.ProviderOpenCode, "cartographer", kbs, kbs); got != mcpConfigMissing {
 		t.Errorf("none present: state = %v, want mcpConfigMissing", got)
 	}
 
 	if err := os.WriteFile(full, []byte(`{"mcp":{"cartographer-alpha":{"type":"remote"}}}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := mcpConfigStatus(dir, configurator.ProviderOpenCode, "cartographer", kbs); got != mcpConfigPartial {
+	if got := mcpConfigStatus(dir, configurator.ProviderOpenCode, "cartographer", kbs, kbs); got != mcpConfigPartial {
 		t.Errorf("one of two present: state = %v, want mcpConfigPartial", got)
 	}
 
@@ -883,7 +883,7 @@ func TestMCPConfigStatus_JSONProviders_MultiKB(t *testing.T) {
 	if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := mcpConfigStatus(dir, configurator.ProviderOpenCode, "cartographer", kbs); got != mcpConfigInSync {
+	if got := mcpConfigStatus(dir, configurator.ProviderOpenCode, "cartographer", kbs, kbs); got != mcpConfigInSync {
 		t.Errorf("both present: state = %v, want mcpConfigInSync", got)
 	}
 }

--- a/cmd/cartographer/upgraderepair_test.go
+++ b/cmd/cartographer/upgraderepair_test.go
@@ -150,9 +150,10 @@ func TestCmdUpgradeRepair_RunningAlreadyCurrent_NoRestart(t *testing.T) {
 	if gotDir != dir {
 		t.Errorf("runSync dir = %q, want %q", gotDir, dir)
 	}
-	// Policy options must be passed unchanged: AutoTrust=false, DryRun=false.
-	if gotOpts != (syncOptions{}) {
-		t.Errorf("runSync opts = %+v, want zero value (AutoTrust=false, DryRun=false)", gotOpts)
+	// Policy options must be passed unchanged: AutoTrust=false, DryRun=false,
+	// and no --client narrowing (upgrade-repair always repairs every provider).
+	if gotOpts.AutoTrust || gotOpts.DryRun || gotOpts.NoHeal || len(gotOpts.Clients) != 0 {
+		t.Errorf("runSync opts = %+v, want zero value (AutoTrust=false, DryRun=false, no client filter)", gotOpts)
 	}
 	if !strings.Contains(out, "restart already-open provider sessions") {
 		t.Errorf("output = %q, want the provider-session restart reminder", out)

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -211,14 +211,22 @@ Re-runs `sync_pull` and reapplies the manifest for every connected provider: mat
 add/update, prunes obsolete artifacts, updates the lockfile. Idempotent.
 
 ```bash
-cartographer sync [--auto-trust] [--dry-run] [--no-heal]
+cartographer sync [--client <provider>]... [--auto-trust] [--dry-run] [--no-heal]
 ```
 
 | Flag | Default | Effect |
 |---|---|---|
+| `--client` | *(all)* | Syncs only this provider (repeatable). A provider left out is not touched at all: not its MCP entries, not its artifacts, not its lockfile entry |
 | `--dry-run` | `false` | Prints without writing |
 | `--auto-trust` | `false` | Also treats KB skills as trusted (unsigned) |
 | `--no-heal` | `false` | Reports managed artifacts that diverged on disk instead of restoring them from the server (D139) |
+
+Each provider receives only the KBs bound to it (§`cartographer client`), so the
+manifest — and therefore the revision — differs per provider. When every targeted
+provider agrees, `sync` prints one `synced to revision <r>` line as before;
+when bindings made them diverge it prints one line per provider instead, rather
+than implying an agreement that does not exist. See [`sync.md`](sync.md)
+§Per-provider projection.
 
 Every sync verifies the managed files on disk, not just the manifest revision, and restores what
 was edited or deleted locally — the restore is reported on its own line, because it discards
@@ -314,6 +322,7 @@ The checks:
 | `capability` | every per-KB gate the server advertises on `/health` is on, and no KB was mounted by discovery rather than by a `kbs[]` entry (D151). Info severity: it names the setting that would change it |
 | `symlink` | no managed destination directory is a symlink — provisioning refuses to write through one, so the artifacts it would hold are not installed (D148) |
 | `kb-collisions` | no two KBs bound to the same provider claim one `kind`+`name` (D171). `sync` refuses outright when they do, so a machine that has not synced since the binding changed would otherwise show no symptom. Silent when the server is unreachable |
+| `unbound-residue` | no managed file comes from a KB no longer bound to the provider holding it (D170) — a projection predating an unbind, or a hand-edited lockfile. Only for providers with an explicit binding; a file with no recorded source (a lockfile written before D170) is unknown, not wrong, and never reported |
 
 **Severities.** `error` — something is broken now (a managed file missing, a hook firing twice);
 `warning` — something is stale or suboptimal (v1 lockfile, no trigger for a hook-less provider, a
@@ -712,7 +721,22 @@ global mode — an operator who wants it everywhere declares a binding per
 provider.
 
 `bind`, `unbind` and `reset` save the configuration and stop: they never
-trigger a sync, and print `run cartographer sync to apply`.
+trigger a sync, and print `run cartographer sync to apply`. `bind` also warns,
+best-effort, when the new binding creates a cross-KB collision (D171); an
+unreachable server makes that check skipped, never a failed command.
+
+The binding governs the whole projection, not just artifacts: a provider's MCP
+entries are emitted for its bound KBs only. Two rules there are easy to get
+wrong and are pinned by tests — the entry **shape** comes from what the server
+mounts (a bare `/mcp` auto-routes only when the server mounts exactly one KB, so
+a client bound to one of four still needs `?kb=`), while the entry **set** comes
+from the binding; and entry *removal* is driven by the union of every known KB,
+never by a provider's filtered list, or an unbound KB's entry would be orphaned
+forever.
+
+`cartographer status` shows each provider's bound KBs and the origin of that
+answer, plus a per-KB breakdown of what it currently holds, read from the
+lockfile's recorded source.
 
 `status` and `sync` read this file (via `internal/clientconfig`): without `.cartographer.yaml` they
 fail with exit 2, suggesting `connect` first (`cartographer resolve` is the exception:

--- a/docs/decisions/sync-provisioning.md
+++ b/docs/decisions/sync-provisioning.md
@@ -835,3 +835,70 @@ reorder lands it fails loudly instead of changing silently.
 and arbitrarily — starts failing its sync with a report and a remedy. That is the
 intent. Everything else is unchanged: single-KB clients and clients whose KBs
 have distinct artifact names never reach the new code path.
+
+---
+
+<a id="d170"></a>
+## D170 — Selection before the merge: each provider is projected only its bound KBs
+
+**Decision.** The client keeps the per-KB `sync_pull` responses unmerged
+(`candidateSet`), and builds one manifest per provider: its bound KBs' responses
+→ `SelectForSources` → `MergeArtifactsStrict` → `VerifiedManifest` →
+`FilterForProvider` → `Apply`. `FilterForProvider` recomputes the revision,
+`ManagedFile` records the artifact's `Source`, MCP entries are emitted per
+provider, and `sync` gains a repeatable `--client`.
+
+**Rationale.**
+
+- **The filter had to move before the merge.** Filtering the merged manifest by
+  source is wrong, and the failure is silent data loss rather than a visible
+  error: `MergeArtifacts` deduplicates on `kind+name` and prefers a `kb:` source
+  over `bundle`, so if `kb-A` overrides a bundled skill and a provider is bound
+  only to `kb-B`, the merge keeps `kb-A`'s copy and the source filter then
+  deletes it — the provider ends with **nothing** where it should have received
+  the bundled copy. The server performs the same KB-over-bundle merge inside each
+  single-KB pull, so the discarded candidate cannot be reconstructed client-side.
+  That is why `fetchCandidates` returns responses keyed by KB.
+- **The revision had to be recomputed.** `FilterForProvider` used to inherit
+  `m.Revision`. With per-provider sets that makes `ComputeDiff.InSync` compare
+  two different manifests under one string, and — worse — changing a binding
+  would not change the revision, so no drift would ever be detected. The lock now
+  records the revision of the manifest actually applied, which also fixed a
+  pre-existing incoherence for providers that support only a subset of kinds.
+- **Unbinding needs no removal logic.** An unbound KB's artifacts leave the
+  provider's manifest, so `ComputeDiff` marks them `Removed` and `PruneManaged`
+  deletes them. The prune only touches files listed in the lock, so user-owned
+  files survive. This is why the projection was built as a filter rather than as
+  a separate teardown path.
+- **Entry shape and entry set are different questions.** A bare `/mcp`
+  auto-routes only when the *server* mounts exactly one KB
+  (`MultiKBServer.Handler`); with four mounted and one bound, the client still
+  needs `?kb=`. `entriesForKBs` therefore takes both lists. Symmetrically,
+  `removeMCPEntries` keeps receiving the **union** of every known KB: it derives
+  the names this client may own from the list it is given, so a filtered list
+  would orphan an unbound KB's entry permanently. Both are pinned by tests.
+- **The default resolves against live discovery, not the cache.** A provider
+  with no binding receives every KB the server currently mounts, read from
+  `/health` rather than from `known_kbs` — `connect` runs before that cache is
+  refreshed, and a dry run never refreshes it, so using the cache produced an
+  empty entry set on both paths.
+- **A nameless endpoint disables bindings rather than starving the client.**
+  When the server does not identify its KBs by name, no binding can match. Every
+  provider then receives everything, with a warning, exactly as before this
+  change — a missing signal is not a reason to strip a client. The one exception
+  is a provider explicitly bound to no KBs, where the declaration is unambiguous.
+- **`--client` leaves the others completely untouched**, including their MCP
+  entries and their lockfile entry, so a targeted sync cannot half-migrate a
+  provider nobody asked about.
+- **`ManagedFile.Source` is `omitempty` and "empty means unknown".** Every
+  lockfile written before this change has none; treating that as "wrong
+  provenance" would make `doctor` flag every existing machine on upgrade, and
+  `ComputeDiff` still compares `ContentHash` only, so nothing re-materializes.
+
+**Consequences.** Every client's revision changes once, on the first sync after
+release, because it is now computed after filtering — that is a recomputation,
+not drift, and it must be called out in the release notes. Behaviour is otherwise
+unchanged for anyone who declares no binding. `statusManifestFn` became
+`statusManifestsFn` (per provider); `materializeForProviders` takes a
+per-provider manifest map, with `uniformManifests` for the callers that
+legitimately have one.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -86,10 +86,11 @@ On the stdio transport, the server emits `notifications/skills/list_changed` aft
 
 When client and server don't share a filesystem (`internal/client`, `internal/clientconfig`, `cmd/cartographer/clientsync.go`):
 
-1. the client calls `sync_pull` (once per KB in `known_kbs`) and merges the manifests with `provisioning.MergeArtifactsStrict`, which refuses a `kind`+`name` claimed by two KBs (§Dedup and collisions);
-2. it reconstructs each artifact hash from received paths, bytes and executable modes, then verifies any detached signature against the local KB pin;
-3. `Apply` materializes/prunes and writes the v2 lockfile;
-4. pruning remains managed-only.
+1. the client calls `sync_pull` once per KB in the **union of every connected provider's binding** (§Per-provider projection) and keeps the responses unmerged;
+2. for each provider it selects its bound KBs' responses (`SelectForSources`), merges them with `provisioning.MergeArtifactsStrict` — which refuses a `kind`+`name` claimed by two of *that provider's* KBs — and verifies signatures;
+3. it reconstructs each artifact hash from received paths, bytes and executable modes, then verifies any detached signature against the local KB pin;
+4. `Apply` materializes/prunes and writes the v2 lockfile, one entry per provider;
+5. pruning remains managed-only.
 
 Each `sync_pull` call (and the equivalent `cartographer reindex` remote call) is qualified with
 that KB's tool-name prefix (D102), discovered from a live `/health` snapshot rather than
@@ -370,6 +371,11 @@ silently dropped, so no provider ever runs a command different from the approved
 ## Implementation choices
 
 - **Dedup by `kind`+`name`**: a skill present both in the bundle and in a KB is materialized only once, with the KB winning. The manifest holds exactly one artifact per `kind`+`name`.
+- **Per-provider projection** (D170): each provider receives only the KBs bound to it in `.cartographer.yaml` (`clients.<provider>.kbs`, see `configurator.md` §`cartographer client`). Three rules make it work:
+  - **selection happens before the merge**, on the per-KB `sync_pull` responses. Filtering the merged manifest is wrong: `MergeArtifacts` has already discarded candidates, so if `kb-A` overrides a bundled skill and a provider is bound only to `kb-B`, the merge keeps `kb-A`'s copy and a source filter then deletes it — the provider loses the skill instead of receiving the bundled one. The server performs the same KB-over-bundle merge inside each single-KB pull, so a candidate the client never received cannot be reconstructed;
+  - **the revision is recomputed per provider**, after selection and after `FilterForProvider`. Two providers holding different KB sets under one revision string would make `ComputeDiff.InSync` lie, and changing a binding would produce no drift at all;
+  - **unbinding removes the artifacts for free**: they leave the provider's manifest, so `ComputeDiff` marks them `Removed` and `PruneManaged` deletes them. Only files listed in the lock are touched, so user-owned files survive.
+  A server that does not identify its KBs by name (no `kbs` in `/health`, or a first sync before any name is known) cannot express a binding: every client receives everything, exactly as before D170, with a warning saying so. `ManagedFile.Source` records each file's origin KB; empty means "unknown" (a lockfile written before D170) and is never treated as wrong.
 - **Cross-KB collisions are refused, not resolved** (D171). Two KBs claiming the same `kind`+`name` is an error: `MergeArtifactsStrict` — what the client uses — fails with a report naming the kind, the name and the claiming KBs, before anything is materialized. `MergeArtifacts` stays tolerant and keeps the alphabetical `source` tie-break; the server builds a manifest from one KB plus the bundle, where the case cannot arise. `cartographer client bind` warns when a new binding creates one, and `doctor`'s `kb-collisions` check reports it per provider.
 - Lockfile: `<base-dir>/.cartographer-sync.lock.json` (v2 multi-provider).
 - Pruning is per tracked file, not per whole directory.

--- a/internal/provisioning/hermes_test.go
+++ b/internal/provisioning/hermes_test.go
@@ -128,7 +128,12 @@ func TestApply_HermesDeliveryIsIdempotent(t *testing.T) {
 		t.Fatalf("BuildManifest: %v", err)
 	}
 	baseDir := t.TempDir()
-	first, err := Apply(m, hermesApplyOptions(kbRoot, baseDir, Lock{}))
+	// Apply the provider's own view, as the client does (materializeForProviders):
+	// since D170 the lock records the revision of the manifest actually applied,
+	// so applying the unfiltered manifest and then diffing the filtered one would
+	// compare two different revisions.
+	hm := FilterForProvider(m, configurator.ProviderHermes)
+	first, err := Apply(hm, hermesApplyOptions(kbRoot, baseDir, Lock{}))
 	if err != nil {
 		t.Fatalf("Apply 1: %v", err)
 	}
@@ -140,10 +145,10 @@ func TestApply_HermesDeliveryIsIdempotent(t *testing.T) {
 
 	// Compare only what hermes can materialize: an unsupported kind is not
 	// drift, it simply does not concern the provider.
-	if d := ComputeDiff(FilterForProvider(m, configurator.ProviderHermes), first.NewLock); !d.InSync {
+	if d := ComputeDiff(hm, first.NewLock); !d.InSync {
 		t.Errorf("re-sync of an unchanged manifest is not in sync: %+v", d)
 	}
-	second, err := Apply(m, hermesApplyOptions(kbRoot, baseDir, first.NewLock))
+	second, err := Apply(hm, hermesApplyOptions(kbRoot, baseDir, first.NewLock))
 	if err != nil {
 		t.Fatalf("Apply 2: %v", err)
 	}

--- a/internal/provisioning/provisioning.go
+++ b/internal/provisioning/provisioning.go
@@ -109,6 +109,13 @@ type ManagedFile struct {
 	// against the server, so drift is detectable only from the next server-side
 	// change onward. RFC3339, empty for a normally-recorded entry.
 	AdoptedAt string `json:"adopted_at,omitempty"`
+	// Source is the artifact's provenance ("kb:<name>" or "bundle"), recorded so
+	// `status` can attribute a materialized file to the KB it came from and
+	// `doctor` can spot one left behind by a KB that is no longer bound (D170).
+	// Empty means "unknown": every lockfile written before D170. That is not
+	// drift and never triggers re-materialization — ComputeDiff still compares
+	// ContentHash only — so no migration runs.
+	Source string `json:"source,omitempty"`
 }
 
 // Lock is the client's lockfile: applied revision + managed files.
@@ -1144,10 +1151,51 @@ func ComputeDiff(m Manifest, lock Lock) Diff {
 // materialize isn't "missing", it simply doesn't apply (e.g. hook
 // exists only for Claude Code — D48; agent for Claude Code and OpenCode — D55).
 func FilterForProvider(m Manifest, provider configurator.Provider) Manifest {
-	out := Manifest{Revision: m.Revision}
+	var out Manifest
 	for _, a := range m.Artifacts {
 		if destDir(a.Kind, a.Name, provider) != "" {
 			out.Artifacts = append(out.Artifacts, a)
+		}
+	}
+	// The revision describes the artifacts, so it must be recomputed rather
+	// than inherited (D170). Two providers receiving different sets under one
+	// revision string make ComputeDiff.InSync lie, and — once bindings decide
+	// those sets — changing a binding would not change the revision, so no
+	// drift would ever be detected. Filtering preserves relative order, and m
+	// arrives sorted from MergeArtifacts, so computeRevision's precondition
+	// still holds.
+	out.Revision = computeRevision(out.Artifacts)
+	return out
+}
+
+// SelectForSources keeps the artifacts a provider bound to `allowed` may
+// receive (D170).
+//
+// It must be applied to the per-KB sync_pull responses, BEFORE the merge, and
+// callers must pass only the responses of the allowed KBs. Filtering the merged
+// manifest instead is wrong: MergeArtifacts has already discarded candidates,
+// so if `kb-A` overrides a bundled skill and the provider is bound only to
+// `kb-B`, the merge keeps `kb-A`'s copy and a source filter then deletes it —
+// the provider loses the skill instead of receiving the bundled one. The server
+// performs the same KB-over-bundle merge inside each single-KB pull, so a
+// candidate the client never received cannot be reconstructed.
+//
+// Given that, the check here is a local guarantee rather than the load-bearing
+// one: a bundled artifact reaching this function arrived in an allowed KB's
+// response by construction, and a `kb:` artifact from outside `allowed` would
+// mean the server answered for a KB that was not asked for.
+//
+// `allowed` is always explicit — nil is "no KBs", never a wildcard. Callers
+// resolve the default through clientconfig.Config.BoundKBs.
+func SelectForSources(candidates []Artifact, allowed []string) []Artifact {
+	permitted := make(map[string]bool, len(allowed))
+	for _, kb := range allowed {
+		permitted["kb:"+kb] = true
+	}
+	out := make([]Artifact, 0, len(candidates))
+	for _, a := range candidates {
+		if a.Source == "bundle" || permitted[a.Source] {
+			out = append(out, a)
 		}
 	}
 	return out
@@ -1479,6 +1527,7 @@ func Apply(m Manifest, opts ApplyOptions) (AppliedResult, error) {
 				Path:             rp,
 				ContentHash:      a.ContentHash,
 				MaterializedHash: materializedHash,
+				Source:           a.Source,
 			}
 			newManaged = append(newManaged, mf)
 			result.Written = append(result.Written, mf)
@@ -1673,7 +1722,7 @@ func applyInstructionsGroup(m Manifest, diff Diff, opts ApplyOptions, tracker *e
 		}
 		contentHashes[a.Name] = contentHash
 		*newManaged = append(*newManaged, ManagedFile{
-			Kind: a.Kind, Name: a.Name, Path: destRel, ContentHash: contentHash,
+			Kind: a.Kind, Name: a.Name, Path: destRel, ContentHash: contentHash, Source: a.Source,
 		})
 	}
 
@@ -1728,7 +1777,7 @@ func applyInstructionsGroup(m Manifest, diff Diff, opts ApplyOptions, tracker *e
 
 	for _, a := range signed {
 		result.Written = append(result.Written, ManagedFile{
-			Kind: a.Kind, Name: a.Name, Path: destRel, ContentHash: contentHashes[a.Name],
+			Kind: a.Kind, Name: a.Name, Path: destRel, ContentHash: contentHashes[a.Name], Source: a.Source,
 		})
 	}
 	return nil

--- a/internal/provisioning/provisioning_test.go
+++ b/internal/provisioning/provisioning_test.go
@@ -1263,3 +1263,104 @@ func TestMergeArtifactsStaysTolerant(t *testing.T) {
 		t.Errorf("source = %q, want the alphabetically first kb:one", m.Artifacts[0].Source)
 	}
 }
+
+// --- D170: per-provider projection ---
+
+// TestSelectForSourcesKeepsBundleOverriddenElsewhere is the reason selection
+// happens BEFORE the merge. kb-one overrides a bundled skill; a provider bound
+// only to kb-two must receive the BUNDLED copy — filtering the merged manifest
+// would leave it with nothing, because the merge already discarded the bundle.
+func TestSelectForSourcesKeepsBundleOverriddenElsewhere(t *testing.T) {
+	// What kb-two's own sync_pull returns: the server merged bundle+KB for
+	// kb-two only, so the bundled copy is still there.
+	kbTwoResponse := []provisioning.Artifact{
+		{Kind: "skill", Name: "shared", Source: "bundle", ContentHash: "bundled"},
+		{Kind: "skill", Name: "other", Source: "kb:two", ContentHash: "two"},
+	}
+	selected := provisioning.SelectForSources(kbTwoResponse, []string{"two"})
+	m, err := provisioning.MergeArtifactsStrict(selected)
+	if err != nil {
+		t.Fatalf("MergeArtifactsStrict: %v", err)
+	}
+	var got string
+	for _, a := range m.Artifacts {
+		if a.Name == "shared" {
+			got = a.Source
+		}
+	}
+	if got != "bundle" {
+		t.Errorf("shared came from %q, want the bundled copy", got)
+	}
+}
+
+func TestSelectForSources(t *testing.T) {
+	candidates := []provisioning.Artifact{
+		{Kind: "skill", Name: "a", Source: "kb:one"},
+		{Kind: "skill", Name: "b", Source: "kb:two"},
+		{Kind: "skill", Name: "c", Source: "bundle"},
+	}
+	cases := []struct {
+		name    string
+		allowed []string
+		want    int
+	}{
+		{"one KB plus the bundle", []string{"one"}, 2},
+		{"both KBs plus the bundle", []string{"one", "two"}, 3},
+		{"nil is no KBs, not a wildcard", nil, 1},
+		{"an unknown KB selects only the bundle", []string{"three"}, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := provisioning.SelectForSources(candidates, tc.allowed); len(got) != tc.want {
+				t.Errorf("SelectForSources(%v) = %+v, want %d artifacts", tc.allowed, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFilterForProviderRecomputesRevision: without this, two providers holding
+// different KB sets would sit at the same revision string, ComputeDiff.InSync
+// would lie, and changing a binding would produce no drift at all.
+func TestFilterForProviderRecomputesRevision(t *testing.T) {
+	full := provisioning.MergeArtifacts([]provisioning.Artifact{
+		{Kind: "skill", Name: "a", Source: "kb:one", ContentHash: "h1"},
+		{Kind: "agent", Name: "b", Source: "kb:one", ContentHash: "h2"},
+	})
+	// kiro supports skills but not agents (destinationMatrix), so its view is
+	// a strict subset and must carry a different revision.
+	kiro := provisioning.FilterForProvider(full, configurator.ProviderKiro)
+	claude := provisioning.FilterForProvider(full, configurator.ProviderClaudeCode)
+
+	if kiro.Revision == full.Revision {
+		t.Error("a filtered manifest kept the unfiltered revision")
+	}
+	if claude.Revision != full.Revision {
+		t.Errorf("claude receives every artifact, so its revision must equal the full one: %q vs %q", claude.Revision, full.Revision)
+	}
+	if kiro.Revision == claude.Revision {
+		t.Error("two providers with different views share a revision")
+	}
+}
+
+// TestManagedFileRecordsSource: provenance in the lockfile is what lets status
+// attribute a file to a KB and doctor spot one from a KB no longer bound.
+func TestManagedFileRecordsSource(t *testing.T) {
+	m := provisioning.Manifest{Revision: "r", Artifacts: []provisioning.Artifact{{
+		Kind: "skill", Name: "example", Source: "kb:homelab", ContentHash: "h",
+		Files: []provisioning.ArtifactFile{{Path: "SKILL.md", Content: []byte("# example")}},
+	}}}
+	applied, err := provisioning.Apply(m, provisioning.ApplyOptions{
+		Provider: configurator.ProviderClaudeCode, BaseDir: t.TempDir(), AutoTrust: true, SkipLockWrite: true,
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(applied.NewLock.Managed) == 0 {
+		t.Fatal("nothing was managed")
+	}
+	for _, mf := range applied.NewLock.Managed {
+		if mf.Source != "kb:homelab" {
+			t.Errorf("ManagedFile %s Source = %q, want kb:homelab", mf.Path, mf.Source)
+		}
+	}
+}


### PR DESCRIPTION
Every connected provider received the artifacts of every mounted KB: the client
pulled each KB, merged everything into one manifest (`clientsync.go`), and
applied that same manifest to all of them. The only existing filter was
`FilterForProvider`, by supported *kind*.

## The ordering is the substance

Selection now happens on the per-KB `sync_pull` responses, **before** any merge.
Filtering the merged manifest by source loses data silently: `MergeArtifacts`
deduplicates on `kind+name` and prefers a `kb:` source over `bundle`, so if
`kb-A` overrides a bundled skill and a provider is bound only to `kb-B`, the
merge keeps `kb-A`'s copy and the source filter then deletes it — the provider
ends with **nothing** where it should have received the bundled copy. The server
performs the same KB-over-bundle merge inside each single-KB pull, so the
discarded candidate cannot be reconstructed client-side. Hence `candidateSet`,
which keeps the responses keyed by KB.

## Revision recomputed per provider

`FilterForProvider` inherited `m.Revision`. With per-provider sets that makes
`ComputeDiff.InSync` compare two different manifests under one string and —
worse — means **changing a binding produces no drift at all**. It now recomputes,
and the lock records the revision of the manifest actually applied. This also
fixed a pre-existing incoherence for providers supporting only a subset of kinds.

## The two MCP-entry traps, pinned by tests

- **Shape vs set.** A bare `/mcp` auto-routes only when the *server* mounts
  exactly one KB (`MultiKBServer.Handler`). With four mounted and one bound, the
  client still needs `?kb=`. `entriesForKBs` takes both lists.
- **Removal uses the union.** `managedEntryNames` derives the names this client
  may own from the list it is given, so feeding it a provider's filtered binding
  would orphan an unbound KB's entry permanently.

## Unbinding is free

An unbound KB's artifacts leave the provider's manifest, so `ComputeDiff` marks
them `Removed` and `PruneManaged` deletes them. Only files listed in the lock are
touched, so user-owned files survive. A regression test materializes two KBs,
binds one away, and asserts the other KB's skill disappears while the bound one
stays.

## Also

- `ManagedFile.Source` records provenance (`omitempty`; empty means *unknown*,
  never *wrong*, so no existing machine is flagged on upgrade).
- `status` shows each provider's bound KBs, the binding origin, and a per-KB
  breakdown of what it holds.
- `doctor` gains an `unbound-residue` check.
- `sync --client <provider>` (repeatable) leaves every other provider completely
  untouched — MCP entries, artifacts and lockfile entry alike.
- The default binding resolves against **live** `/health` discovery, not the
  persisted cache: `connect` runs before that cache is refreshed and a dry run
  never refreshes it, so using the cache produced an empty entry set on both.
- A server that does not identify its KBs by name cannot express a binding:
  every provider then receives everything, with a warning, exactly as before.

## Release impact

Every client's revision changes **once**, on the first sync after release,
because it is now computed after filtering. That is a recomputation, not drift.

## Verification

`make fmt && make vet && make test` green. New tests cover: the bundle-override
case that motivated the ordering; `SelectForSources` (nil is *no KBs*, never a
wildcard); per-provider revision divergence; `ManagedFile.Source`; two providers
bound to different KBs receiving disjoint manifests; the default still receiving
everything; an empty binding that never contacts the server; the stale-binding
error naming the provider; unbind-then-prune; `selectProviders`; entry shape vs
set across three server sizes; the empty binding getting no MCP entry; and the
`unbound-residue` check including the pre-D170 lockfile that must stay silent.

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpK3mMfKpbRVttAmkFnHbh
