### PR TITLE
fix(auth): strict validation of the effective authentication configuration (D179)

### DIFF
--- a/cmd/cartographer/serve.go
+++ b/cmd/cartographer/serve.go
@@ -115,6 +115,13 @@ func loadServeConfig(fs *flag.FlagSet, overrides config.FlagOverrides, configFla
 	})
 	config.ApplyFlags(cfg, explicit)
 
+	// Validate the configuration that will actually be served, not just the
+	// YAML: environment- and flag-supplied tokens reach the listener too, and
+	// an invalid one used to widen access rather than stop startup (D179).
+	if err := config.ValidateAuth(cfg.Auth); err != nil {
+		return nil, fmt.Errorf("config: auth: %w", err)
+	}
+
 	return cfg, nil
 }
 
@@ -446,8 +453,16 @@ func serveHTTP(addr string, kbs []*kb.KB, names []string, toolPrefixes []string,
 
 	var store *auth.TokenStore
 	if authOn {
-		store = auth.NewScopedTokenStore(scopedTokensWithRoles(authCfg.Tokens, authCfg.Roles))
-		log.Printf("HTTP auth enabled (%d token(s))", len(authCfg.Tokens))
+		// RequireAuth carries the decision explicitly (D179). Without it the
+		// middleware re-derived enforcement from the token count, which is not
+		// the count resolveAuth decided on: the store drops unusable entries,
+		// so a configuration that asked for authentication could produce an
+		// empty store and serve every request as a local admin.
+		store = auth.NewScopedTokenStore(scopedTokensWithRoles(authCfg.Tokens, authCfg.Roles)).RequireAuth()
+		if store.TokenCount() == 0 {
+			log.Fatal("auth is enabled but no usable token was configured (see auth.tokens, CARTOGRAPHER_TOKENS or --tokens)")
+		}
+		log.Printf("HTTP auth enabled (%d token(s))", store.TokenCount())
 	} else {
 		store = auth.NewTokenStore(nil)
 		log.Print("HTTP auth disabled")
@@ -562,13 +577,11 @@ func scopedTokensWithRoles(specs []config.TokenSpec, roles []config.RoleSpec) []
 		for _, s := range spec.Scopes {
 			scopes = append(scopes, auth.ParseScopes(s)...)
 		}
-		// Fail loud on operator typos: a token that declared scopes but whose
-		// entries all failed to parse would otherwise silently degrade to nil
-		// scopes = full admin access. Warn so the misconfiguration is visible.
-		// A token carrying roles is already bounded, so it is not a typo case.
-		if len(spec.Scopes) > 0 && len(scopes) == 0 && len(spec.Roles) == 0 {
-			log.Printf("WARNING: token %s declares scopes %v but none parsed as kb:<name>:r|rw — this token has FULL ADMIN access; fix the scope syntax", principalID(spec), spec.Scopes)
-		}
+		// The warning this replaces (D118) named the right hazard — a token
+		// whose scopes all failed to parse ended up with full admin access —
+		// but a warning cannot stop a listener from starting. config.ValidateAuth
+		// now refuses the configuration outright (D179), so reaching this point
+		// with unparsed scopes is impossible.
 		var policy auth.Policy
 		for _, name := range spec.Roles {
 			for _, rule := range byName[name].Rules {
@@ -580,6 +593,12 @@ func scopedTokensWithRoles(specs []config.TokenSpec, roles []config.RoleSpec) []
 					Types:    rule.Types,
 				})
 			}
+		}
+		// The pre-scopes admin token is DECLARED here, not inferred downstream
+		// (D179): only this layer can tell "the operator wrote no restriction"
+		// apart from "the restrictions the operator wrote produced nothing".
+		if len(spec.Scopes) == 0 && len(spec.Roles) == 0 {
+			policy.Admin = true
 		}
 		out[i] = auth.ScopedToken{
 			Token:     spec.Token,

--- a/cmd/cartographer/serve_test.go
+++ b/cmd/cartographer/serve_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"flag"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/BeppeTemp/cartographer/internal/config"
@@ -66,5 +68,57 @@ func TestCompleteIdentity(t *testing.T) {
 				t.Fatalf("completeIdentity(%q, %q) error = %v", tc.nameValue, tc.email, err)
 			}
 		})
+	}
+}
+
+// --- D179: the effective configuration is validated, not just the YAML ---
+
+// TestLoadServeConfigValidatesEnvSuppliedScopes: an invalid scope arriving from
+// the environment must stop startup. Validating only at YAML load left every
+// environment- and flag-supplied token unchecked, and an unparsed scope used to
+// widen a token to full admin rather than fail.
+func TestLoadServeConfigValidatesEnvSuppliedScopes(t *testing.T) {
+	cases := []struct {
+		name    string
+		tokens  string
+		wantErr bool
+	}{
+		{"valid scope", "tok|kb:docs:rw", false},
+		{"bare token stays a legacy admin", "tok", false},
+		{"scope missing its access segment", "tok|kb:docs", true},
+		{"unknown access value", "tok|kb:docs:write", true},
+		{"entry with no token half", "|kb:docs:r", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CARTOGRAPHER_TOKENS", tc.tokens)
+			t.Setenv("CARTOGRAPHER_CONFIG", "")
+
+			fs := flag.NewFlagSet("serve", flag.ContinueOnError)
+			_, err := loadServeConfig(fs, config.FlagOverrides{}, "")
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("loadServeConfig err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if err != nil && strings.Contains(err.Error(), "tok") && !strings.Contains(err.Error(), "token 0") {
+				t.Errorf("the diagnostic leaked the token value: %q", err)
+			}
+		})
+	}
+}
+
+// TestScopedTokensWithRolesDeclaresLegacyAdmin: the intent has to be expressed
+// at this layer, because only it can tell "no restriction was written" apart
+// from "the restrictions written produced nothing".
+func TestScopedTokensWithRolesDeclaresLegacyAdmin(t *testing.T) {
+	out := scopedTokensWithRoles([]config.TokenSpec{
+		{Token: "legacy"},
+		{Token: "scoped", Scopes: []string{"kb:docs:r"}},
+	}, nil)
+
+	if !out[0].Policy.Admin {
+		t.Error("a token with neither scopes nor roles must be declared admin")
+	}
+	if out[1].Policy.Admin {
+		t.Error("a scoped token must not be admin")
 	}
 }

--- a/docs/decisions/transport-auth.md
+++ b/docs/decisions/transport-auth.md
@@ -692,3 +692,60 @@ suite that pinned the era machinery byte for byte is replaced by a much smaller 
 asserting only what Cartographer still owns. Issue #118 can be closed as overtaken:
 the cost it existed to remove is gone, and the removal it proposed — which would have
 stranded every un-migrated provider — is no longer necessary.
+
+---
+
+<a id="d179"></a>
+## D179 — Invalid auth configuration fails startup instead of widening access
+
+**Decision.** `config.ValidateAuth` runs on the effective auth configuration —
+after YAML, environment and flags are merged — and refuses empty credentials,
+scopes that are not exactly `kb:<name>:r|rw`, token-less environment entries,
+unknown roles and unknown modes, for every mode including `off`.
+`auth.ParseScopesStrict` is the strict half of the existing grammar.
+Unrestricted access is declared by the caller (`Policy.Admin`), never inferred
+from an empty permission set, and `TokenStore.RequireAuth` makes an enforcing
+store fail closed when it holds no usable token.
+
+**Rationale.**
+
+- **Two paths turned a configuration mistake into more authority.** A token
+  whose declared scopes all failed to parse reached the store with an empty
+  permission set, and the store read that as the pre-scopes admin token — so
+  `scopes: ["kb:finance"]`, a missing `:r`, granted every KB. Separately,
+  `resolveAuth` gated enforcement on the number of *configured records* while
+  the store kept only *usable* ones, so `mode: on` with an empty token value
+  produced an empty store, `IsEnabled()` false, and every request served with a
+  local admin principal.
+- **The ambiguity had to be removed at the layer that can see it.** Only the
+  configuration layer can tell "the operator wrote no restriction" from "the
+  restrictions the operator wrote produced nothing"; both reach the store as an
+  empty policy. So the store stopped guessing and the caller now states intent.
+- **A warning was not enough.** D118 already warned that such a token had full
+  admin access (`scopedTokensWithRoles`). The hazard was correctly identified;
+  a log line simply cannot stop a listener from starting, and this is a
+  fail-open, so it became a startup error.
+- **Validation moved to the effective configuration.** `ValidateAuthRoles` ran
+  only inside `config.Load`, leaving every environment- and flag-supplied token
+  unchecked — which is how a deployment configured entirely through
+  `CARTOGRAPHER_TOKENS` was validated not at all.
+- **An unknown access value is not read access.** `kb:docs:write` used to parse
+  as read. Granting something nobody wrote is the same class of defect as
+  granting everything, so the tolerant parser now discards it and the strict one
+  rejects it.
+- **A token-less `|scopes` entry is retained, not skipped.** Dropping it changed
+  the record count that gates enforcement; carrying it through lets validation
+  refuse it by name.
+- **Validation runs with `mode: off`.** A typo that is harmless today becomes an
+  exposure the day someone enables authentication, and by then nobody is
+  re-reading the file.
+- **Diagnostics never echo a token or a raw scope string.** A scope field is
+  exactly where a credential gets pasted by mistake, and startup output is
+  copied into issues and logs. Tokens are named by index or by `id`.
+
+**Consequences.** A deployment whose auth configuration was invalid — and which
+therefore ran with more authority than written, or with authentication silently
+off — now fails to start with a message naming the offending token and problem.
+That is the intent, and it is the migration note the release needs. Valid
+configurations, including legacy unrestricted tokens and the auth-disabled local
+mode, are unchanged.

--- a/docs/transport-auth.md
+++ b/docs/transport-auth.md
@@ -120,6 +120,31 @@ Tokens can be configured through server YAML or
 
 Send a token only in `Authorization: Bearer <token>`, never in a URL.
 
+### Validation is strict, on the effective configuration
+
+The auth configuration is validated **after** YAML, environment and flags are
+merged — the shape that will actually be served — and an invalid declaration
+stops startup rather than being reinterpreted (D179). Refused:
+
+- an empty or whitespace-only token value;
+- any scope that is not exactly `kb:<name>:r` or `kb:<name>:rw`, including an
+  unknown access value (`kb:docs:write`) and a missing access segment
+  (`kb:docs`) — a partially valid list is refused as a whole, and valid roles on
+  the same token do not excuse a malformed scope;
+- an environment/flag entry with a scope separator but no token (`|kb:docs:r`);
+- a reference to an undeclared role, a duplicate principal id, an unknown auth
+  mode.
+
+Validation runs for every mode, `off` included, so a latent typo does not become
+an exposure the day authentication is enabled. Diagnostics name the offending
+token by index or `id` and never contain a token value or a raw scope string.
+
+When authentication is required, enforcement is carried explicitly: a
+configuration that asked for it and produced no usable credential fails startup,
+and a store that somehow reached the middleware empty refuses every request
+instead of serving them as a local admin. `/health` and the RFC 9728 metadata
+path stay public either way, so probes keep working.
+
 ## Per-KB scopes
 
 A token may carry `kb:<name>:r` or `kb:<name>:rw` scopes. The KB name is its
@@ -137,8 +162,10 @@ auth:
 ```
 
 The environment/flag form is
-`token|kb:homelab:rw;kb:reference:r`. A legacy token with no scopes has full
-access to every mounted KB.
+`token|kb:homelab:rw;kb:reference:r`. A legacy token that declares **neither**
+scopes nor roles has full access to every mounted KB — that absence is the
+declaration. A token that declares restrictions and ends up with none grants
+nothing: unrestricted access is never inferred from an empty policy (D179).
 
 For HTTP requests:
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -107,9 +107,14 @@ func matchesSelector(values []string, value string) bool {
 }
 
 // TokenStore manages valid bearer tokens stored as SHA-256 hashes, each mapped
-// to its per-KB scopes. A nil or empty scope list means full access (admin):
-// the token is not restricted to any KB.
-type TokenStore struct{ hashes map[string]Principal }
+// to the immutable policy it grants. Unrestricted access is declared by the
+// caller (Policy.Admin), never inferred from an empty policy (D179).
+type TokenStore struct {
+	hashes map[string]Principal
+	// required is set by RequireAuth for a deployment that configured
+	// authentication: such a store enforces even when empty (D179).
+	required bool
+}
 
 // ScopedToken pairs a plaintext bearer token with the KB scopes it grants.
 type ScopedToken struct {
@@ -119,19 +124,27 @@ type ScopedToken struct {
 	Policy    Policy
 }
 
-// NewTokenStore creates a token store from plain token strings, each granted full
-// access (nil scopes). If tokens is nil or empty, auth is disabled.
+// NewTokenStore creates a token store from plain token strings, each granted
+// full access. If tokens is nil or empty, auth is disabled.
+//
+// Admin is set explicitly rather than inferred from an empty permission set
+// (D179): a bare token string IS the declaration of an unrestricted token, and
+// stating it here is what lets the store refuse to invent that intent for
+// anyone else.
 func NewTokenStore(tokens []string) *TokenStore {
 	scoped := make([]ScopedToken, 0, len(tokens))
 	for _, t := range tokens {
-		scoped = append(scoped, ScopedToken{Token: t})
+		scoped = append(scoped, ScopedToken{Token: t, Policy: Policy{Admin: true}})
 	}
 	return NewScopedTokenStore(scoped)
 }
 
 // NewScopedTokenStore creates a token store where each token carries its own
-// per-KB scopes. A token with nil/empty Scopes has full access. If tokens is
-// nil or empty, auth is disabled.
+// policy: role-derived permissions, legacy per-KB scopes, or an explicit
+// Policy.Admin. A token whose policy ends up empty grants NOTHING — see the
+// comment inside. Entries with an empty token value are skipped; a caller that
+// requires authentication must mark the store with RequireAuth so an empty
+// result fails closed rather than disabling enforcement.
 func NewScopedTokenStore(tokens []ScopedToken) *TokenStore {
 	ts := &TokenStore{hashes: make(map[string]Principal)}
 	for _, st := range tokens {
@@ -145,11 +158,13 @@ func NewScopedTokenStore(tokens []ScopedToken) *TokenStore {
 				for _, scope := range st.Scopes {
 					policy.Permissions = append(policy.Permissions, Permission{KB: scope.KB, Write: scope.Write})
 				}
-				// A token that carries neither scopes nor permissions is the
-				// pre-scopes admin token: preserve its historical full access.
-				if len(policy.Permissions) == 0 {
-					policy.Admin = true
-				}
+				// Deliberately NOT promoted to admin when the result is empty
+				// (D179). "The operator declared no restriction" and "every
+				// restriction the operator declared failed to parse" both
+				// arrive here as an empty permission set, and inferring admin
+				// from that turned a scope typo into unrestricted access.
+				// The legacy pre-scopes admin token is now declared by its
+				// caller setting Policy.Admin explicitly.
 			}
 			id := st.Principal
 			if id == "" {
@@ -161,9 +176,29 @@ func NewScopedTokenStore(tokens []ScopedToken) *TokenStore {
 	return ts
 }
 
-// IsEnabled returns true if authentication is required.
+// IsEnabled returns true if authentication is enforced for requests.
+//
+// A store built by RequireAuth enforces even when it holds no token, so that a
+// configuration which asked for authentication and produced no usable
+// credential fails closed instead of serving every request as a local admin
+// (D179).
 func (ts *TokenStore) IsEnabled() bool {
-	return len(ts.hashes) > 0
+	return ts.required || len(ts.hashes) > 0
+}
+
+// TokenCount reports how many usable tokens the store holds — the count AFTER
+// unusable entries were dropped, which is the number a caller must check
+// against its own expectations rather than the number of configured records.
+func (ts *TokenStore) TokenCount() int { return len(ts.hashes) }
+
+// RequireAuth marks the store as enforcing regardless of how many tokens it
+// holds. serve calls it whenever auth resolved to "on", so the decision to
+// enforce is carried explicitly instead of being re-derived from the token
+// count — the two disagreed, because the count that gated the decision was of
+// configured records while the store had already dropped the unusable ones.
+func (ts *TokenStore) RequireAuth() *TokenStore {
+	ts.required = true
+	return ts
 }
 
 // Validate checks if the given token is valid. The returned ID is never
@@ -311,23 +346,57 @@ type KBScope struct {
 
 // ParseScopes parses a scope string like "kb:docs:rw kb:notes:r" (or
 // ";"-separated, e.g. "kb:docs:rw;kb:notes:r") into KBScope entries.
+//
+// Malformed components are skipped. That is tolerable ONLY because every
+// configuration path validates with ParseScopesStrict first (D179): on its own,
+// silently dropping a component makes a typo indistinguishable from an absent
+// restriction, and a token whose every restriction vanished used to be read as
+// an unrestricted legacy admin.
 func ParseScopes(scope string) []KBScope {
-	var out []KBScope
+	out, _ := parseScopes(scope)
+	return out
+}
+
+// ParseScopesStrict parses scope and rejects anything ParseScopes would have
+// discarded, naming the offending component. It never includes the whole input
+// in the error: a scope field is a place credentials get pasted by mistake, and
+// a startup error is a place they must not appear.
+func ParseScopesStrict(scope string) ([]KBScope, error) {
+	out, bad := parseScopes(scope)
+	if len(bad) > 0 {
+		return nil, fmt.Errorf("invalid scope %q: want kb:<name>:r|rw", bad[0])
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no scope declared: want kb:<name>:r|rw")
+	}
+	return out, nil
+}
+
+// parseScopes splits scope and reports both the components it understood and
+// the ones it did not, so the tolerant and strict entry points cannot disagree
+// about the grammar.
+func parseScopes(scope string) (parsed []KBScope, malformed []string) {
 	for _, part := range strings.FieldsFunc(scope, func(r rune) bool {
 		return unicode.IsSpace(r) || r == ';'
 	}) {
 		// expected format: kb:<name>:<r|rw>
 		segs := strings.SplitN(part, ":", 3)
 		if len(segs) != 3 || segs[0] != "kb" || segs[1] == "" {
+			malformed = append(malformed, part)
 			continue
 		}
-		ks := KBScope{KB: segs[1]}
-		if segs[2] == "rw" {
-			ks.Write = true
+		switch segs[2] {
+		case "r":
+			parsed = append(parsed, KBScope{KB: segs[1]})
+		case "rw":
+			parsed = append(parsed, KBScope{KB: segs[1], Write: true})
+		default:
+			// An unknown access value ("write", "*", "") is not read access:
+			// reading it as one grants something nobody wrote.
+			malformed = append(malformed, part)
 		}
-		out = append(out, ks)
 	}
-	return out
+	return parsed, malformed
 }
 
 // HasAccess checks if the scopes include at least read (or write) access to the given KB.

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -351,3 +351,117 @@ func TestPolicyAndPrincipalCopiesCannotBeMutated(t *testing.T) {
 		t.Fatal("PrincipalFromContext returned mutable context state")
 	}
 }
+
+// --- D179: invalid auth configuration must not widen access ---
+
+func TestParseScopesStrictRejectsWhatParseScopesDiscards(t *testing.T) {
+	cases := []struct {
+		name  string
+		scope string
+		ok    bool
+	}{
+		{"read", "kb:finance:r", true},
+		{"write", "kb:finance:rw", true},
+		{"several", "kb:a:r kb:b:rw", true},
+		{"missing access segment", "kb:finance", false},
+		{"unknown access value", "kb:finance:write", false},
+		{"empty access value", "kb:finance:", false},
+		{"empty kb name", "kb::r", false},
+		{"wrong prefix", "db:finance:r", false},
+		{"empty string", "", false},
+		{"one valid one not", "kb:a:r kb:b", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseScopesStrict(tc.scope)
+			if (err == nil) != tc.ok {
+				t.Errorf("ParseScopesStrict(%q) err = %v, want ok=%v", tc.scope, err, tc.ok)
+			}
+		})
+	}
+}
+
+// TestParseScopesUnknownAccessIsNotRead: "kb:x:write" used to be read access.
+// Granting something nobody wrote is the same class of bug as granting
+// everything.
+func TestParseScopesUnknownAccessIsNotRead(t *testing.T) {
+	if got := ParseScopes("kb:finance:write"); len(got) != 0 {
+		t.Errorf("ParseScopes = %+v, want nothing for an unknown access value", got)
+	}
+}
+
+// TestEmptyPolicyIsNotAdmin is the core regression: a token whose declared
+// restrictions produced no permission grants NOTHING. Before D179 it was
+// promoted to a legacy admin, so `scopes: ["kb:finance"]` — a typo — meant full
+// access to every KB.
+func TestEmptyPolicyIsNotAdmin(t *testing.T) {
+	ts := NewScopedTokenStore([]ScopedToken{{
+		Token:  "secret-token",
+		Scopes: ParseScopes("kb:finance"), // malformed: yields nothing
+	}})
+	p, ok := ts.PrincipalOf("secret-token")
+	if !ok {
+		t.Fatal("token not found")
+	}
+	if p.Policy.Admin {
+		t.Fatal("a token whose scopes all failed to parse was promoted to admin")
+	}
+	if p.Policy.Allows("finance", "", "", "", false) {
+		t.Error("the empty policy granted read access")
+	}
+}
+
+// TestDeclaredAdminStillWorks: the legacy pre-scopes token keeps full access —
+// it is now declared by the caller rather than inferred from emptiness.
+func TestDeclaredAdminStillWorks(t *testing.T) {
+	ts := NewTokenStore([]string{"legacy-token"})
+	p, ok := ts.PrincipalOf("legacy-token")
+	if !ok {
+		t.Fatal("token not found")
+	}
+	if !p.Policy.Admin {
+		t.Error("a bare token string must remain an unrestricted admin token")
+	}
+}
+
+// TestRequireAuthFailsClosedOnEmptyStore: a deployment that asked for
+// authentication and ended up with no usable token must reject requests, not
+// serve them as a local admin.
+func TestRequireAuthFailsClosedOnEmptyStore(t *testing.T) {
+	ts := NewScopedTokenStore(nil).RequireAuth()
+	if !ts.IsEnabled() {
+		t.Fatal("a required store must report itself enabled even when empty")
+	}
+
+	var reached bool
+	h := ts.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/mcp", nil))
+	if reached {
+		t.Error("an unauthenticated request reached the handler")
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+
+	// Liveness must stay reachable: a probe is not a bypass.
+	reached = false
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	if !reached {
+		t.Error("/health must stay public so probes keep working")
+	}
+}
+
+// TestUnrequiredEmptyStoreStillDisablesAuth: the auth-off path is unchanged —
+// enforcement is only forced when a caller explicitly required it.
+func TestUnrequiredEmptyStoreStillDisablesAuth(t *testing.T) {
+	ts := NewTokenStore(nil)
+	if ts.IsEnabled() {
+		t.Error("an empty store with no requirement must leave auth disabled")
+	}
+}

--- a/internal/config/authvalidate.go
+++ b/internal/config/authvalidate.go
@@ -1,0 +1,54 @@
+package config
+
+// Strict validation of the effective HTTP authentication configuration (D179).
+//
+// It runs on the CONFIGURATION THAT WILL ACTUALLY BE SERVED — after YAML,
+// environment and flags have been merged — because that is the only shape whose
+// mistakes reach a listener. Validating only the YAML left every
+// environment- or flag-supplied token unchecked.
+//
+// The rule throughout: an invalid declaration is an error, never a silently
+// narrower or wider interpretation. Every diagnostic names the offending token
+// by index or principal ID and the category of the problem, and never contains a
+// token value or a raw scope string — a scope field is where a credential gets
+// pasted by mistake, and startup output is where it must not appear.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/BeppeTemp/cartographer/internal/auth"
+)
+
+// ValidateAuth rejects an auth configuration that would grant more than the
+// operator wrote. It is called for every mode, including "off": a latent typo
+// must not become an exposure on the day someone enables authentication.
+func ValidateAuth(a AuthConfig) error {
+	switch a.Mode {
+	case "", "auto", "on", "off":
+	default:
+		return fmt.Errorf("mode %q: want \"auto\", \"on\" or \"off\"", a.Mode)
+	}
+	if err := ValidateAuthRoles(a); err != nil {
+		return err
+	}
+	for i, tok := range a.Tokens {
+		where := fmt.Sprintf("token %d", i)
+		if tok.ID != "" {
+			where = fmt.Sprintf("token %q", tok.ID)
+		}
+		if strings.TrimSpace(tok.Token) == "" {
+			// resolveAuth counts configured records while the store keeps only
+			// usable ones; an empty credential is exactly where those two
+			// numbers diverged, and a store that silently ended up empty
+			// stopped enforcing.
+			return fmt.Errorf("%s: empty token value", where)
+		}
+		for _, scope := range tok.Scopes {
+			if _, err := auth.ParseScopesStrict(scope); err != nil {
+				return fmt.Errorf("%s: %w", where, err)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/config/authvalidate_test.go
+++ b/internal/config/authvalidate_test.go
@@ -1,0 +1,132 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/BeppeTemp/cartographer/internal/config"
+)
+
+// sentinelToken is a stand-in for a real credential. Every negative case
+// asserts it never appears in a diagnostic: a scope field is exactly where a
+// token gets pasted by mistake, and startup output is where it must not show up.
+const sentinelToken = "s3cr3t-do-not-print"
+
+func TestValidateAuthAcceptsValidConfigurations(t *testing.T) {
+	role := config.RoleSpec{Name: "reader", Rules: []config.RuleSpec{{KB: "docs", Access: "r"}}}
+	cases := []struct {
+		name string
+		cfg  config.AuthConfig
+	}{
+		{"no auth at all", config.AuthConfig{}},
+		{"legacy admin token: no scopes, no roles", config.AuthConfig{
+			Mode: "on", Tokens: []config.TokenSpec{{Token: sentinelToken}}}},
+		{"scoped token", config.AuthConfig{
+			Mode: "on", Tokens: []config.TokenSpec{{Token: sentinelToken, Scopes: []string{"kb:docs:rw"}}}}},
+		{"role-only token", config.AuthConfig{
+			Mode: "on", Roles: []config.RoleSpec{role},
+			Tokens: []config.TokenSpec{{Token: sentinelToken, Roles: []string{"reader"}}}}},
+		{"roles and scopes together", config.AuthConfig{
+			Mode: "on", Roles: []config.RoleSpec{role},
+			Tokens: []config.TokenSpec{{Token: sentinelToken, Roles: []string{"reader"}, Scopes: []string{"kb:notes:r"}}}}},
+		{"several scopes in one string", config.AuthConfig{
+			Mode: "on", Tokens: []config.TokenSpec{{Token: sentinelToken, Scopes: []string{"kb:a:r kb:b:rw"}}}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := config.ValidateAuth(tc.cfg); err != nil {
+				t.Errorf("ValidateAuth rejected a valid configuration: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateAuthRejectsWideningConfigurations(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  config.AuthConfig
+		want string
+	}{
+		{
+			// The whole point: this used to become an unrestricted admin token.
+			name: "scope missing its access segment",
+			cfg:  config.AuthConfig{Mode: "on", Tokens: []config.TokenSpec{{Token: sentinelToken, Scopes: []string{"kb:finance"}}}},
+			want: "invalid scope",
+		},
+		{
+			name: "unknown access value",
+			cfg:  config.AuthConfig{Mode: "on", Tokens: []config.TokenSpec{{Token: sentinelToken, Scopes: []string{"kb:finance:write"}}}},
+			want: "invalid scope",
+		},
+		{
+			// One good scope must not excuse a broken one.
+			name: "mixed valid and invalid scopes",
+			cfg:  config.AuthConfig{Mode: "on", Tokens: []config.TokenSpec{{Token: sentinelToken, Scopes: []string{"kb:a:r", "kb:b"}}}},
+			want: "invalid scope",
+		},
+		{
+			// Valid roles must not rescue a malformed scope on the same token.
+			name: "valid roles plus a malformed scope",
+			cfg: config.AuthConfig{Mode: "on",
+				Roles:  []config.RoleSpec{{Name: "reader", Rules: []config.RuleSpec{{KB: "docs", Access: "r"}}}},
+				Tokens: []config.TokenSpec{{Token: sentinelToken, Roles: []string{"reader"}, Scopes: []string{"kb:b"}}}},
+			want: "invalid scope",
+		},
+		{
+			// resolveAuth counted this record; the store dropped it.
+			name: "empty token value",
+			cfg:  config.AuthConfig{Mode: "on", Tokens: []config.TokenSpec{{Token: "", Scopes: []string{"kb:a:r"}}}},
+			want: "empty token value",
+		},
+		{
+			name: "whitespace-only token value",
+			cfg:  config.AuthConfig{Mode: "on", Tokens: []config.TokenSpec{{Token: "   "}}},
+			want: "empty token value",
+		},
+		{
+			name: "unknown role",
+			cfg:  config.AuthConfig{Mode: "on", Tokens: []config.TokenSpec{{Token: sentinelToken, Roles: []string{"nonesuch"}}}},
+			want: "unknown role",
+		},
+		{
+			name: "unknown mode",
+			cfg:  config.AuthConfig{Mode: "onn", Tokens: []config.TokenSpec{{Token: sentinelToken}}},
+			want: "mode",
+		},
+		{
+			// A latent typo must not become an exposure the day auth is turned on.
+			name: "invalid scope is refused even with auth off",
+			cfg:  config.AuthConfig{Mode: "off", Tokens: []config.TokenSpec{{Token: sentinelToken, Scopes: []string{"kb:finance"}}}},
+			want: "invalid scope",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := config.ValidateAuth(tc.cfg)
+			if err == nil {
+				t.Fatal("ValidateAuth accepted a configuration that grants more than declared")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want it to mention %q", err, tc.want)
+			}
+			if strings.Contains(err.Error(), sentinelToken) {
+				t.Errorf("the diagnostic leaked the token value: %q", err)
+			}
+		})
+	}
+}
+
+// TestValidateAuthNamesTheToken: an operator with several tokens needs to know
+// which one, and the ID is the non-secret way to say it.
+func TestValidateAuthNamesTheToken(t *testing.T) {
+	err := config.ValidateAuth(config.AuthConfig{Mode: "on", Tokens: []config.TokenSpec{
+		{Token: "fine", Scopes: []string{"kb:a:r"}},
+		{Token: sentinelToken, ID: "ci-runner", Scopes: []string{"kb:b"}},
+	}})
+	if err == nil {
+		t.Fatal("expected a rejection")
+	}
+	if !strings.Contains(err.Error(), "ci-runner") {
+		t.Errorf("error = %q, want it to name the offending principal", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -612,9 +612,13 @@ func parseTokenSpecs(v string) []TokenSpec {
 			continue
 		}
 		tok, scopeStr, hasScopes := strings.Cut(e, "|")
-		if tok == "" {
+		if tok == "" && !hasScopes {
 			continue
 		}
+		// A "|scopes" entry with no token half is NOT skipped (D179): the
+		// operator wrote something, and dropping it silently changes the token
+		// count that gates enforcement. It is carried through with an empty
+		// value so ValidateAuth refuses it by name.
 		spec := TokenSpec{Token: tok}
 		if hasScopes {
 			for _, s := range strings.Split(scopeStr, ";") {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -384,3 +384,24 @@ func TestRemovedSearchConfigIsIgnored(t *testing.T) {
 		t.Errorf("a stale search block changed the config:\ngot  %+v\nwant %+v", got, want)
 	}
 }
+
+// TestParseTokenSpecsKeepsTokenlessEntry: "|kb:a:r" is an operator writing
+// something, not an absence. Skipping it silently changed the token count that
+// gates enforcement; it is carried through so ValidateAuth can refuse it (D179).
+func TestParseTokenSpecsKeepsTokenlessEntry(t *testing.T) {
+	specs := parseTokenSpecs("|kb:a:r")
+	if len(specs) != 1 {
+		t.Fatalf("parseTokenSpecs = %+v, want the malformed entry retained", specs)
+	}
+	if err := ValidateAuth(AuthConfig{Mode: "on", Tokens: specs}); err == nil {
+		t.Error("ValidateAuth accepted a token-less entry")
+	}
+}
+
+// TestParseTokenSpecsIgnoresPureSeparators: an empty entry from ",," is still
+// nothing at all, and must not become a rejected record.
+func TestParseTokenSpecsIgnoresPureSeparators(t *testing.T) {
+	if specs := parseTokenSpecs("a,,b"); len(specs) != 2 {
+		t.Errorf("parseTokenSpecs = %+v, want two tokens", specs)
+	}
+}


### PR DESCRIPTION
Validates the **effective** authentication configuration — after YAML, environment and flags are merged — and makes unrestricted access something the configuration layer declares explicitly rather than something a lower layer infers.

- `config.ValidateAuth` runs on the merged configuration, for every mode: empty credentials, malformed scopes, token-less `|scopes` entries, unknown roles and unknown modes are refused at startup, naming the offending token by index or id (never echoing a token value or a raw scope string).
- `auth.ParseScopesStrict` is the strict counterpart of the existing tolerant grammar, so the two parsers cannot disagree on what a scope means.
- `Policy.Admin` makes unrestricted access explicit instead of derived from an empty policy.
- `TokenStore.RequireAuth` carries the enforcement decision explicitly. `/health` and the RFC 9728 metadata path stay public.

A configuration that is invalid under these rules no longer starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpK3mMfKpbRVttAmkFnHbh
