### PR TITLE
fix(client): persist search_depth instead of round-tripping it through Extra (D180)

### DIFF
--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -688,6 +688,7 @@ clients:         # per-provider KB binding (D169); absent provider = every known
   claude:
     kbs: [homelab]
 search_roots: ["~/Documents"]   # where repoindex.Scan looks for git clones for {{repo:<key>}} (D75)
+search_depth: 4                 # how many levels repoindex descends from each root (D162); omitted when 0 = the default
 paths: {}                       # manual name -> path mapping for {{path:<name>}} (and an override for {{repo:<key>}}, D75)
 ```
 

--- a/docs/decisions/client-configurator.md
+++ b/docs/decisions/client-configurator.md
@@ -701,3 +701,34 @@ loads unchanged and is migrated on its next write. No projection behaviour
 changes here — bindings are recorded and not yet enforced, which the mutating
 commands state in their own output so the feature is not mistaken for active
 isolation. Enforcement is the filtered projection that follows.
+
+---
+
+<a id="d180"></a>
+## D180 — Every typed client-config field is written by `Save`
+
+**Decision.** `Save` emits `search_depth`, `Load` strips it from `Extra`, and a
+table-driven test asserts that every field of the YAML struct appears in the
+written file.
+
+**Rationale.**
+
+- **The defect was invisible because a second bug hid it.** `SearchDepth` was
+  read (`yamlConfig.SearchDepth`) but missing from the struct `Save` marshals,
+  so it never reached the file from the typed field. It looked fine anyway,
+  because `Load` did not strip `search_depth` from `Extra`, and `Save`'s merge
+  wrote the stale raw value back. A file therefore round-tripped correctly while
+  every programmatic change to the field was silently discarded — including the
+  clamping D162 documents, which could never be persisted, so its warning
+  repeated on every run.
+- **Both halves had to be fixed together.** Fixing only `Save` leaves `Extra`
+  shadowing the field, and the merge would keep the stale copy; fixing only
+  `Load` starts dropping the value from disk entirely.
+- **`Extra` is for genuinely unknown keys.** A known, typed field living there
+  is a latent conflict, not a redundancy.
+- **The guard is a test over the struct, not a comment.** This defect class is
+  invisible on review — an omission from a literal — so the next one fails a
+  test instead of shipping.
+
+**Consequences.** None observable for a hand-written config: `omitempty` means a
+zero `SearchDepth` still writes no key, so existing files are not churned.

--- a/internal/clientconfig/clientconfig.go
+++ b/internal/clientconfig/clientconfig.go
@@ -173,7 +173,7 @@ func Load(dir string) (*Config, error) {
 	if err := yaml.Unmarshal(data, &extra); err != nil {
 		return nil, fmt.Errorf("clientconfig: parse extras %s: %w", Path(dir), err)
 	}
-	for _, key := range []string{"server_url", "server_name", "auth", "token_env", "agents", "kbs", "known_kbs", "clients", "trust", "search_roots", "paths", "signing_keys", "mcp_approvals"} {
+	for _, key := range []string{"server_url", "server_name", "auth", "token_env", "agents", "kbs", "known_kbs", "clients", "trust", "search_roots", "search_depth", "paths", "signing_keys", "mcp_approvals"} {
 		delete(extra, key)
 	}
 	cfg := Config{
@@ -223,6 +223,7 @@ func Save(dir string, cfg *Config) error {
 		Clients:      cfg.Clients,
 		Trust:        &cfg.Trust,
 		SearchRoots:  cfg.SearchRoots,
+		SearchDepth:  cfg.SearchDepth,
 		Paths:        cfg.Paths,
 		SigningKeys:  cfg.SigningKeys,
 		MCPApprovals: cfg.MCPApprovals,

--- a/internal/clientconfig/clientconfig_test.go
+++ b/internal/clientconfig/clientconfig_test.go
@@ -462,3 +462,113 @@ func TestSyncStyleSaveKeepsBindings(t *testing.T) {
 		t.Errorf("binding = %v explicit=%v, want [alpha] explicit=true — the sync overwrote it", kbs, explicit)
 	}
 }
+
+// --- D180: every typed field must survive a write ---
+
+// TestSearchDepthRoundTrips asserts on the BYTES, not on the reloaded struct.
+// SearchDepth was read but omitted from Save's marshalled struct, and the raw
+// value survived through Extra — so a reload looked correct while every
+// programmatic change to the typed field was silently discarded.
+func TestSearchDepthRoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	cfg := clientconfig.Default()
+	cfg.SearchDepth = 6
+	if err := clientconfig.Save(dir, cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	data, err := os.ReadFile(clientconfig.Path(dir))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !strings.Contains(string(data), "search_depth: 6") {
+		t.Errorf("search_depth missing from the written file:\n%s", data)
+	}
+
+	reloaded, err := clientconfig.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if reloaded.SearchDepth != 6 {
+		t.Errorf("SearchDepth = %d, want 6", reloaded.SearchDepth)
+	}
+}
+
+// TestSearchDepthChangeIsPersisted is the case Extra used to mask: the file
+// already carries a value and the typed field is changed.
+func TestSearchDepthChangeIsPersisted(t *testing.T) {
+	dir := t.TempDir()
+	writeConfigFile(t, dir, "server_url: http://localhost:39273/mcp\nsearch_depth: 4\n")
+
+	cfg, err := clientconfig.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.SearchDepth != 4 {
+		t.Fatalf("SearchDepth = %d, want the value from the file", cfg.SearchDepth)
+	}
+	cfg.SearchDepth = 8
+	if err := clientconfig.Save(dir, cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	reloaded, err := clientconfig.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if reloaded.SearchDepth != 8 {
+		t.Errorf("SearchDepth = %d, want 8 — the change was discarded", reloaded.SearchDepth)
+	}
+}
+
+// TestZeroSearchDepthWritesNoKey: zero means "use the default", so an existing
+// file is not churned with a redundant key.
+func TestZeroSearchDepthWritesNoKey(t *testing.T) {
+	dir := t.TempDir()
+	if err := clientconfig.Save(dir, clientconfig.Default()); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	data, err := os.ReadFile(clientconfig.Path(dir))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if strings.Contains(string(data), "search_depth") {
+		t.Errorf("a zero SearchDepth wrote a key:\n%s", data)
+	}
+}
+
+// TestEveryYamlFieldIsWrittenBySave is the guard against the next omission: a
+// field present in the YAML struct but absent from Save's literal round-trips
+// through Extra and looks fine until someone changes it in code.
+func TestEveryYamlFieldIsWrittenBySave(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &clientconfig.Config{
+		ServerURL: "http://example.test/mcp", ServerName: "srv", Auth: true,
+		TokenEnv: "TOK", Agents: []string{"claude"}, KnownKBs: []string{"kb"},
+		Clients:     map[string]clientconfig.ClientBinding{"claude": {KBs: []string{"kb"}}},
+		Trust:       true,
+		SearchRoots: []string{"~/x"}, SearchDepth: 5,
+		Paths:       map[string]string{"n": "/p"},
+		SigningKeys: map[string][]string{"kb": {strings.Repeat("ab", 32)}},
+	}
+	if err := cfg.ApproveMCP("kb", "srv", "hash", time.Now()); err != nil {
+		t.Fatalf("ApproveMCP: %v", err)
+	}
+	if err := clientconfig.Save(dir, cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	data, err := os.ReadFile(clientconfig.Path(dir))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	raw := string(data)
+	for _, key := range []string{
+		"server_url", "server_name", "auth", "token_env", "agents",
+		"known_kbs", "clients", "trust", "search_roots", "search_depth",
+		"paths", "signing_keys", "mcp_approvals",
+	} {
+		if !strings.Contains(raw, key+":") {
+			t.Errorf("Save omitted %q:\n%s", key, raw)
+		}
+	}
+}


### PR DESCRIPTION
`SearchDepth` was read from YAML but absent from the struct `Save` marshals, so it never reached the file from the typed field. A second defect hid the first: `Load` did not strip `search_depth` from `Extra`, and `Save`'s merge wrote the stale raw value back — the file round-tripped correctly while every programmatic change to the field was silently discarded, including the clamping documented in D162, whose warning therefore repeated on every run.

Both halves are fixed together: fixing only `Save` leaves `Extra` shadowing the field, fixing only `Load` starts dropping the value from disk.

A table-driven test now asserts that every field of the YAML struct appears in the bytes `Save` writes, so the next omission fails a test instead of shipping — this class of defect is an absence from a literal and is invisible on review.

No observable change for a hand-written config: `omitempty` means a zero `SearchDepth` still writes no key.

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpK3mMfKpbRVttAmkFnHbh
