### PR TITLE
fix(server): gate multi-KB readiness on the audit sink (D176)

### DIFF
--- a/docs/decisions/deployment-release.md
+++ b/docs/decisions/deployment-release.md
@@ -450,3 +450,42 @@ now expects `print` → `enable` → `kickstart -k`, and
 `TestCmdKBCreateRemoteFailureKeepsScaffold` — both were asserting the old behaviour, which
 is the behaviour this entry reverses. The initial commit message also moved from Italian
 (`init: KB inizializzata`) to English, the only such string on that path.
+
+---
+
+<a id="d176"></a>
+## D176 — The multi-KB readiness path gates on the audit sink too
+
+**Decision.** `MultiKBServer`'s `/health` and `/ready` fold every mounted KB's
+audit state into their verdict, name the degraded KBs, and expose each KB's
+audit state under `kbs[].audit`. The rule itself lives in one place,
+`auditGate`, shared with the single-KB handlers.
+
+**Rationale.**
+
+- **The audit-aware readiness code was unreachable on the HTTP path.** D119 made
+  readiness gate on a required-mode audit sink so an operator, or a
+  `readinessProbe`, notices before the next required-mode call is rejected. Only
+  `Server.handleHealth`/`handleReady` implemented it. `MultiKBServer.Handler`
+  answered `ready` from the mount count alone — and `serveHTTP` builds a
+  `MultiKBServer` unconditionally, with the KB count only deciding the
+  advertised server name. Every HTTP deployment, single-KB ones included, was
+  therefore served by the handler that ignored the gate: a server that would
+  refuse every write reported itself ready and kept receiving traffic.
+- **One degraded KB makes the process not ready.** A probe must return one
+  answer; the conservative one is the only safe choice, and a partially usable
+  process is not a state a `readinessProbe` can express.
+- **The degraded KBs are named.** Collapsing several KBs into one boolean tells
+  an operator that something is wrong and nothing about where to look, which is
+  the failure mode this endpoint exists to prevent.
+- **`/health` stays liveness.** It keeps answering 200 with `status:"ok"` even
+  when not ready: `auth.isPublicPath` exempts it, probes depend on that shape,
+  and a liveness probe must never restart a process over a sink problem.
+- **One shared fold.** Two implementations of one readiness rule is exactly how
+  these two drifted apart; `auditGate` is small enough that sharing it costs
+  nothing and asserting on it is cheap.
+
+**Consequences.** A deployment whose required-mode audit sink is unhealthy starts
+failing its readiness probe instead of silently rejecting writes — the intent,
+and a change worth calling out in the release notes. Deployments with no sink, or
+one in `best_effort` mode, are unaffected.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -510,13 +510,25 @@ to stderr. It does not expose Prometheus metrics or derive token/queue/search
 SLIs from the audit file; the audit log is evidence for compliance review
 (`cartographer audit verify|export`), not a metrics source.
 
-**Liveness vs readiness (D84)**: `/health` is liveness — `status:"ok"` unconditionally (a probe that
-restarted the process on `status != "ok"` must never fire from a KB-mounting issue); it also carries
-a `ready: <bool>` field (single-KB server: always `true`; MultiKB: `len(kbs) > 0`) for callers that
-want both signals from one request. `/ready` is the dedicated readiness endpoint: `200
-{"ready":true}` once at least one KB is mounted, `503 {"ready":false,"kbs":0}` otherwise (e.g. a
-fresh local install with an empty data dir, §Cold start). Point k8s
+**Liveness vs readiness (D84, D119, D176)**: `/health` is liveness — `status:"ok"` unconditionally (a
+probe that restarted the process on `status != "ok"` must never fire from a KB-mounting issue); it
+also carries a `ready: <bool>` field for callers that want both signals from one request. `/ready`
+is the dedicated readiness endpoint: `200 {"ready":true}`, or `503` otherwise. Point k8s
 `livenessProbe` at `/health` and `readinessProbe` at `/ready`.
+
+Two things make a server not ready, and both are reported by either endpoint:
+
+- **no KB mounted** — e.g. a fresh local install with an empty data dir (§Cold start):
+  `503 {"ready":false,"kbs":0}`;
+- **a required-mode audit sink that is unhealthy** (D119) — the server will reject every
+  required-mode call, so readiness fails *before* the next one is refused rather than after.
+  The response names the affected KBs (`"degraded":["<kb>",…]`), and `/health` carries each KB's
+  audit state under `kbs[].audit`, because a single boolean says something is wrong and nothing
+  about where to look.
+
+The audit gate applies on the HTTP path whatever the KB count: `serve` builds a multi-KB server even
+for one mounted KB, so a single-KB HTTP deployment is gated exactly like a multi-KB one (D176). A
+deployment with no audit sink, or one in `best_effort` mode, is unaffected.
 
 **Connected clients (D129)**: `GET /clients` reports which clients have talked to this process,
 with their self-reported name and version, the protocol version and era, a request count and a

--- a/internal/mcpserver/httpserver.go
+++ b/internal/mcpserver/httpserver.go
@@ -46,6 +46,12 @@ func (s *Server) auditState() *audit.State {
 	return &st
 }
 
+// auditGate is the one rule both the single-KB and multi-KB readiness paths
+// apply (D119/D176): no sink contributes nothing, an unhealthy required-mode
+// sink makes the server not ready. Shared because two implementations of one
+// readiness rule is how they drifted apart in the first place.
+func auditGate(st *audit.State) bool { return st == nil || st.Ready }
+
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -53,16 +59,17 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	ready := true // a single-KB server always has its one KB mounted
+	// A single-KB server always has its one KB mounted; only the audit gate
+	// can make it not ready.
+	st := s.auditState()
 	result := map[string]interface{}{
 		"status":  "ok",
 		"version": s.version,
 	}
-	if st := s.auditState(); st != nil {
+	if st != nil {
 		result["audit"] = st
-		ready = ready && st.Ready
 	}
-	result["ready"] = ready
+	result["ready"] = auditGate(st)
 	json.NewEncoder(w).Encode(result)
 }
 
@@ -76,10 +83,10 @@ func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	ready := true
+	st := s.auditState()
+	ready := auditGate(st)
 	var auditInfo interface{}
-	if st := s.auditState(); st != nil {
-		ready = st.Ready
+	if st != nil {
 		auditInfo = st
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -135,6 +142,10 @@ type KBInfo struct {
 	// `cartographer doctor` can report a capability that is off without a
 	// session: a client otherwise has no way to ask.
 	Capabilities map[string]KBCapability `json:"capabilities,omitempty"`
+	// Audit is this KB's audit-sink state when one is attached (D119/D176).
+	// Omitted when there is no sink. Reported per KB rather than folded into a
+	// single boolean so an operator knows where to look.
+	Audit interface{} `json:"audit,omitempty"`
 }
 
 // KBCapability is one gate's state plus the configuration key controlling it.
@@ -148,6 +159,39 @@ type MultiKBServer struct {
 	servers map[string]*Server // one MCP server per KB
 	kbs     []KBInfo
 	version string
+}
+
+// readiness folds every mounted KB's audit state into one verdict, and returns
+// the per-KB view alongside it (D176).
+//
+// Readiness gates on a required-mode audit sink (D119) so an operator — or a
+// readinessProbe — notices before the next required-mode call is rejected. The
+// single-KB handlers did that; this one did not, and serveHTTP builds a
+// MultiKBServer unconditionally, so on the HTTP path the audit-aware code was
+// unreachable and a server that would refuse every write reported itself ready.
+//
+// Any degraded KB makes the process not ready: a probe must pick one answer,
+// and the conservative one is the only safe choice.
+func (m *MultiKBServer) readiness() (ready bool, kbs []KBInfo, degraded []string) {
+	ready = len(m.servers) > 0
+	kbs = make([]KBInfo, len(m.kbs))
+	copy(kbs, m.kbs)
+	for i := range kbs {
+		srv, ok := m.servers[kbs[i].Name]
+		if !ok {
+			continue
+		}
+		st := srv.auditState()
+		if st == nil {
+			continue
+		}
+		kbs[i].Audit = st
+		if !auditGate(st) {
+			ready = false
+			degraded = append(degraded, kbs[i].Name)
+		}
+	}
+	return ready, kbs, degraded
 }
 
 // NewMultiKBServer creates a multi-KB server.
@@ -260,12 +304,16 @@ func (m *MultiKBServer) Handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/health":
+			// Liveness: always 200 with status "ok", even when not ready.
+			// auth.isPublicPath exempts this path, and probes depend on the
+			// shape. Only `ready` reflects the audit gate (D176).
 			w.Header().Set("Content-Type", "application/json")
+			ready, kbs, _ := m.readiness()
 			result := map[string]interface{}{
 				"status":  "ok",
 				"version": m.version,
-				"kbs":     m.kbs,
-				"ready":   len(m.servers) > 0,
+				"kbs":     kbs,
+				"ready":   ready,
 			}
 			json.NewEncoder(w).Encode(result)
 			return
@@ -283,9 +331,16 @@ func (m *MultiKBServer) Handler() http.Handler {
 
 		case r.URL.Path == "/ready":
 			w.Header().Set("Content-Type", "application/json")
-			if len(m.servers) == 0 {
+			ready, _, degraded := m.readiness()
+			if !ready {
 				w.WriteHeader(http.StatusServiceUnavailable)
-				json.NewEncoder(w).Encode(map[string]interface{}{"ready": false, "kbs": 0})
+				body := map[string]interface{}{"ready": false, "kbs": len(m.servers)}
+				if len(degraded) > 0 {
+					// Name them: a single boolean tells an operator that
+					// something is wrong and nothing about where to look.
+					body["degraded"] = degraded
+				}
+				json.NewEncoder(w).Encode(body)
 				return
 			}
 			json.NewEncoder(w).Encode(map[string]interface{}{"ready": true})

--- a/internal/mcpserver/httpserver_test.go
+++ b/internal/mcpserver/httpserver_test.go
@@ -5,9 +5,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/BeppeTemp/cartographer/internal/audit"
 	"github.com/BeppeTemp/cartographer/internal/auth"
 )
 
@@ -468,5 +471,147 @@ func TestClients_NoOverflow(t *testing.T) {
 	}
 	if _, ok := raw["overflow"]; ok {
 		t.Fatalf("'overflow' present in response with 0 overflow")
+	}
+}
+
+// --- D176: readiness accounts for a required-mode audit sink ---
+
+// unhealthyRequiredLog returns an audit log in required mode whose next append
+// fails, which is what makes it report not-ready. The file is opened per append
+// (audit.appendDurable), so making it read-only is enough.
+func unhealthyRequiredLog(t *testing.T) *audit.Log {
+	t.Helper()
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores file permissions, so the append cannot be made to fail")
+	}
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	l, err := audit.OpenWithOptions(path, audit.Options{Mode: "required"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { l.Close() })
+	if err := os.Chmod(path, 0o400); err != nil {
+		t.Fatal(err)
+	}
+	if err := l.Append(audit.Entry{Tool: "x"}); err == nil {
+		t.Fatal("expected the append to fail against a read-only file")
+	}
+	if st := l.State(); st.Ready {
+		t.Fatal("expected the sink to report not-ready")
+	}
+	return l
+}
+
+func TestAuditGate(t *testing.T) {
+	if !auditGate(nil) {
+		t.Error("no sink must not make a server not ready")
+	}
+	if !auditGate(&audit.State{Ready: true}) {
+		t.Error("a healthy sink must not make a server not ready")
+	}
+	if auditGate(&audit.State{Ready: false}) {
+		t.Error("an unhealthy required-mode sink must make a server not ready")
+	}
+}
+
+// TestMultiKB_Ready_GatesOnAuditSink is the defect: the HTTP path always builds
+// a MultiKBServer (serveHTTP), so before D176 a server whose required-mode sink
+// was unhealthy — and which therefore rejects every write — answered ready.
+func TestMultiKB_Ready_GatesOnAuditSink(t *testing.T) {
+	m := NewMultiKBServer("test")
+	healthy := New("test")
+	degraded := New("test")
+	degraded.SetAuditLog(unhealthyRequiredLog(t))
+	m.servers["ok"] = healthy
+	m.servers["broken"] = degraded
+	m.kbs = []KBInfo{{Name: "ok", Status: "normal"}, {Name: "broken", Status: "normal"}}
+
+	rec := httptest.NewRecorder()
+	m.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("/ready status = %d, want 503", rec.Code)
+	}
+	var ready struct {
+		Ready    bool     `json:"ready"`
+		Degraded []string `json:"degraded"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &ready); err != nil {
+		t.Fatal(err)
+	}
+	if ready.Ready {
+		t.Error("ready = true despite a degraded audit sink")
+	}
+	// Naming the KB is the difference between a diagnosis and a mystery.
+	if len(ready.Degraded) != 1 || ready.Degraded[0] != "broken" {
+		t.Errorf("degraded = %v, want [broken]", ready.Degraded)
+	}
+}
+
+// TestMultiKB_Health_StaysLiveWhenNotReady: /health is liveness and is exempt
+// from authentication, so it must keep answering 200 with status "ok" — only
+// `ready` reflects the gate.
+func TestMultiKB_Health_StaysLiveWhenNotReady(t *testing.T) {
+	m := NewMultiKBServer("test")
+	degraded := New("test")
+	degraded.SetAuditLog(unhealthyRequiredLog(t))
+	m.servers["broken"] = degraded
+	m.kbs = []KBInfo{{Name: "broken", Status: "normal"}}
+
+	rec := httptest.NewRecorder()
+	m.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	if rec.Code != http.StatusOK {
+		t.Errorf("/health status = %d, want 200 (liveness)", rec.Code)
+	}
+	var body struct {
+		Status string `json:"status"`
+		Ready  bool   `json:"ready"`
+		KBs    []struct {
+			Name  string `json:"name"`
+			Audit *struct {
+				Ready bool `json:"ready"`
+			} `json:"audit"`
+		} `json:"kbs"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Status != "ok" {
+		t.Errorf("status = %q, want ok", body.Status)
+	}
+	if body.Ready {
+		t.Error("ready = true despite a degraded audit sink")
+	}
+	if len(body.KBs) != 1 || body.KBs[0].Audit == nil || body.KBs[0].Audit.Ready {
+		t.Errorf("per-KB audit state missing or wrong: %+v", body.KBs)
+	}
+}
+
+// TestMultiKB_Ready_SingleKBMountedStillGates: the deployment shape the defect
+// hid in — one KB mounted, served by MultiKBServer all the same.
+func TestMultiKB_Ready_SingleKBMountedStillGates(t *testing.T) {
+	m := NewMultiKBServer("test")
+	only := New("test")
+	only.SetAuditLog(unhealthyRequiredLog(t))
+	m.servers["only"] = only
+	m.kbs = []KBInfo{{Name: "only", Status: "normal"}}
+
+	rec := httptest.NewRecorder()
+	m.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("/ready status = %d, want 503 with a single mounted KB", rec.Code)
+	}
+}
+
+// TestMultiKB_Ready_NoSinkUnaffected: a deployment without an audit sink, or
+// with one in best-effort mode, keeps reporting ready exactly as before.
+func TestMultiKB_Ready_NoSinkUnaffected(t *testing.T) {
+	m := NewMultiKBServer("test")
+	m.servers["ok"] = New("test")
+	m.kbs = []KBInfo{{Name: "ok", Status: "normal"}}
+
+	rec := httptest.NewRecorder()
+	m.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	if rec.Code != http.StatusOK {
+		t.Errorf("/ready status = %d, want 200", rec.Code)
 	}
 }


### PR DESCRIPTION
D119 made readiness gate on a required-mode audit sink, so that an operator — or a `readinessProbe` — notices before the next required-mode call is rejected. Only the single-KB handlers implemented it: `MultiKBServer.Handler` answered `ready` from the mount count alone.

That is not a corner case. `serveHTTP` builds a `MultiKBServer` unconditionally, with the KB count only deciding the advertised server name, so every HTTP deployment — single-KB ones included — was served by the handler that ignored the gate. A server that would refuse every write reported itself ready and kept receiving traffic.

- `/health` and `/ready` now fold every mounted KB's audit state into their verdict. One degraded KB makes the process not ready: a probe must return one answer and the conservative one is the only safe choice.
- The response names the degraded KBs, and `/health` carries each KB's audit state under `kbs[].audit` — a single boolean says something is wrong and nothing about where to look.
- `/health` stays liveness: 200 with status `ok` even when not ready, since `auth.isPublicPath` exempts it and a liveness probe must never restart a process over a sink problem.
- The rule lives in one shared `auditGate` used by both paths: two implementations of one readiness rule is how these drifted apart.

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpK3mMfKpbRVttAmkFnHbh
