### PR TITLE
fix(cli): report the local service's observable state, not a verdict on nothing (D174)

### DIFF
--- a/cmd/cartographer/doctor.go
+++ b/cmd/cartographer/doctor.go
@@ -559,11 +559,21 @@ func checkServer(dir string, cfg *clientconfig.Config, providers []string) []doc
 	configPath := filepath.Join(dir, clientconfig.FileName)
 	facts, err := enumerateKBs(cfg.ServerURL, cfg.Auth, cfg.TokenEnv)
 	if err != nil {
-		return []doctorFinding{{
+		f := doctorFinding{
 			Check: "server", Severity: doctorWarning, Path: configPath,
 			Message: fmt.Sprintf("server %s is unreachable: %s", cfg.ServerURL, err),
 			Fix:     "cartographer service status",
-		}}
+		}
+		// The one configuration that cannot work rather than merely looking
+		// unusual: the client points at this machine, nothing answers, and
+		// there is no local service that ever could (D174). Sending the
+		// operator to `service status` here would only report `installed:
+		// false` — name the cause instead.
+		if noLocalServiceFor(cfg.ServerURL) {
+			f.Message = fmt.Sprintf("server %s is unreachable and no local cartographer service is installed to serve it", cfg.ServerURL)
+			f.Fix = "cartographer service install, or point server_url at a running server"
+		}
+		return []doctorFinding{f}
 	}
 
 	var out []doctorFinding
@@ -585,6 +595,24 @@ func checkServer(dir string, cfg *clientconfig.Config, providers []string) []doc
 		})
 	}
 	return out
+}
+
+// noLocalServiceFor reports whether rawURL names this machine and no native
+// service is installed to answer it.
+//
+// A local service installed while the client points at a REMOTE server is
+// deliberately not a finding: that coexistence is normal (a local test server
+// plus a shared one), and its one real consequence — `kb` commands acting on
+// the wrong data dir — belongs to its own check.
+func noLocalServiceFor(rawURL string) bool {
+	if !isLoopbackURL(rawURL) {
+		return false
+	}
+	st, err := statusServiceFn()
+	if err != nil {
+		return false
+	}
+	return !st.Installed
 }
 
 // checkUnboundResidues: a managed file whose source KB is no longer bound to

--- a/cmd/cartographer/doctor_test.go
+++ b/cmd/cartographer/doctor_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -544,4 +545,34 @@ func TestCheckUnboundResidues(t *testing.T) {
 			t.Errorf("findings = %+v, want none for a default binding", findings)
 		}
 	})
+}
+
+// TestNoLocalServiceFor pins the single combination that is actually broken
+// (D174): the client points at this machine and no local service exists to
+// answer. The three neighbouring combinations are legitimate.
+func TestNoLocalServiceFor(t *testing.T) {
+	cases := []struct {
+		name      string
+		url       string
+		installed bool
+		statusErr error
+		want      bool
+	}{
+		{"loopback with no local service", "http://127.0.0.1:39273/mcp", false, nil, true},
+		{"loopback with a local service", "http://127.0.0.1:39273/mcp", true, nil, false},
+		{"remote server, no local service", "https://cartographer.example.com/mcp", false, nil, false},
+		{"service state unknown", "http://localhost:39273/mcp", false, errors.New("unsupported platform"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			orig := statusServiceFn
+			statusServiceFn = func() (service.Status, error) {
+				return service.Status{Installed: tc.installed}, tc.statusErr
+			}
+			t.Cleanup(func() { statusServiceFn = orig })
+			if got := noLocalServiceFor(tc.url); got != tc.want {
+				t.Errorf("noLocalServiceFor(%q) = %v, want %v", tc.url, got, tc.want)
+			}
+		})
+	}
 }

--- a/cmd/cartographer/service.go
+++ b/cmd/cartographer/service.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/BeppeTemp/cartographer/internal/clientconfig"
 	"github.com/BeppeTemp/cartographer/internal/config"
 	"github.com/BeppeTemp/cartographer/internal/defaults"
 	"github.com/BeppeTemp/cartographer/internal/service"
@@ -250,7 +251,7 @@ func cmdServiceStatus(args []string) int {
 		return exitStatusError
 	}
 
-	s := statusSnapshot{Schema: statusSchema, Client: version, State: "running", Service: &serviceSnapshot{st.Installed, st.Running, st.Healthy, st.HTTPAddr}}
+	s := statusSnapshot{Schema: statusSchema, Client: version, State: "running", Service: newServiceSnapshot(st), ServerURL: clientServerURL()}
 	if !st.Installed {
 		s.State = "not_installed"
 	} else if !st.Running {
@@ -259,11 +260,7 @@ func cmdServiceStatus(args []string) int {
 	if output == "json" {
 		_ = json.NewEncoder(os.Stdout).Encode(s)
 	} else {
-		fmt.Printf("binary:  %s\n", st.BinPath)
-		fmt.Printf("config:  %s\n", st.ConfigPath)
-		fmt.Printf("installed: %v\n", st.Installed)
-		fmt.Printf("running:   %v\n", st.Running)
-		fmt.Printf("healthy:   %v (http %s)\n", st.Healthy, st.HTTPAddr)
+		printServiceStatus(os.Stdout, st, s.ServerURL)
 	}
 
 	if !st.Installed {
@@ -273,6 +270,71 @@ func cmdServiceStatus(args []string) int {
 		return exitStatusStopped
 	}
 	return exitStatusRunning
+}
+
+// printServiceStatus renders the human view of the local native service.
+//
+// It prints a health verdict only for a service that exists: `healthy: false`
+// next to `installed: false` describes the absence of a service, and reads as
+// an outage (D174). serverURL is what the client on this machine points at,
+// printed as context only when it is not this local service — a legitimate
+// configuration (a local test server plus a shared one), never a warning.
+func printServiceStatus(w io.Writer, st service.Status, serverURL string) {
+	fmt.Fprintf(w, "binary:  %s\n", st.BinPath)
+	fmt.Fprintf(w, "config:  %s\n", st.ConfigPath)
+	fmt.Fprintf(w, "installed: %v\n", st.Installed)
+	if st.Installed {
+		fmt.Fprintf(w, "loaded:    %v (known to the init system; not a liveness check)\n", st.Running)
+		fmt.Fprintln(w, serviceHealthLine(st))
+	} else {
+		fmt.Fprintln(w, "no local cartographer service is installed on this machine")
+		fmt.Fprintf(w, "  install one with: cartographer service install --data %s\n", defaultDataDir())
+	}
+	if serverURL != "" && !isLoopbackURL(serverURL) {
+		fmt.Fprintf(w, "client:  configured against %s, which is not this local service\n", serverURL)
+	}
+}
+
+// serviceHealthLine states whether the probe ran. A skipped check is never
+// rendered as `healthy: false`: nothing was measured.
+func serviceHealthLine(st service.Status) string {
+	if st.HealthChecked {
+		return fmt.Sprintf("healthy:   %v (http %s)", st.Healthy, st.HTTPAddr)
+	}
+	return fmt.Sprintf("health:    not checked (%s)", healthSkipExplanation(st.HealthSkipReason))
+}
+
+// healthSkipExplanation turns a machine-readable skip reason into the phrase
+// printed to an operator. An unknown reason is passed through rather than
+// swallowed.
+func healthSkipExplanation(reason string) string {
+	switch reason {
+	case service.HealthSkipStdio:
+		return "server configured for stdio transport: no endpoint to probe"
+	case service.HealthSkipNoConfig:
+		return "no server config at the path above"
+	case service.HealthSkipUnreadableConfig:
+		return "server config could not be read"
+	default:
+		return reason
+	}
+}
+
+// clientServerURL reports what the client config on this machine points at,
+// or "" when there is none to read. `service status` inspects the local
+// service only (widening it would make it ambiguous); this is the context
+// that explains why a working client can coexist with an absent local
+// service.
+func clientServerURL() string {
+	dir, err := clientconfig.TargetDir()
+	if err != nil {
+		return ""
+	}
+	cfg, err := clientconfig.Load(dir)
+	if err != nil {
+		return ""
+	}
+	return cfg.ServerURL
 }
 
 // defaultDataDir returns ~/cartographer-data, the default --data for

--- a/cmd/cartographer/service_test.go
+++ b/cmd/cartographer/service_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -105,5 +106,106 @@ func TestCmdServiceRestart_WaitPrintsSuccessOnlyAfterProof(t *testing.T) {
 
 	if code := cmdServiceRestart([]string{"--wait"}); code != exitStatusError {
 		t.Errorf("exit = %d, want %d", code, exitStatusError)
+	}
+}
+
+// TestPrintServiceStatus covers what the D174 rework is about: never a health
+// verdict on a service that does not exist, never a claim of a live process,
+// and the one context line that explains a remote client.
+func TestPrintServiceStatus(t *testing.T) {
+	cases := []struct {
+		name      string
+		st        service.Status
+		serverURL string
+		want      []string
+		absent    []string
+	}{
+		{
+			name:   "not installed",
+			st:     service.Status{Lifecycle: service.LifecycleNotInstalled, HealthSkipReason: service.HealthSkipNoConfig},
+			want:   []string{"installed: false", "no local cartographer service is installed", "cartographer service install"},
+			absent: []string{"healthy:", "health:", "loaded:"},
+		},
+		{
+			name:   "installed with an http address",
+			st:     service.Status{Installed: true, Running: true, Lifecycle: service.LifecycleLoaded, HealthChecked: true, Healthy: true, HTTPAddr: "127.0.0.1:39273"},
+			want:   []string{"installed: true", "loaded:    true", "healthy:   true (http 127.0.0.1:39273)"},
+			absent: []string{"running:", "not checked"},
+		},
+		{
+			name:   "installed, stdio transport",
+			st:     service.Status{Installed: true, Running: true, Lifecycle: service.LifecycleLoaded, HealthSkipReason: service.HealthSkipStdio},
+			want:   []string{"health:    not checked", "stdio transport"},
+			absent: []string{"healthy:"},
+		},
+		{
+			name:   "installed, config unreadable",
+			st:     service.Status{Installed: true, Lifecycle: service.LifecycleNotLoaded, HealthSkipReason: service.HealthSkipUnreadableConfig},
+			want:   []string{"loaded:    false", "health:    not checked", "could not be read"},
+			absent: []string{"healthy:"},
+		},
+		{
+			name:      "remote client is context, not a warning",
+			st:        service.Status{Installed: true, Running: true, Lifecycle: service.LifecycleLoaded, HealthChecked: true},
+			serverURL: "https://cartographer.example.com/mcp",
+			want:      []string{"client:  configured against https://cartographer.example.com/mcp"},
+			absent:    []string{"warning", "Error"},
+		},
+		{
+			name:      "loopback client gets no context line",
+			st:        service.Status{Installed: true, Running: true, Lifecycle: service.LifecycleLoaded, HealthChecked: true},
+			serverURL: "http://127.0.0.1:39273/mcp",
+			absent:    []string{"client:"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var sb strings.Builder
+			printServiceStatus(&sb, tc.st, tc.serverURL)
+			got := sb.String()
+			for _, w := range tc.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("output missing %q:\n%s", w, got)
+				}
+			}
+			for _, a := range tc.absent {
+				if strings.Contains(got, a) {
+					t.Errorf("output should not contain %q:\n%s", a, got)
+				}
+			}
+		})
+	}
+}
+
+// TestServiceSnapshotContract: `service status --output json` is consumed by
+// scripts. New fields are fine, renamed or re-meaning ones are not.
+func TestServiceSnapshotContract(t *testing.T) {
+	st := service.Status{Installed: true, Running: true, Healthy: true, HTTPAddr: ":39273", Lifecycle: service.LifecycleLoaded, HealthChecked: true}
+	b, err := json.Marshal(newServiceSnapshot(st))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	for k, want := range map[string]any{
+		"installed":      true,
+		"running":        true,
+		"healthy":        true,
+		"http_addr":      ":39273",
+		"lifecycle":      "loaded",
+		"health_checked": true,
+	} {
+		if got[k] != want {
+			t.Errorf("%s = %v, want %v", k, got[k], want)
+		}
+	}
+	// A skipped check must be visible next to the bool it invalidates.
+	b, _ = json.Marshal(newServiceSnapshot(service.Status{Lifecycle: service.LifecycleNotInstalled, HealthSkipReason: service.HealthSkipStdio}))
+	got = map[string]any{}
+	json.Unmarshal(b, &got)
+	if got["health_checked"] != false || got["health_skip_reason"] != "stdio_transport" {
+		t.Errorf("skipped check snapshot = %s", b)
 	}
 }

--- a/cmd/cartographer/status_snapshot.go
+++ b/cmd/cartographer/status_snapshot.go
@@ -12,6 +12,7 @@ import (
 	"github.com/BeppeTemp/cartographer/internal/clientconfig"
 	"github.com/BeppeTemp/cartographer/internal/configurator"
 	"github.com/BeppeTemp/cartographer/internal/provisioning"
+	"github.com/BeppeTemp/cartographer/internal/service"
 )
 
 // statusSchema is deliberately versioned: scripts can reject incompatible
@@ -65,11 +66,35 @@ type statusArtifact struct {
 	Trust  string `json:"trust,omitempty"`
 }
 
+// serviceSnapshot is part of the `service status --output json` contract:
+// fields may be added, existing ones may not change meaning (D174).
+//
+// Healthy is a verdict only when HealthChecked is true; otherwise
+// HealthSkipReason says why nothing was measured. Running means the init
+// system knows the job, which on darwin is not proof of a live process —
+// Lifecycle is the field to read for the observable state.
 type serviceSnapshot struct {
-	Installed bool   `json:"installed"`
-	Running   bool   `json:"running"`
-	Healthy   bool   `json:"healthy"`
-	HTTPAddr  string `json:"http_addr,omitempty"`
+	Installed        bool   `json:"installed"`
+	Running          bool   `json:"running"`
+	Healthy          bool   `json:"healthy"`
+	HTTPAddr         string `json:"http_addr,omitempty"`
+	Lifecycle        string `json:"lifecycle,omitempty"`
+	HealthChecked    bool   `json:"health_checked"`
+	HealthSkipReason string `json:"health_skip_reason,omitempty"`
+}
+
+// newServiceSnapshot projects a service.Status onto the JSON contract. One
+// constructor, so the two call sites cannot drift on a newly added field.
+func newServiceSnapshot(st service.Status) *serviceSnapshot {
+	return &serviceSnapshot{
+		Installed:        st.Installed,
+		Running:          st.Running,
+		Healthy:          st.Healthy,
+		HTTPAddr:         st.HTTPAddr,
+		Lifecycle:        string(st.Lifecycle),
+		HealthChecked:    st.HealthChecked,
+		HealthSkipReason: st.HealthSkipReason,
+	}
 }
 
 // statusSnapshot has no renderer-specific fields and is the single remote
@@ -135,7 +160,7 @@ func snapshotForConfig(dir string, cfg *clientconfig.Config, includeService bool
 	s := statusSnapshot{Schema: statusSchema, Client: version, State: "in_sync", Providers: providerStatuses(cfg), ServerURL: cfg.ServerURL}
 	if includeService && isLoopbackURL(cfg.ServerURL) {
 		if st, err := statusServiceFn(); err == nil {
-			s.Service = &serviceSnapshot{st.Installed, st.Running, st.Healthy, st.HTTPAddr}
+			s.Service = newServiceSnapshot(st)
 		}
 	}
 	health, err := statusHealthFn(cfg)

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -317,7 +317,7 @@ The checks:
 | `mcp-entries` | the Cartographer entries in the provider's native config match the KBs recorded in `.cartographer.yaml` — an entry for a KB the server no longer mounts, or a missing one |
 | `instructions` | exactly one well-formed managed block per provider that has instructions materialized (begin recognized by prefix, so a block written by an older version still counts) |
 | `hooks` | one native registration per managed hook — the D99 double-fire is a registration left outside the managed block by Codex's own rewrite |
-| `server` | `/health` reachable; the recorded `server_version` (D142) against the live one; client binary against server |
+| `server` | `/health` reachable; the recorded `server_version` (D142) against the live one; client binary against server. When an unreachable server is loopback **and** no local native service is installed, the finding names that cause and the two remedies instead of pointing at `service status`, which would only repeat `installed: false` (D174) |
 | `trigger` | every connected provider has a session hook, or the scheduled trigger is installed (D140) |
 | `capability` | every per-KB gate the server advertises on `/health` is on, and no KB was mounted by discovery rather than by a `kbs[]` entry (D151). Info severity: it names the setting that would change it |
 | `symlink` | no managed destination directory is a symlink — provisioning refuses to write through one, so the artifacts it would hold are not installed (D148) |

--- a/docs/decisions/deployment-release.md
+++ b/docs/decisions/deployment-release.md
@@ -489,3 +489,51 @@ audit state under `kbs[].audit`. The rule itself lives in one place,
 failing its readiness probe instead of silently rejecting writes — the intent,
 and a change worth calling out in the release notes. Deployments with no sink, or
 one in `best_effort` mode, are unaffected.
+
+## D174 — `service status` reports observable state, not a verdict on nothing
+
+**Decision.** `cartographer service status` keeps inspecting the **local native
+service only**, and says what it observed rather than rendering everything as a
+pair of booleans. `service.Status` gains `Lifecycle`
+(`not_installed`/`not_loaded`/`loaded`), `HealthChecked` and `HealthSkipReason`;
+the health line is printed only for a service that exists; a client pointed at a
+different server is one line of context. `doctor` names the one combination that
+cannot work.
+
+**Context.** The starting report was a contradiction: a server answering `/health`
+while `service status` said `healthy: false`. There is no contradiction — the two
+speak about different things and both answer correctly, `/health` about the remote
+server in `server_url` and `service status` about the local launchd/systemd job.
+What was genuinely wrong is narrower, and all of it is a presentation defect.
+
+- **No health verdict on what does not exist.** The `healthy` line was printed
+  unconditionally, so a machine with no local service showed `healthy: false
+  (http )`. Read quickly that is an outage; it is an absence. With
+  `installed: false` the output now says there is no local service and how to
+  install one.
+- **`Healthy` conflated "unhealthy" with "not checked".** One boolean carried
+  both meanings whenever the config was missing, unreadable, or configured for
+  stdio. The probe now reports whether it ran, and why not — the root of the
+  misreading was the missing distinction, not the probe.
+- **An empty `http:` is stdio, not "apply the default".** `serve` selects the
+  stdio path exactly when `cfg.HTTP` is empty. Substituting
+  `defaults.DefaultListenAddress` in `Status` would report a health check against
+  an address nothing listens on: a fabricated failure.
+- **`Running` promised more than the probe delivers.** `launchctl print`
+  succeeding proves the job is registered with launchd, not that a process is
+  alive. The JSON field keeps its name (it is a contract) and its printed label
+  became `loaded`, with `lifecycle` as the field to read.
+- **`service status` is not widened to the remote server.** Answering about both
+  would make it ambiguous; the remedy for the misreading is to *say* which one it
+  inspects. A local service alongside a client pointed at a shared remote server
+  is legitimate — context, never a warning.
+- **One `doctor` finding, for the case that is actually broken.** `server_url` is
+  loopback, nothing answers, and no local service is installed: the client points
+  at a server that does not exist. The generic remedy, `service status`, would
+  only repeat `installed: false`. The mirror case — a local service installed
+  while the client points elsewhere — is deliberately not a finding.
+
+**Consequences.** Output and JSON fields only. Existing fields and the
+systemctl-like exit codes (`0`/`3`/`4`) keep their meaning, so `install.sh update`
+is unaffected. A script reading `healthy` should read `health_checked` next to it;
+one that wants the state should read `lifecycle`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -309,7 +309,7 @@ The local mode (D73) uses the binary already installed by `install.sh` as a **us
 
 ```bash
 cartographer service install                 # generates config + plist/unit, starts the server
-cartographer service status                  # binary, config, installed/running/healthy
+cartographer service status                  # binary, config, and the observable state of the local service
 cartographer service start|stop|restart
 cartographer service uninstall               # removes the service; config and data remain
 cartographer kb create <name> --remote <url> # scaffolds a KB in the data dir, pushes it to <url> (D85, D134)
@@ -332,6 +332,15 @@ cartographer kb clone <remote>               # mounts an existing remote KB in t
 Binds to **loopback** by default (`127.0.0.1:39273`) → auth stays in auto-off mode without exposing anything on the network. With an empty (or missing — D83: `serve` creates it and treats it as empty rather than failing) data dir the server starts with 0 KBs — `/health` is still up (liveness: `status:"ok"`) but `/ready` reports `503 {"ready":false}` (D84, §Observability): `cartographer kb create <name> --remote <url>` scaffolds a subfolder KB the same way `serve --kb <path> --init` would (D85) and pushes it to the empty repository at `<url>`, which becomes its `origin` — the remote is mandatory, `--no-remote` being the explicit opt-out for a local-only, non-durable KB (D134) — while `cartographer kb clone <remote>` mounts an existing OKF remote there (D97; `service install` itself prints a hint pointing at creation if it starts with 0 KBs mounted), or add `kbs:` entries to clone remotes (§Bootstrapping a KB) — either way, `service restart` (or `kb create --restart` / `kb clone --restart`, which do this for you and wait for the server to report healthy again) is what makes the new KB visible.
 
 `service status` uses systemctl-like exit codes: `0` running, `3` installed but stopped, `4` not installed — this is what lets `install.sh update` automatically restart only a running service (see §Client installation).
+
+**What `service status` reports** (D174). It inspects the **local native service** and nothing else: the remote server a client points at is a different question, answered by `cartographer status` and `cartographer doctor`. It reports what it observed, never a verdict on what does not exist:
+
+- `installed` — the plist/unit is on disk. When it is `false` the output says there is no local service and how to install one, and prints **no health line**: `healthy: false` next to `installed: false` describes an absence, and reads as an outage.
+- `loaded` — `launchctl print` / `systemctl --user is-active` succeeded. On macOS that proves the job is registered with launchd, **not** that a process is alive. The JSON field keeps its name, `running`, and `lifecycle` (`not_installed` / `not_loaded` / `loaded`) is the field to read.
+- `healthy` — the result of `GET /health` on the address in the server config. It is a verdict only when the probe **ran**: `health_checked` says whether it did, and `health_skip_reason` why not (`config_missing`, `config_unreadable`, `stdio_transport`). An empty `http:` means the server is configured for **stdio**, so there is no endpoint to probe — the default listen address is never substituted, since that would probe an address nothing listens on.
+- `client` — one context line when the `.cartographer.yaml` on this machine points at a server that is not this local service. A local service alongside a client pointed at a shared remote one is a legitimate configuration, reported as context and never as a warning.
+
+The `--output json` shape is a contract: fields are added, existing fields and the exit codes keep their meaning.
 
 **Data/code separation**: the cartographer repo contains no data. KBs live in the data dir (default `~/cartographer-data`); every subdirectory of it is a separate KB. For multiple users on shared KBs, see the k8s topology below — the server configuration is identical, only where it runs changes; one server process is the sole writer of a given working copy, so several instances mean separate clones synchronizing through the same remote, never two writers on one checkout (`concurrency.md` §Writer boundary).
 

--- a/internal/service/manager.go
+++ b/internal/service/manager.go
@@ -560,21 +560,66 @@ func displayVersion(expected string) string {
 	return expected
 }
 
+// Lifecycle names the three observable states of the native service, which
+// two booleans cannot express without one of the four combinations being
+// meaningless. A caller that reads Lifecycle never has to decide what
+// Running means when Installed is false.
+type Lifecycle string
+
+const (
+	// LifecycleNotInstalled: no plist/unit on disk. Nothing else is a fault.
+	LifecycleNotInstalled Lifecycle = "not_installed"
+	// LifecycleNotLoaded: installed, but the init system does not know it.
+	LifecycleNotLoaded Lifecycle = "not_loaded"
+	// LifecycleLoaded: registered with launchd/systemd — see Status.Running
+	// for exactly how much that proves.
+	LifecycleLoaded Lifecycle = "loaded"
+)
+
+// HealthSkip* are the reasons Status did not perform the /health probe. When
+// one is set, Healthy is not a verdict: nothing was measured.
+const (
+	// HealthSkipNoConfig: the server config does not exist yet.
+	HealthSkipNoConfig = "config_missing"
+	// HealthSkipUnreadableConfig: the config exists but could not be parsed.
+	HealthSkipUnreadableConfig = "config_unreadable"
+	// HealthSkipStdio: the server is configured for stdio transport (empty
+	// http:), so there is no endpoint to probe. Substituting the default
+	// listen address here would probe an address nothing listens on.
+	HealthSkipStdio = "stdio_transport"
+)
+
 // Status reports the current state of the service.
+//
+// Healthy is meaningful ONLY when HealthChecked is true. When it is false,
+// HealthSkipReason says why nothing was measured, and Healthy is the zero
+// value rather than a verdict — a single boolean that conflates "unhealthy"
+// with "not checked" is how an absent service came to read as an outage
+// (D174).
+//
+// Running reports that the service is registered with the init system: on
+// darwin `launchctl print` on the label succeeded, on linux `systemctl
+// --user is-active`. On darwin that proves the job is loaded and known to
+// launchd, NOT that a process is currently alive. Callers must not present
+// it as a liveness probe.
 type Status struct {
-	BinPath    string
-	ConfigPath string
-	HTTPAddr   string
-	Installed  bool
-	Running    bool
-	Healthy    bool
+	BinPath          string
+	ConfigPath       string
+	HTTPAddr         string
+	Installed        bool
+	Running          bool
+	Healthy          bool
+	HealthChecked    bool
+	HealthSkipReason string
+	Lifecycle        Lifecycle
 }
 
 // Status inspects the service: whether its plist/unit is installed, whether
-// it's currently running (launchctl print / systemctl is-active), and
+// the init system knows it (launchctl print / systemctl is-active), and
 // whether its /health endpoint responds (read from the config YAML's http
-// address, best-effort — absent/unreadable config just leaves Healthy false
-// and HTTPAddr empty).
+// address). The probe is best-effort and reports whether it ran: an absent,
+// unreadable or stdio-transport config leaves HealthChecked false with a
+// reason, never a bare Healthy: false.
 func (m *Manager) Status(configPath string) (Status, error) {
 	var st Status
 	st.ConfigPath = configPath
@@ -616,8 +661,28 @@ func (m *Manager) Status(configPath string) (Status, error) {
 		return st, fmt.Errorf("service: unsupported platform %q", goos)
 	}
 
-	if cfg, err := config.Load(st.ConfigPath); err == nil {
+	switch st.Installed {
+	case false:
+		st.Lifecycle = LifecycleNotInstalled
+	default:
+		st.Lifecycle = LifecycleNotLoaded
+		if st.Running {
+			st.Lifecycle = LifecycleLoaded
+		}
+	}
+
+	cfg, err := config.Load(st.ConfigPath)
+	switch {
+	case err != nil:
+		st.HealthSkipReason = HealthSkipUnreadableConfig
+		if _, statErr := os.Stat(st.ConfigPath); errors.Is(statErr, os.ErrNotExist) {
+			st.HealthSkipReason = HealthSkipNoConfig
+		}
+	case cfg.HTTP == "":
+		st.HealthSkipReason = HealthSkipStdio
+	default:
 		st.HTTPAddr = cfg.HTTP
+		st.HealthChecked = true
 		st.Healthy = checkHealth(cfg.HTTP)
 	}
 

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1056,3 +1056,114 @@ func TestRenderedDefinitionsCarryTheSamePATH(t *testing.T) {
 		t.Errorf("unit missing Environment=PATH=%s\n---\n%s", want, unit)
 	}
 }
+
+// TestStatus_Lifecycle pins the three observable states. Two booleans admit
+// a fourth combination (not installed but "running") that means nothing;
+// Lifecycle is what callers should read.
+func TestStatus_Lifecycle(t *testing.T) {
+	cases := []struct {
+		name      string
+		installed bool
+		loaded    bool
+		want      Lifecycle
+	}{
+		{"absent", false, false, LifecycleNotInstalled},
+		{"installed but unknown to launchd", true, false, LifecycleNotLoaded},
+		{"loaded", true, true, LifecycleLoaded},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := withTestHome(t, "darwin")
+			if tc.installed {
+				plistPath := filepath.Join(home, "Library", "LaunchAgents", "com.cartographer.serve.plist")
+				os.MkdirAll(filepath.Dir(plistPath), 0o755)
+				os.WriteFile(plistPath, []byte("<plist/>"), 0o644)
+			}
+			m, stub := newTestManager()
+			if !tc.loaded {
+				stub.fail = map[string]bool{"launchctl print": true}
+			}
+			st, err := m.Status(filepath.Join(home, "absent.yaml"))
+			if err != nil {
+				t.Fatalf("Status: %v", err)
+			}
+			if st.Lifecycle != tc.want {
+				t.Errorf("Lifecycle = %q, want %q", st.Lifecycle, tc.want)
+			}
+		})
+	}
+}
+
+// TestStatus_HealthCheckSkipped: every path that cannot probe reports that it
+// did not, instead of leaving a bare Healthy: false that reads as an outage.
+func TestStatus_HealthCheckSkipped(t *testing.T) {
+	cases := []struct {
+		name       string
+		writeConf  bool
+		conf       string
+		wantReason string
+	}{
+		{"no config", false, "", HealthSkipNoConfig},
+		{"unreadable config", true, "http: \"unterminated\n", HealthSkipUnreadableConfig},
+		{"stdio transport", true, "kb: /tmp/kb\n", HealthSkipStdio},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := withTestHome(t, "darwin")
+			configPath := filepath.Join(home, "server.yaml")
+			if tc.writeConf {
+				if err := os.WriteFile(configPath, []byte(tc.conf), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			m, _ := newTestManager()
+			st, err := m.Status(configPath)
+			if err != nil {
+				t.Fatalf("Status: %v", err)
+			}
+			if st.HealthChecked {
+				t.Error("HealthChecked should be false: there was nothing to probe")
+			}
+			if st.HealthSkipReason != tc.wantReason {
+				t.Errorf("HealthSkipReason = %q, want %q", st.HealthSkipReason, tc.wantReason)
+			}
+			// An empty http: means stdio, not "apply the default": reporting
+			// the default listen address would probe an address nothing
+			// listens on.
+			if st.HTTPAddr != "" {
+				t.Errorf("HTTPAddr = %q, want empty", st.HTTPAddr)
+			}
+			if st.Healthy {
+				t.Error("Healthy must stay false when no probe ran")
+			}
+		})
+	}
+}
+
+// TestStatus_HealthChecked: with an address configured the probe runs, and
+// says so, even when the server is not up.
+func TestStatus_HealthChecked(t *testing.T) {
+	home := withTestHome(t, "darwin")
+	configPath := filepath.Join(home, "server.yaml")
+	// Port 1 on loopback: nothing listens, the probe runs and fails fast.
+	if err := os.WriteFile(configPath, []byte("http: \"127.0.0.1:1\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m, _ := newTestManager()
+	st, err := m.Status(configPath)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if !st.HealthChecked {
+		t.Error("HealthChecked should be true: an address was configured")
+	}
+	if st.HealthSkipReason != "" {
+		t.Errorf("HealthSkipReason = %q, want empty", st.HealthSkipReason)
+	}
+	if st.Healthy {
+		t.Error("Healthy should be false: nothing listens on 127.0.0.1:1")
+	}
+	if st.HTTPAddr != "127.0.0.1:1" {
+		t.Errorf("HTTPAddr = %q", st.HTTPAddr)
+	}
+}


### PR DESCRIPTION
The report behind this was a contradiction: a server answering `/health` while `cartographer service status` said `healthy: false`. There is none — `/health` was queried against the **remote** server in `server_url`, `service status` inspects the **local** launchd/systemd job, and both answered correctly. What was genuinely wrong is narrower, and all of it is presentation.

**WP1 — an honest `service status`**

- The `healthy` line was printed unconditionally, so a machine with no local service showed `healthy: false (http )`. That describes an absence and reads as an outage. With `installed: false` the output now says there is no local service and how to install one, and prints no health line.
- `Healthy` conflated *unhealthy* with *not checked*: it stayed false whenever the config was missing, unreadable, or configured for stdio. `service.Status` now reports whether the probe ran (`HealthChecked`) and why not (`HealthSkipReason`).
- An empty `http:` means **stdio**, not "apply the default" — `serve` selects the stdio path exactly when `cfg.HTTP` is empty, so substituting the default listen address would probe an address nothing listens on.
- `Running` promised more than `launchctl print` delivers: a registered job, not a live process. The JSON field keeps its name (contract), its printed label became `loaded`, and `Lifecycle` (`not_installed`/`not_loaded`/`loaded`) is the field to read.
- A client pointed at a different server is **one context line**, never a warning: a local test server alongside a shared remote one is a legitimate setup. `service status` is not widened to answer about both — that would make it ambiguous.

**WP2 — one `doctor` finding, for the case that is actually broken**

Loopback `server_url`, nothing answering, and no local service installed: the client points at a server that does not exist. The generic remedy (`service status`) would only repeat `installed: false`. The mirror case — a local service while the client points elsewhere — is deliberately not a finding.

**Contract**: `newServiceSnapshot` is the single projection onto the JSON shape, so the two call sites cannot drift on a newly added field. Existing fields and the systemctl-like exit codes (`0`/`3`/`4`) are unchanged, so `install.sh update` is unaffected.

Docs: `docs/deployment.md` (§native local service), `docs/configurator.md` (`server` check), D174 in `docs/decisions/deployment-release.md`.

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpK3mMfKpbRVttAmkFnHbh
