### PR TITLE
feat(cli): add `kb rename` — offline, bounded, with an identity preflight (D177)

### DIFF
--- a/cmd/cartographer/kbcmd.go
+++ b/cmd/cartographer/kbcmd.go
@@ -58,8 +58,10 @@ func cmdKB(args []string) int {
 		return cmdKBClone(rest)
 	case "list":
 		return cmdKBList(rest)
+	case "rename":
+		return cmdKBRename(rest)
 	default:
-		fmt.Fprintln(os.Stderr, "Error: usage: cartographer kb create <name> (--remote <url> | --no-remote) [--data <dir>] [--restart]\n       cartographer kb clone <remote> [name] [--data <dir>] [--timeout <d>] [--restart]\n       cartographer kb list [--data <dir>] [--config <path>]")
+		fmt.Fprintln(os.Stderr, "Error: usage: cartographer kb create <name> (--remote <url> | --no-remote) [--data <dir>] [--restart]\n       cartographer kb clone <remote> [name] [--data <dir>] [--timeout <d>] [--restart]\n       cartographer kb list [--data <dir>] [--config <path>]\n       cartographer kb rename <old> <new> [--data <dir>] [--config <path>] [--restart]")
 		return 2
 	}
 }

--- a/cmd/cartographer/kbrename.go
+++ b/cmd/cartographer/kbrename.go
@@ -1,0 +1,376 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/BeppeTemp/cartographer/internal/clientconfig"
+	"github.com/BeppeTemp/cartographer/internal/config"
+	"github.com/BeppeTemp/cartographer/internal/service"
+	"gopkg.in/yaml.v3"
+)
+
+// renamePlan is what the preflight determined, before anything moved. It
+// carries both what the command will change and what it will only report:
+// a KB's name is an identity, and most of the places that use it are
+// configured out of band (D177).
+type renamePlan struct {
+	Old, New         string
+	OldPath, NewPath string
+
+	// ConfigPath is the server config to rewrite, "" when none exists.
+	// EntryIndex is the kbs[] entry to rewrite, -1 when the KB is mounted
+	// by discovery and has no entry at all.
+	ConfigPath string
+	EntryIndex int
+
+	// DerivedPrefix means the tool prefix follows the KB name, so every
+	// tool the agents see is about to be renamed with it.
+	DerivedPrefix        bool
+	OldPrefix, NewPrefix string
+
+	// Scopes/SigningKey/Approvals are references to the old name this
+	// command deliberately does NOT migrate: rewriting an operator's auth
+	// configuration silently would be worse than telling them what to change.
+	Scopes     []string
+	SigningKey bool
+	Approvals  bool
+}
+
+// cmdKBRename implements `cartographer kb rename <old> <new> [--data <dir>]
+// [--config <path>] [--restart]`.
+//
+// It is offline and local: the data dir and the local server config, never a
+// server, a client or a git remote. The git `origin` is untouched — renaming
+// a local mount point is not renaming a repository. The scope is deliberately
+// bounded to the pair (directory, server config), which is the only rollback
+// that can honestly be implemented, with a preflight that reports every other
+// reference it can find (D177).
+func cmdKBRename(args []string) int {
+	old, rest := splitPositional(args, "")
+	newName, rest := splitPositional(rest, "")
+
+	fs := flag.NewFlagSet("kb rename", flag.ExitOnError)
+	dataFlag := fs.String("data", "", "KB data directory (default: the server config's data:, or "+defaultDataDir()+")")
+	configFlag := fs.String("config", "", "Server config YAML to rewrite (default: the standard path)")
+	localFlag := fs.Bool("local", false, "Act on the local data dir even though the client points at a remote server")
+	restartFlag := fs.Bool("restart", false, "Restart the local service and wait until healthy after the rename")
+	fs.Parse(rest)
+
+	if old == "" || newName == "" || fs.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "Usage: cartographer kb rename <old> <new> [--data <dir>] [--config <path>] [--restart]")
+		return 2
+	}
+	if code := checkLocalTarget(*dataFlag, *localFlag); code != 0 {
+		return code
+	}
+	dataDir := *dataFlag
+	if dataDir == "" {
+		dataDir = resolveServerDataDir(*configFlag)
+	}
+
+	plan, err := planKBRename(old, newName, dataDir, *configFlag)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		return 2
+	}
+	printRenamePreflight(os.Stdout, plan)
+
+	if err := applyKBRename(plan); err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		return 1
+	}
+
+	fmt.Printf("KB %q renamed to %q at %s\n", plan.Old, plan.New, plan.NewPath)
+	if plan.EntryIndex >= 0 {
+		fmt.Printf("updated the kbs[] entry in %s\n", plan.ConfigPath)
+	}
+	fmt.Println("every connected client realigns its MCP entries on its next `cartographer sync`.")
+	printPostCreateGuidanceFn(*configFlag, *restartFlag)
+	return 0
+}
+
+// planKBRename validates the rename and collects what it affects, writing
+// nothing. A KB is recognised by data/index.md — the same file kb.Open
+// checks — read directly, because kb.Open self-migrates the repository's
+// git-exclude entry and a preflight must not write into what it inspects.
+func planKBRename(old, newName, dataDir, configPath string) (*renamePlan, error) {
+	if err := validateKBName(old); err != nil {
+		return nil, err
+	}
+	if err := validateKBName(newName); err != nil {
+		return nil, err
+	}
+	if old == newName {
+		return nil, fmt.Errorf("KB %q is already called that", old)
+	}
+
+	p := &renamePlan{
+		Old: old, New: newName,
+		OldPath:    filepath.Join(dataDir, old),
+		NewPath:    filepath.Join(dataDir, newName),
+		EntryIndex: -1,
+	}
+	if _, err := os.Stat(filepath.Join(p.OldPath, "data", "index.md")); err != nil {
+		return nil, fmt.Errorf("%s is not an OKF KB (no data/index.md): nothing to rename", p.OldPath)
+	}
+	if _, err := os.Stat(p.NewPath); err == nil {
+		return nil, fmt.Errorf("%s already exists", p.NewPath)
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	if configPath == "" {
+		if resolved, err := service.ConfigPath(); err == nil {
+			configPath = resolved
+		}
+	}
+	if configPath == "" {
+		return p, nil
+	}
+	if _, err := os.Stat(configPath); errors.Is(err, os.ErrNotExist) {
+		return p, nil
+	}
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("server config %s cannot be read, refusing to rewrite it: %w", configPath, err)
+	}
+	p.ConfigPath = configPath
+
+	if err := locateKBEntry(p, cfg); err != nil {
+		return nil, err
+	}
+	describePrefixChange(p, cfg)
+	p.Scopes = scopeRefs(cfg, old)
+	p.SigningKey, p.Approvals = clientRefs(old)
+	return p, nil
+}
+
+// locateKBEntry finds the kbs[] entry that mounts the KB, by resolved name or
+// by path. More than one match is a refusal: guessing here silently detaches
+// a KB from its configuration. NO match is not a refusal — a KB created by
+// `kb create` or found by discovery legitimately has no entry (D151), and
+// renaming its directory is then the whole job.
+func locateKBEntry(p *renamePlan, cfg *config.Config) error {
+	var matches []int
+	for i, spec := range cfg.KBs {
+		name := resolveKBName(spec, spec.Path)
+		if name == p.Old || (spec.Path != "" && sameDir(spec.Path, p.OldPath)) {
+			matches = append(matches, i)
+		}
+	}
+	if len(matches) > 1 {
+		var found []string
+		for _, i := range matches {
+			found = append(found, fmt.Sprintf("kbs[%d] (name=%q path=%q remote=%q)", i, cfg.KBs[i].Name, cfg.KBs[i].Path, cfg.KBs[i].Remote))
+		}
+		return fmt.Errorf("KB %q matches %d entries in %s: %s — make the intended one unambiguous first",
+			p.Old, len(matches), p.ConfigPath, strings.Join(found, ", "))
+	}
+	if len(matches) == 1 {
+		p.EntryIndex = matches[0]
+	}
+	return nil
+}
+
+// sameDir compares two directory paths after cleaning, tolerating a trailing
+// separator. Symlinks are not resolved: the config's own spelling is what the
+// server uses.
+func sameDir(a, b string) bool {
+	return filepath.Clean(a) == filepath.Clean(b)
+}
+
+// describePrefixChange records whether the MCP tool prefix follows the name.
+// An explicit kbs[].tool_prefix is preserved verbatim by the rewrite and
+// nothing changes for the agents; a derived one renames every tool they see,
+// which is the kind of consequence an operator must be told before it happens.
+func describePrefixChange(p *renamePlan, cfg *config.Config) {
+	var spec config.KBSpec
+	if p.EntryIndex >= 0 {
+		spec = cfg.KBs[p.EntryIndex]
+	}
+	if spec.ToolPrefix != "" || cfg.MCP.ToolPrefixMode != "kb-name" {
+		return
+	}
+	p.DerivedPrefix = true
+	p.OldPrefix = config.SanitizeToolPrefix(p.Old)
+	p.NewPrefix = config.SanitizeToolPrefix(p.New)
+}
+
+// scopeRefs lists the configured tokens whose scopes name the old KB. They
+// are reported, never rewritten: a token is a credential, and editing one on
+// an operator's behalf is not this command's business.
+func scopeRefs(cfg *config.Config, old string) []string {
+	var refs []string
+	prefix := "kb:" + old + ":"
+	for i, tok := range cfg.Auth.Tokens {
+		id := tok.ID
+		if id == "" {
+			id = fmt.Sprintf("tokens[%d]", i)
+		}
+		for _, s := range tok.Scopes {
+			if strings.HasPrefix(s, prefix) {
+				refs = append(refs, fmt.Sprintf("%s: %s", id, s))
+			}
+		}
+	}
+	for _, role := range cfg.Auth.Roles {
+		for i, rule := range role.Rules {
+			if rule.KB == old {
+				refs = append(refs, fmt.Sprintf("role %q rule %d: kb: %s", role.Name, i, rule.KB))
+			}
+		}
+	}
+	return refs
+}
+
+// clientRefs reports whether this machine's client config pins a signing key
+// or an MCP approval under the old KB name. Both are keyed by source KB and
+// neither is migrated by a later sync.
+func clientRefs(old string) (signingKey, approvals bool) {
+	dir, err := clientconfig.TargetDir()
+	if err != nil {
+		return false, false
+	}
+	cfg, err := clientconfig.Load(dir)
+	if err != nil {
+		return false, false
+	}
+	_, signingKey = cfg.SigningKeys[old]
+	_, approvals = cfg.MCPApprovals[old]
+	return signingKey, approvals
+}
+
+// printRenamePreflight states what will change and what the operator must
+// change themselves. The second list is the point: a rename that quietly left
+// an operator with a token scoped to a name nothing answers to would be a
+// worse outcome than a noisy one.
+func printRenamePreflight(w io.Writer, p *renamePlan) {
+	fmt.Fprintf(w, "renaming %s → %s\n", p.OldPath, p.NewPath)
+	switch {
+	case p.ConfigPath == "":
+		fmt.Fprintln(w, "no server config found: only the directory changes")
+	case p.EntryIndex < 0:
+		fmt.Fprintf(w, "%s has no kbs[] entry for this KB (mounted by discovery): only the directory changes\n", p.ConfigPath)
+	default:
+		fmt.Fprintf(w, "%s: rewriting kbs[%d]\n", p.ConfigPath, p.EntryIndex)
+	}
+	if p.DerivedPrefix {
+		fmt.Fprintf(w, "\nWARNING: the MCP tool prefix is derived from the KB name (mcp.tool_prefix_mode: kb-name)\n")
+		fmt.Fprintf(w, "  every tool the agents see is renamed: %s… → %s…\n", p.OldPrefix, p.NewPrefix)
+	}
+	if len(p.Scopes) == 0 && !p.SigningKey && !p.Approvals {
+		return
+	}
+	fmt.Fprintf(w, "\nNOT migrated by this command or by a later sync — update them yourself:\n")
+	for _, s := range p.Scopes {
+		fmt.Fprintf(w, "  auth scope in %s → %s\n", p.ConfigPath, s)
+	}
+	if p.SigningKey {
+		fmt.Fprintf(w, "  signing_keys[%q] in this machine's .cartographer.yaml\n", p.Old)
+	}
+	if p.Approvals {
+		fmt.Fprintf(w, "  mcp_approvals[%q] in this machine's .cartographer.yaml\n", p.Old)
+	}
+}
+
+// applyKBRename moves the directory and rewrites the config entry, or neither.
+// The directory goes first because it is the operation that can fail for
+// reasons outside this process (permissions, a different filesystem); a failed
+// config write is then undone by renaming it back, which is the only rollback
+// this command claims.
+func applyKBRename(p *renamePlan) error {
+	if err := os.Rename(p.OldPath, p.NewPath); err != nil {
+		if errors.Is(err, syscall.EXDEV) {
+			return fmt.Errorf("%s and %s are on different filesystems: move the KB yourself (a recursive copy would silently change the ownership and timestamps of a git repository), then rerun with the directory already in place", p.OldPath, p.NewPath)
+		}
+		return err
+	}
+	if p.EntryIndex < 0 {
+		return nil
+	}
+	if err := rewriteKBEntry(p); err != nil {
+		if back := os.Rename(p.NewPath, p.OldPath); back != nil {
+			return fmt.Errorf("%w (and the directory could not be renamed back: %v — it is now at %s)", err, back, p.NewPath)
+		}
+		return err
+	}
+	return nil
+}
+
+// rewriteKBEntry edits the kbs[] entry in place through a yaml.Node document,
+// so the operator's comments, key order and unmodelled fields survive: a
+// rename must not silently reformat a hand-written server config.
+func rewriteKBEntry(p *renamePlan) error {
+	data, err := os.ReadFile(p.ConfigPath)
+	if err != nil {
+		return err
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("parse %s: %w", p.ConfigPath, err)
+	}
+	entry, err := kbEntryNode(&doc, p.EntryIndex)
+	if err != nil {
+		return fmt.Errorf("%s: %w", p.ConfigPath, err)
+	}
+
+	if path := mapValue(entry, "path"); path != nil {
+		path.Value = p.NewPath
+		path.Tag = "!!str"
+	}
+	if name := mapValue(entry, "name"); name != nil {
+		name.Value = p.New
+		name.Tag = "!!str"
+	} else if mapValue(entry, "remote") != nil {
+		// The name was derived from the remote, which the rename does not
+		// touch: without an explicit name the KB would keep its old identity.
+		entry.Content = append(entry.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "name"},
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: p.New})
+	}
+
+	out, err := yaml.Marshal(&doc)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(p.ConfigPath, out, 0o600)
+}
+
+// kbEntryNode returns the index-th element of the kbs sequence.
+func kbEntryNode(doc *yaml.Node, index int) (*yaml.Node, error) {
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return nil, errors.New("not a YAML document")
+	}
+	kbs := mapValue(doc.Content[0], "kbs")
+	if kbs == nil || kbs.Kind != yaml.SequenceNode {
+		return nil, errors.New("no kbs: sequence")
+	}
+	if index >= len(kbs.Content) {
+		return nil, fmt.Errorf("kbs[%d] is out of range", index)
+	}
+	entry := kbs.Content[index]
+	if entry.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("kbs[%d] is not a mapping", index)
+	}
+	return entry, nil
+}
+
+// mapValue returns the value node for key in a mapping node, or nil.
+func mapValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}

--- a/cmd/cartographer/kbrename_test.go
+++ b/cmd/cartographer/kbrename_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BeppeTemp/cartographer/internal/kb"
+)
+
+// seedRenameKB creates a data dir holding one valid KB called name.
+func seedRenameKB(t *testing.T, name string) string {
+	t.Helper()
+	dataDir := t.TempDir()
+	if _, err := kb.Init(filepath.Join(dataDir, name)); err != nil {
+		t.Fatal(err)
+	}
+	return dataDir
+}
+
+func writeServerConfig(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "server.yaml")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestPlanKBRename_Refusals: every refusal happens before anything moves, and
+// names what to fix.
+func TestPlanKBRename_Refusals(t *testing.T) {
+	if !hasGitBinary() {
+		t.Skip("git not available")
+	}
+	dataDir := seedRenameKB(t, "wiki")
+	if err := os.MkdirAll(filepath.Join(dataDir, "taken"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name       string
+		old, newer string
+		wantErr    string
+	}{
+		{"missing source", "absent", "other", "not an OKF KB"},
+		{"destination exists", "wiki", "taken", "already exists"},
+		{"invalid new name", "wiki", "bad/name", "invalid KB name"},
+		{"same name", "wiki", "wiki", "already called that"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := planKBRename(tc.old, tc.newer, dataDir, filepath.Join(dataDir, "no-config.yaml"))
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err = %v, want one containing %q", err, tc.wantErr)
+			}
+		})
+	}
+
+	// A source that is a directory but not a KB is refused too: renaming it
+	// would move something this command cannot vouch for.
+	if err := os.MkdirAll(filepath.Join(dataDir, "plain"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := planKBRename("plain", "renamed", dataDir, filepath.Join(dataDir, "no-config.yaml")); err == nil {
+		t.Error("a non-KB directory should not be renamable")
+	}
+}
+
+// TestPlanKBRename_AmbiguousConfig: two entries could be the KB, so the
+// command refuses rather than guessing which one to detach from its config.
+func TestPlanKBRename_AmbiguousConfig(t *testing.T) {
+	if !hasGitBinary() {
+		t.Skip("git not available")
+	}
+	dataDir := seedRenameKB(t, "wiki")
+	cfgPath := writeServerConfig(t, "data: "+dataDir+"\nkbs:\n"+
+		"  - path: "+filepath.Join(dataDir, "wiki")+"\n"+
+		"  - path: /elsewhere/wiki\n    name: wiki\n")
+
+	_, err := planKBRename("wiki", "atlas", dataDir, cfgPath)
+	if err == nil || !strings.Contains(err.Error(), "matches 2 entries") {
+		t.Fatalf("err = %v, want an ambiguity refusal", err)
+	}
+	// Nothing moved.
+	if _, statErr := os.Stat(filepath.Join(dataDir, "wiki")); statErr != nil {
+		t.Errorf("the preflight moved the KB: %v", statErr)
+	}
+}
+
+// TestCmdKBRename_HappyPath covers the two shapes: a KB with a kbs[] entry,
+// and one mounted by discovery (created by `kb create`, no entry at all).
+func TestCmdKBRename_HappyPath(t *testing.T) {
+	if !hasGitBinary() {
+		t.Skip("git not available")
+	}
+	t.Run("with a kbs entry", func(t *testing.T) {
+		withClientServerURL(t, "")
+		dataDir := seedRenameKB(t, "wiki")
+		cfgPath := writeServerConfig(t, "# operator's own note\nhttp: \"127.0.0.1:39273\"\ndata: "+dataDir+"\n"+
+			"kbs:\n  - path: "+filepath.Join(dataDir, "wiki")+"\n    tool_prefix: wk\n")
+
+		var code int
+		out := withStdout(t, func() {
+			withNoGuidance(t, func() {
+				code = cmdKBRename([]string{"wiki", "atlas", "--data", dataDir, "--config", cfgPath})
+			})
+		})
+		if code != 0 {
+			t.Fatalf("exit = %d, want 0:\n%s", code, out)
+		}
+		if _, err := os.Stat(filepath.Join(dataDir, "atlas", "data", "index.md")); err != nil {
+			t.Errorf("the KB is not at its new path: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(dataDir, "wiki")); !os.IsNotExist(err) {
+			t.Error("the old directory survived")
+		}
+		body, err := os.ReadFile(cfgPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := string(body)
+		if !strings.Contains(got, filepath.Join(dataDir, "atlas")) {
+			t.Errorf("the config still points at the old path:\n%s", got)
+		}
+		// An explicit tool_prefix is preserved verbatim, and so are the
+		// operator's comments: a rename must not reformat a hand-written file.
+		if !strings.Contains(got, "tool_prefix: wk") {
+			t.Errorf("explicit tool_prefix was not preserved:\n%s", got)
+		}
+		if !strings.Contains(got, "operator's own note") {
+			t.Errorf("the operator's comment was dropped:\n%s", got)
+		}
+	})
+
+	t.Run("mounted by discovery", func(t *testing.T) {
+		withClientServerURL(t, "")
+		dataDir := seedRenameKB(t, "wiki")
+		cfgPath := writeServerConfig(t, "data: "+dataDir+"\n")
+
+		var code int
+		out := withStdout(t, func() {
+			withNoGuidance(t, func() {
+				code = cmdKBRename([]string{"wiki", "atlas", "--data", dataDir, "--config", cfgPath})
+			})
+		})
+		if code != 0 {
+			t.Fatalf("exit = %d, want 0:\n%s", code, out)
+		}
+		if !strings.Contains(out, "no kbs[] entry") {
+			t.Errorf("a discovered KB should be reported as such:\n%s", out)
+		}
+		if _, err := os.Stat(filepath.Join(dataDir, "atlas")); err != nil {
+			t.Errorf("the KB was not renamed: %v", err)
+		}
+	})
+}
+
+// TestPlanKBRename_ReportsWhatItDoesNotMigrate: a derived tool prefix renames
+// every tool the agents see, and auth scopes are not rewritten by anyone.
+func TestPlanKBRename_ReportsWhatItDoesNotMigrate(t *testing.T) {
+	if !hasGitBinary() {
+		t.Skip("git not available")
+	}
+	withClientServerURL(t, "")
+	dataDir := seedRenameKB(t, "wiki")
+	cfgPath := writeServerConfig(t, "data: "+dataDir+"\n"+
+		"mcp:\n  tool_prefix_mode: kb-name\n"+
+		"auth:\n  mode: \"on\"\n  tokens:\n    - token: s3cret\n      id: ops\n      scopes: [\"kb:wiki:rw\"]\n"+
+		"kbs:\n  - path: "+filepath.Join(dataDir, "wiki")+"\n")
+
+	p, err := planKBRename("wiki", "atlas", dataDir, cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !p.DerivedPrefix || p.OldPrefix == "" || p.NewPrefix == "" {
+		t.Errorf("a derived prefix should be announced: %+v", p)
+	}
+	if len(p.Scopes) != 1 || !strings.Contains(p.Scopes[0], "ops") {
+		t.Errorf("the scoped token should be reported: %v", p.Scopes)
+	}
+
+	var sb strings.Builder
+	printRenamePreflight(&sb, p)
+	out := sb.String()
+	for _, want := range []string{"WARNING", "kb:wiki:rw", "NOT migrated"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("preflight is missing %q:\n%s", want, out)
+		}
+	}
+	// The preflight wrote nothing.
+	if _, err := os.Stat(filepath.Join(dataDir, "wiki")); err != nil {
+		t.Errorf("the preflight moved the KB: %v", err)
+	}
+}
+
+// TestApplyKBRename_RollsBackOnConfigFailure: directory and config change
+// together or not at all. An unwritable config leaves the KB under its
+// original name.
+func TestApplyKBRename_RollsBackOnConfigFailure(t *testing.T) {
+	if !hasGitBinary() {
+		t.Skip("git not available")
+	}
+	dataDir := seedRenameKB(t, "wiki")
+	cfgDir := t.TempDir()
+	cfgPath := filepath.Join(cfgDir, "server.yaml")
+	if err := os.WriteFile(cfgPath, []byte("kbs:\n  - path: "+filepath.Join(dataDir, "wiki")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the file mode this test relies on")
+	}
+	if err := os.Chmod(cfgPath, 0o400); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(cfgPath, 0o600) })
+
+	p := &renamePlan{
+		Old: "wiki", New: "atlas",
+		OldPath:    filepath.Join(dataDir, "wiki"),
+		NewPath:    filepath.Join(dataDir, "atlas"),
+		ConfigPath: cfgPath,
+		EntryIndex: 0,
+	}
+	if err := applyKBRename(p); err == nil {
+		t.Fatal("a config that cannot be written should fail the rename")
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "wiki", "data", "index.md")); err != nil {
+		t.Errorf("the directory was not renamed back: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "atlas")); !os.IsNotExist(err) {
+		t.Error("the new directory survived a rolled-back rename")
+	}
+}

--- a/docs/decisions/deployment-release.md
+++ b/docs/decisions/deployment-release.md
@@ -591,3 +591,55 @@ CLI could observe.
 `--timeout`), and a guard that starts **failing** a usage which is silently
 ineffective today — worth naming in the release notes together with `--local`.
 `kb create --remote` stays mandatory (D134); this changes nothing about it.
+
+## D177 — `kb rename` is offline, bounded, and says what it does not migrate
+
+**Decision.** `cartographer kb rename <old> <new>` renames a KB's mount point —
+the directory and the matching `kbs[]` entry, together or neither — after a
+preflight that reports every other reference to the name it can find. It never
+contacts a server, a client or a git remote.
+
+**Context.** Renaming a KB meant moving the directory by hand and editing
+`server.yaml`, with nothing checking that the two stayed consistent and no way to
+see what else depended on the old name. A KB's name is an identity: the HTTP
+endpoint (`/mcp?kb=`, `/mcp/<name>`), the derived tool prefix, auth scopes
+`kb:<name>:r|rw`, and the client-side `signing_keys` / `mcp_approvals` keys.
+
+- **Bounded scope, honest rollback.** Directory plus server config, both local,
+  is the only pair this command can undo. A command that promises to fix
+  everything is one that will half-fix something, so everything else is reported
+  instead: scopes, role rules and client-side pins are configured out of band and
+  are not rewritten here or by a later sync. Silently editing an operator's auth
+  configuration would be the worse failure.
+- **Offline by construction.** The git `origin` is untouched — renaming a local
+  mount point is not renaming a repository — and clients need no orchestration:
+  `removeMCPEntries` + `applyMCPEntries` already perform the rename on the next
+  sync, so driving them from here would duplicate a mechanism that works.
+- **The directory moves first.** It is the step that can fail for reasons outside
+  the process (permissions, a different filesystem). A failed config write renames
+  it back; that is the only rollback claimed, and it is implemented.
+- **A cross-device rename fails.** Falling back to a recursive copy would silently
+  change the ownership and timestamps of a git repository. The operator is told to
+  move it themselves.
+- **Ambiguity refuses, absence does not.** Two `kbs[]` entries that could both be
+  the KB is a refusal naming them, because guessing detaches a KB from its
+  configuration. **No** entry is not: a KB created by `kb create` or found by
+  discovery legitimately has none (D151), and refusing there would make the
+  command useless in its most common case — the directory rename is then the whole
+  job, and the output says so.
+- **A derived prefix is announced, not prevented.** With
+  `mcp.tool_prefix_mode: kb-name` the rename renames every tool the agents see.
+  That is a legitimate consequence of renaming a KB; the failure mode to avoid is
+  discovering it afterwards, so both prefixes are printed first. An explicit
+  `kbs[].tool_prefix` is preserved verbatim.
+- **The preflight writes nothing**, including no `kb.Open` — which self-migrates a
+  repository's git-exclude entry. Validity is read from `data/index.md` directly,
+  the same file `Open` checks.
+- **The config is edited as a YAML node tree**, so comments, key order and
+  unmodelled fields survive: a rename must not reformat a hand-written server
+  config.
+- **No restart.** `--restart` is offered, mirroring `kb create`/`kb clone`, and a
+  failed restart does not roll the rename back: the files are already consistent,
+  and undoing them because a supervisor misbehaved would leave a worse state.
+
+**Consequences.** A new subcommand; nothing existing changes behaviour. Minor.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -197,6 +197,8 @@ pure noise — so a single-KB deployment keeps bare tool names; adding a second 
 first one's tools, and that rename is announced at startup rather than happening silently.
 `mcp.tool_prefix_mode: off` is retained as the documented opt-out.
 
+**Renaming a KB renames its derived prefix.** With `tool_prefix_mode: kb-name`, `cartographer kb rename` changes every tool name the agents see, in exactly the way adding a second KB does. The command prints the old and new prefix before acting (D177); an explicit `kbs[].tool_prefix` is immune, since it does not follow the name.
+
 *Upgrading from 0.8.x:* a multi-KB deployment will see tool names change on first start. The
 generated steering block follows automatically (it is rendered with each KB's effective prefix), but
 **hand-written tool citations inside skill bodies are not rewritten** and must be updated — the
@@ -315,6 +317,7 @@ cartographer service uninstall               # removes the service; config and d
 cartographer kb create <name> --remote <url> # scaffolds a KB in the data dir, pushes it to <url> (D85, D134)
 cartographer kb clone <remote>               # mounts an existing remote KB in that data dir (D97)
 cartographer kb list                         # what is on disk, and what the server actually serves (D173)
+cartographer kb rename <old> <new>           # renames the mount point: directory + kbs[] entry (D177)
 ```
 
 `service install` (idempotent: re-running it rewrites the plist/unit and restarts):
@@ -335,6 +338,12 @@ Binds to **loopback** by default (`127.0.0.1:39273`) → auth stays in auto-off 
 **The `kb` commands act on the LOCAL server's data dir** (D173). They take `--config <path>` to name the server config to read `data:` from, mirroring `service install`/`service status`: without it a service installed at a custom config path is invisible, and the command reports `KB "x" mounted at …` about a directory no running server reads. On a machine whose `.cartographer.yaml` points at a **remote** server they refuse to run, since mounting a KB on that server is an operation on its deployment — `--local` is the explicit opt-out, and `--data <dir>` (naming the target outright) bypasses the question.
 
 `kb clone` is bounded: `--timeout` (default 120s) caps the whole operation, `GIT_TERMINAL_PROMPT=0` and, for ssh remotes, `BatchMode=yes -o ConnectTimeout=10` make git fail instead of blocking on a credential or host-key prompt, and progress is streamed as it happens. Host-key *policy* is left to the operator's ssh config: `accept-new` would trade a hang for a silent trust-on-first-use decision. Recognised failures (DNS, SSH key, host key, repository not found, authentication) are reported with a remedy, and an interrupt removes the partial clone it created — never a directory that was already there. A pre-existing `GIT_SSH_COMMAND` is never overwritten.
+
+`kb rename <old> <new> [--data <dir>] [--config <path>] [--restart]` renames a KB's **mount point**: the directory and the matching `kbs[]` entry, together or neither (D177). It is offline and local — it never contacts a server, a client or a git remote, and the git `origin` is untouched: renaming a mount point is not renaming a repository. A cross-filesystem move fails explicitly rather than falling back to a recursive copy, which would silently change the ownership and timestamps of a git repository.
+
+Before moving anything it reports what else the name is an identity for. An explicit `kbs[].tool_prefix` is preserved verbatim; a **derived** one (`mcp.tool_prefix_mode: kb-name`) changes with the name, so every tool the agents see is renamed and the command says so with both prefixes. Auth scopes (`kb:<old>:r|rw`), role rules, client `signing_keys` pins and `mcp_approvals` entries are **listed, never rewritten**: they are configured out of band, and silently editing an operator's auth configuration would be worse than telling them what to change. Clients' MCP entries need no orchestration — they reconcile on the next `cartographer sync`.
+
+Two entries that could both be the KB is a refusal, naming them: guessing there silently detaches a KB from its configuration. **No** entry is not a refusal — a KB created by `kb create` or found by discovery legitimately has none, and renaming its directory is then the whole job.
 
 `kb list [--data <dir>] [--config <path>]` prints one row per subdirectory of the data dir — name, whether it is an OKF KB (`data/index.md`), whether it is a git repository, its `origin` — and a `MOUNTED` column when the server answers `/health`. When it does not, the column disappears and the reason is printed: absence of the signal is not evidence that nothing is mounted. The command writes **nothing**: a missing data dir is reported rather than created, and no repository is opened (which would migrate its git-exclude entry as a side effect).
 


### PR DESCRIPTION
Renaming a KB meant moving the directory by hand and editing `server.yaml`, with nothing checking the two stayed consistent and no way to see what else depended on the old name. A KB's name is an identity: the HTTP endpoint (`/mcp?kb=`, `/mcp/<name>`), the derived tool prefix, auth scopes `kb:<name>:r|rw`, and the client-side `signing_keys` / `mcp_approvals` keys.

`cartographer kb rename <old> <new> [--data <dir>] [--config <path>] [--restart]` renames the **mount point** — directory plus the matching `kbs[]` entry, together or neither — and reports the rest.

**WP1 — identity preflight** (writes nothing)

- `<new>` is a valid KB name and its directory does not exist; `<old>` is an OKF KB, recognised by `data/index.md` read directly — never `kb.Open`, which self-migrates a repository's git-exclude entry.
- The `kbs[]` entry is located by resolved name or by path. **Two** entries that could both be the KB is a refusal naming them: guessing there silently detaches a KB from its configuration. **No** entry is deliberately *not* a refusal — a KB created by `kb create` or found by discovery legitimately has none (D151), and refusing would make the command useless in its most common case.
- It then reports what it will not migrate: a derived tool prefix (`mcp.tool_prefix_mode: kb-name`) renames every tool the agents see, so both prefixes are printed first; auth scopes, role rules and client-side pins are listed, never rewritten — silently editing an operator's auth configuration would be the worse failure. An explicit `kbs[].tool_prefix` is immune and preserved verbatim.

**WP2 — the move, with the one rollback that is real**

The directory moves first, being the step that can fail for reasons outside the process; a failed config write renames it back. A cross-device rename fails explicitly rather than falling back to a recursive copy, which would silently change a git repository's ownership and timestamps. The config is edited as a `yaml.Node` tree, so the operator's comments, key order and unmodelled fields survive — a test pins that. `--restart` mirrors `kb create`/`kb clone`, and a failed restart does not roll the rename back: the files are already consistent.

Offline by construction: no server, no client, no git remote, and `origin` untouched — renaming a local mount point is not renaming a repository. Clients reconcile their MCP entries on the next `cartographer sync`, which already performs that rename.

Docs: `docs/deployment.md` (§`kb` commands and §MCP tool-name prefix), D177 in `docs/decisions/deployment-release.md`.

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpK3mMfKpbRVttAmkFnHbh
