### PR TITLE
fix(sync): order the writes, checkpoint per provider, and serialize client state (D172)

### DIFF
--- a/cmd/cartographer/clientsync.go
+++ b/cmd/cartographer/clientsync.go
@@ -424,6 +424,7 @@ func materializeForProviders(manifests map[string]provisioning.Manifest, provide
 			return nil, err
 		}
 	}
+	var appliedSoFar []string
 	for _, p := range providers {
 		previous := lockFile.ForProvider(p)
 		opts := provisioning.ApplyOptions{
@@ -446,6 +447,11 @@ func materializeForProviders(manifests map[string]provisioning.Manifest, provide
 		// simply don't concern it.
 		applied, err := provisioning.Apply(provisioning.FilterForProvider(manifests[p], configurator.Provider(p)), opts)
 		if err != nil {
+			// Name what is already recorded, so a rerun is informed rather
+			// than a guess about how far the previous one got.
+			if len(appliedSoFar) > 0 {
+				return nil, fmt.Errorf("apply %s: %w (already applied and recorded: %s)", p, err, strings.Join(appliedSoFar, ", "))
+			}
 			return nil, fmt.Errorf("apply %s: %w", p, err)
 		}
 		// Record the base dir only when it is not the lockfile's own
@@ -462,11 +468,18 @@ func materializeForProviders(manifests map[string]provisioning.Manifest, provide
 		}
 		lockFile.SetProvider(p, applied.NewLock)
 		results[p] = applied
-	}
 
-	if !dryRun {
-		if err := provisioning.WriteLockFile(lockPath, lockFile); err != nil {
-			return nil, fmt.Errorf("write lockfile: %w", err)
+		// Checkpoint after every provider, not once at the end (D172). With a
+		// single trailing write, a failure on provider N left providers
+		// 1..N-1 with files on disk and NO lock entry: unmanaged files that
+		// nothing prunes and doctor cannot see. This protects COMPLETED
+		// providers; it does not make one Apply atomic, so the failed
+		// provider's own partial files are still possible (D178).
+		if !dryRun {
+			if err := provisioning.WriteLockFile(lockPath, lockFile); err != nil {
+				return nil, fmt.Errorf("write lockfile after %s: %w", p, err)
+			}
+			appliedSoFar = append(appliedSoFar, p)
 		}
 	}
 	return results, nil

--- a/cmd/cartographer/clientsync_test.go
+++ b/cmd/cartographer/clientsync_test.go
@@ -690,14 +690,12 @@ func TestSyncFailsBeforeMaterializing(t *testing.T) {
 		t.Error("the colliding skill was materialized despite the refused merge")
 	}
 
-	// Known limitation, pinned deliberately: runSync writes the providers' MCP
-	// entries BEFORE fetching the manifest (sync.go, removeMCPEntries/
-	// applyMCPEntries ahead of fetchMergedManifest), so a refused merge still
-	// leaves them rewritten. Reordering that is D172's subject, not this one.
-	// When D172 lands this assertion flips, and it should — it is here so the
-	// change is deliberate rather than silent.
-	if _, err := os.Stat(filepath.Join(dir, ".claude.json")); os.IsNotExist(err) {
-		t.Error("MCP entries were not written: D172 reordered runSync — update this assertion and the D171 note")
+	// D172 reordered runSync: nothing is written before the manifest is
+	// fetched and verified, so a refused merge no longer leaves the
+	// providers' MCP entries rewritten either. This assertion is the
+	// inversion of the limitation D171 pinned here deliberately.
+	if _, err := os.Stat(filepath.Join(dir, ".claude.json")); !os.IsNotExist(err) {
+		t.Errorf("MCP entries were written despite the refused merge (err=%v)", err)
 	}
 }
 
@@ -899,5 +897,197 @@ func TestCommonRevision(t *testing.T) {
 	diff := map[string]provisioning.Manifest{"a": {Revision: "r1"}, "b": {Revision: "r2"}}
 	if got := commonRevision(diff, []string{"a", "b"}); got != "" {
 		t.Errorf("commonRevision = %q, want empty when providers diverge", got)
+	}
+}
+
+// healthOnlyServer answers /health with the given KBs and fails every tool
+// call: the shape of a reachable server whose sync_pull does not work.
+func healthOnlyServer(t *testing.T, kbs ...string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			entries := make([]map[string]any, 0, len(kbs))
+			for _, name := range kbs {
+				entries = append(entries, map[string]any{"name": name})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "kbs": entries})
+			return
+		}
+		var req struct {
+			ID int `json:"id"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": map[string]any{
+			"content": []map[string]string{{"type": "text", "text": "sync_pull is unavailable"}},
+			"isError": true,
+		}})
+	}))
+}
+
+// TestSyncWritesNothingWhenPullFails is WP1's assertion: /health answers, so
+// the old runSync had already rewritten the providers' MCP entries and
+// .cartographer.yaml by the time sync_pull failed. Nothing may change now,
+// and the error must say so (D172).
+func TestSyncWritesNothingWhenPullFails(t *testing.T) {
+	srv := healthOnlyServer(t, "one", "two")
+	defer srv.Close()
+
+	dir := t.TempDir()
+	cfg := &clientconfig.Config{
+		ServerURL: srv.URL + "/mcp", ServerName: "cartographer",
+		Agents: []string{"claude"}, KnownKBs: []string{"gone"}, Trust: true,
+	}
+	if err := clientconfig.Save(dir, cfg); err != nil {
+		t.Fatal(err)
+	}
+	before := treeSnapshot(t, dir)
+
+	_, err := runSync(dir, cfg, syncOptions{})
+	if err == nil {
+		t.Fatal("runSync succeeded despite a failing sync_pull")
+	}
+	if !strings.Contains(err.Error(), "no configuration was modified") {
+		t.Errorf("the error must state that nothing changed: %v", err)
+	}
+
+	after := treeSnapshot(t, dir)
+	if len(before) != len(after) {
+		t.Fatalf("file set changed: %d before, %d after", len(before), len(after))
+	}
+	for name, content := range before {
+		if after[name] != content {
+			t.Errorf("%s changed despite the failed sync:\n--- before\n%s\n--- after\n%s", name, content, after[name])
+		}
+	}
+	// The persisted KB list in particular: it is what the next run
+	// reconciles MCP entries against.
+	reloaded, err := clientconfig.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(reloaded.KnownKBs, ",") != "gone" {
+		t.Errorf("known_kbs = %v, want the pre-sync value", reloaded.KnownKBs)
+	}
+}
+
+// TestMaterializeCheckpointsPerProvider is WP2's assertion: a failure on the
+// second provider leaves the first one RECORDED. With a single trailing
+// lockfile write, its files were on disk with no lock entry — unmanaged,
+// never pruned, invisible to doctor (D172).
+func TestMaterializeCheckpointsPerProvider(t *testing.T) {
+	manifest := provisioning.Manifest{
+		Revision: "rev-1",
+		Artifacts: []provisioning.Artifact{{
+			Kind: "skill", Name: "alpha", ContentHash: "hash-alpha", Source: "bundle", BuiltIn: true,
+			Files: []provisioning.ArtifactFile{{Path: "SKILL.md", Content: []byte("# alpha\n")}},
+		}},
+	}
+	// opencode materializes agents, not skills (D55): give it a kind it
+	// actually supports, or nothing is applied and nothing can fail.
+	agentManifest := provisioning.Manifest{
+		Revision: "rev-1",
+		Artifacts: []provisioning.Artifact{{
+			Kind: "agent", Name: "beta", ContentHash: "hash-beta", Source: "bundle", BuiltIn: true,
+			Files: []provisioning.ArtifactFile{{Path: "beta.md", Content: []byte("# beta\n")}},
+		}},
+	}
+	manifests := map[string]provisioning.Manifest{"claude": manifest, "opencode": agentManifest}
+	providers := []string{"claude", "opencode"}
+
+	// Learn where opencode materializes, by letting it succeed once in a
+	// throwaway directory, then sabotage that exact path in the real one.
+	probe := t.TempDir()
+	if _, err := materializeForProviders(map[string]provisioning.Manifest{"opencode": agentManifest}, []string{"opencode"}, probe, "", true, false, false, portabilityOptions{}); err != nil {
+		t.Fatalf("probe run: %v", err)
+	}
+	probeLock, err := provisioning.ReadLockFile(lockFilePath(probe))
+	if err != nil {
+		t.Fatal(err)
+	}
+	managed := probeLock.ForProvider("opencode").Managed
+	if len(managed) == 0 {
+		t.Fatal("the probe run recorded no managed file")
+	}
+
+	dir := t.TempDir()
+	sabotage := filepath.Join(provisioning.LockBaseDir(probeLock.ForProvider("opencode"), dir), managed[0].Path)
+	if err := os.MkdirAll(sabotage, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = materializeForProviders(manifests, providers, dir, "", true, false, false, portabilityOptions{})
+	if err == nil {
+		t.Fatal("materialize should fail: opencode's destination file is a directory")
+	}
+	if !strings.Contains(err.Error(), "already applied and recorded") || !strings.Contains(err.Error(), "claude") {
+		t.Errorf("the error must name what was already recorded: %v", err)
+	}
+
+	lockFile, err := provisioning.ReadLockFile(lockFilePath(dir))
+	if err != nil {
+		t.Fatalf("read lockfile after the failure: %v", err)
+	}
+	if got := lockFile.ForProvider("claude").Managed; len(got) == 0 {
+		t.Error("the completed provider was not recorded: its files are unmanaged")
+	}
+	if got := lockFile.ForProvider("opencode").Managed; len(got) != 0 {
+		t.Errorf("the failed provider should not be recorded: %v", got)
+	}
+}
+
+// TestDryRunPlanCoversRemovalsAndKnownKBs is WP4: the preview must cover
+// everything the sync would write. It used to show artifacts and the MCP
+// entries it would add, but neither the entries it would REMOVE nor the
+// rewrite of known_kbs — so a KB that disappeared server-side produced a plan
+// that hid the only destructive part of the run (D172).
+func TestDryRunPlanCoversRemovalsAndKnownKBs(t *testing.T) {
+	srv := prefixAwareMCPServer(t, map[string]string{"one": ""}, "sync_pull", func(kb string) string {
+		return syncPullPayload(t, kb, "solo")
+	})
+	defer srv.Close()
+
+	dir := t.TempDir()
+	cfg := &clientconfig.Config{
+		ServerURL: srv.URL + "/mcp", ServerName: "cartographer",
+		Agents: []string{"claude"}, KnownKBs: []string{"one", "gone"}, Trust: true,
+	}
+	if err := clientconfig.Save(dir, cfg); err != nil {
+		t.Fatal(err)
+	}
+	// An MCP entry for the KB that disappeared, so there is something real to
+	// report as removed.
+	if _, _, err := removeMCPEntries(cfg.ServerName, cfg.KnownKBs, []string{"claude"}, dir, false, "", false); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := entriesByProviderForKBs(cfg, []string{"claude"}, cfg.ServerName, cfg.ServerURL, []string{"one", "gone"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := applyMCPEntries(entries, []string{"claude"}, dir, false, "", false); err != nil {
+		t.Fatal(err)
+	}
+	before := treeSnapshot(t, dir)
+
+	out := withStdout(t, func() {
+		if _, err := runSync(dir, cfg, syncOptions{DryRun: true}); err != nil {
+			t.Fatalf("dry-run sync: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "would remove MCP entry") {
+		t.Errorf("the plan hides the entries it would remove:\n%s", out)
+	}
+	if !strings.Contains(out, "would update known_kbs") {
+		t.Errorf("the plan hides the known_kbs rewrite:\n%s", out)
+	}
+
+	after := treeSnapshot(t, dir)
+	if len(before) != len(after) {
+		t.Fatalf("a dry run changed the file set: %d before, %d after", len(before), len(after))
+	}
+	for name, content := range before {
+		if after[name] != content {
+			t.Errorf("a dry run modified %s", name)
+		}
 	}
 }

--- a/cmd/cartographer/connect.go
+++ b/cmd/cartographer/connect.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -565,7 +566,7 @@ func doConnect(opts connectOptions) (connectResult, error) {
 	if err != nil {
 		return connectResult{}, err
 	}
-	if _, err := removeMCPEntries(opts.Name, existing.KnownKBs, opts.Providers, opts.Dir, opts.Auth, opts.TokenEnv, opts.DryRun); err != nil {
+	if _, _, err := removeMCPEntries(opts.Name, existing.KnownKBs, opts.Providers, opts.Dir, opts.Auth, opts.TokenEnv, opts.DryRun); err != nil {
 		return connectResult{}, err
 	}
 	configsWritten, configWarnings, err := applyMCPEntries(entriesByProvider, opts.Providers, opts.Dir, opts.Auth, opts.TokenEnv, opts.DryRun)
@@ -646,6 +647,86 @@ func printMCPEntryLines(providers, entries []string, dryRun bool) {
 			fmt.Printf("wrote MCP entry %s\n", entry)
 		}
 	}
+}
+
+// printMCPEntryRemovals reports the MCP entries reconciliation removes.
+// Only the ones NOT being rewritten are worth a line: an entry that is
+// removed and immediately re-applied is an implementation detail of the
+// rewrite, and printing it as a removal would make a no-op sync look
+// destructive. Under --dry-run this is the half of the plan that was missing
+// entirely (D172 WP4).
+func printMCPEntryRemovals(providers []string, removed map[string][]string, applied []string, dryRun bool) {
+	if len(providersManagingMCP(providers)) == 0 {
+		return
+	}
+	keep := make(map[string]bool, len(applied))
+	for _, name := range applied {
+		keep[name] = true
+	}
+	seen := map[string]bool{}
+	var gone []string
+	for _, p := range providers {
+		for _, name := range removed[p] {
+			if keep[name] || seen[name] {
+				continue
+			}
+			seen[name] = true
+			gone = append(gone, name)
+		}
+	}
+	sort.Strings(gone)
+	for _, name := range gone {
+		if dryRun {
+			fmt.Printf("[dry-run] would remove MCP entry %s\n", name)
+		} else {
+			fmt.Printf("removed MCP entry %s\n", name)
+		}
+	}
+}
+
+// printKnownKBsChange reports the rewrite of .cartographer.yaml's known_kbs.
+// A dry run that showed every artifact and every MCP entry but not this was
+// an incomplete plan: the persisted KB list is what the next run reconciles
+// against (D172 WP4).
+func printKnownKBsChange(previous, current []string, dryRun bool) {
+	if sameStringSet(previous, current) {
+		return
+	}
+	verb := "updated"
+	if dryRun {
+		verb = "[dry-run] would update"
+	}
+	fmt.Printf("%s known_kbs: %s → %s\n", verb, kbListLabel(previous), kbListLabel(current))
+}
+
+// kbListLabel renders a KB list for a one-line diff, sorted so the two sides
+// are comparable at a glance.
+func kbListLabel(kbs []string) string {
+	if len(kbs) == 0 {
+		return "(none)"
+	}
+	out := append([]string(nil), kbs...)
+	sort.Strings(out)
+	return strings.Join(out, ", ")
+}
+
+// sameStringSet compares two lists as sets: known_kbs order is not meaningful
+// and reordering it is not a change worth reporting.
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := make(map[string]int, len(a))
+	for _, s := range a {
+		seen[s]++
+	}
+	for _, s := range b {
+		seen[s]--
+		if seen[s] < 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // providersManagingMCP filters providers down to those whose MCP configuration

--- a/cmd/cartographer/disconnect.go
+++ b/cmd/cartographer/disconnect.go
@@ -115,6 +115,17 @@ func doDisconnect(opts disconnectOptions) (disconnectResult, error) {
 		return res, nil
 	}
 
+	// Same client-state lock every other mutating path takes (D172): a
+	// disconnect racing a sync would otherwise resurrect the provider entry
+	// it just dropped, or lose the one the sync recorded.
+	if !opts.DryRun {
+		release, err := provisioning.LockClientState(opts.Dir, provisioning.DefaultClientLockTimeout)
+		if err != nil {
+			return res, err
+		}
+		defer release()
+	}
+
 	cfg, err := clientconfig.Load(opts.Dir)
 	if err != nil {
 		cfg = clientconfig.Default()
@@ -128,7 +139,7 @@ func doDisconnect(opts disconnectOptions) (disconnectResult, error) {
 	for _, p := range opts.Providers {
 		pr := disconnectProviderResult{Provider: p}
 
-		removed, err := removeMCPEntries(cfg.ServerName, cfg.KnownKBs, []string{p}, opts.Dir, cfg.Auth, cfg.TokenEnv, opts.DryRun)
+		_, removed, err := removeMCPEntries(cfg.ServerName, cfg.KnownKBs, []string{p}, opts.Dir, cfg.Auth, cfg.TokenEnv, opts.DryRun)
 		if err != nil {
 			return disconnectResult{}, fmt.Errorf("remove config for %s: %w", p, err)
 		}

--- a/cmd/cartographer/doctor.go
+++ b/cmd/cartographer/doctor.go
@@ -108,6 +108,15 @@ func cmdDoctor(args []string) int {
 // every managed artifact on every client — in the field ~150 file operations to
 // backfill six hashes, with a partial failure leaving both clients without skills.
 func repairManagedHashes(dir, only string) int {
+	// Rewrites the lockfile, so it takes the client-state lock like every
+	// other mutating path (D172). Read-only `doctor` does not.
+	release, err := provisioning.LockClientState(dir, provisioning.DefaultClientLockTimeout)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		return 2
+	}
+	defer release()
+
 	lf, err := provisioning.ReadLockFile(lockFilePath(dir))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Error: read lockfile:", err)

--- a/cmd/cartographer/multikb.go
+++ b/cmd/cartographer/multikb.go
@@ -434,8 +434,9 @@ func applyMCPEntries(entriesByProvider map[string][]mcpEntry, providers []string
 	return written, warnings, nil
 }
 
-func removeMCPEntries(baseName string, kbs []string, providers []string, dir string, auth bool, tokenEnv string, dryRun bool) (map[string]bool, error) {
+func removeMCPEntries(baseName string, kbs []string, providers []string, dir string, auth bool, tokenEnv string, dryRun bool) (map[string][]string, map[string]bool, error) {
 	removed := make(map[string]bool, len(providers))
+	names := make(map[string][]string, len(providers))
 	for _, provider := range providers {
 		if !configurator.ManagesMCPConfig(configurator.Provider(provider)) {
 			// Nothing was ever written for it (D141), so there is nothing to
@@ -445,12 +446,18 @@ func removeMCPEntries(baseName string, kbs []string, providers []string, dir str
 		for _, name := range managedEntryNames(baseName, kbs) {
 			ok, err := configurator.Remove(&configurator.ServerConfig{Name: name, AuthEnabled: auth, TokenEnv: tokenEnv}, configurator.Provider(provider), dir, dryRun)
 			if err != nil {
-				return nil, fmt.Errorf("remove config for %s: %w", provider, err)
+				return nil, nil, fmt.Errorf("remove config for %s: %w", provider, err)
+			}
+			if ok {
+				// Under dryRun configurator.Remove reports what it WOULD
+				// remove without touching the file, which is what makes the
+				// removals visible in a --dry-run plan (D172 WP4).
+				names[provider] = append(names[provider], name)
 			}
 			removed[provider] = removed[provider] || ok
 		}
 	}
-	return removed, nil
+	return names, removed, nil
 }
 
 // unmanagedMCPConfigNote is what `connect` reports for a provider whose MCP

--- a/cmd/cartographer/multikb_test.go
+++ b/cmd/cartographer/multikb_test.go
@@ -222,7 +222,7 @@ func TestRemoveMCPEntries_RemovesEveryManagedEntry(t *testing.T) {
 	if _, _, err := applyMCPEntries(sameEntriesFor([]string{"claude", "codex", "kiro", "opencode"}, entries), []string{"claude", "codex", "kiro", "opencode"}, dir, false, "", false); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := removeMCPEntries("wiki", []string{"a", "b"}, []string{"claude", "codex", "kiro", "opencode"}, dir, false, "", false); err != nil {
+	if _, _, err := removeMCPEntries("wiki", []string{"a", "b"}, []string{"claude", "codex", "kiro", "opencode"}, dir, false, "", false); err != nil {
 		t.Fatal(err)
 	}
 	for _, provider := range []string{"claude", "codex", "kiro", "opencode"} {

--- a/cmd/cartographer/reconnect_test.go
+++ b/cmd/cartographer/reconnect_test.go
@@ -28,6 +28,12 @@ func treeSnapshot(t *testing.T, root string) map[string]string {
 		if relErr != nil {
 			return relErr
 		}
+		// The client-state lock file (D172) is created by any mutating path
+		// and is empty by construction: it is infrastructure, not part of
+		// what a rebuild reproduces.
+		if rel == provisioning.ClientLockFileName {
+			return nil
+		}
 		data, readErr := os.ReadFile(path)
 		if readErr != nil {
 			return readErr

--- a/cmd/cartographer/sync.go
+++ b/cmd/cartographer/sync.go
@@ -85,11 +85,38 @@ func runSync(dir string, cfg *clientconfig.Config, opts syncOptions) (syncResult
 		return syncResult{}, err
 	}
 
-	// Reconcile the provider MCP entries from the mounted KB list before
-	// sync_pull. On an unreachable server no local entry or persisted KB list
-	// changes; fetchMergedManifest below then reports the ordinary sync error.
+	// One writer at a time across PROCESSES: the session-start bootstrap hook
+	// runs `cartographer sync` per agent session, so several are routinely in
+	// flight at once and the loser of that race silently drops another
+	// provider's lock entry (D172). A dry run writes nothing and needs none.
+	if !opts.DryRun {
+		release, err := provisioning.LockClientState(dir, provisioning.DefaultClientLockTimeout)
+		if err != nil {
+			return syncResult{}, err
+		}
+		defer release()
+	}
+
+	// A plan restricted to some providers must say so: read without the
+	// command line that produced it, a partial plan looks like a complete one
+	// (D170 WP2, D172 WP4).
+	if opts.DryRun && len(opts.Clients) > 0 {
+		fmt.Printf("[dry-run] plan for %s only; other connected providers are untouched\n", strings.Join(targets, ", "))
+	}
+
+	// The KB list as it was persisted: what this client may own MCP entries
+	// for. Reconciliation compares it against what the server mounts now, so
+	// it must be read before cfg.KnownKBs is refreshed in memory.
+	previousKnownKBs := cfg.KnownKBs
+
+	// Nothing is written before the manifest is fetched and verified (D172).
+	// The previous order rewrote the providers' MCP entries and
+	// .cartographer.yaml first, so a failed sync_pull, an unverifiable
+	// signature or a cross-KB collision (D171) left a machine reconfigured for
+	// a sync that never happened — and the error said nothing about it.
 	facts, healthErr := enumerateKBs(cfg.ServerURL, cfg.Auth, cfg.TokenEnv)
 	kbs := facts.Names
+	var entriesByProvider map[string][]mcpEntry
 	if healthErr != nil {
 		fmt.Fprintf(os.Stderr, "Warning: MCP entry reconciliation skipped, server unreachable: %v\n", healthErr)
 	} else {
@@ -102,17 +129,31 @@ func runSync(dir string, cfg *clientconfig.Config, opts syncOptions) (syncResult
 		if !facts.Listed {
 			entryKBs = nil
 		}
-		entriesByProvider, err := entriesByProviderForKBs(cfg, targets, cfg.ServerName, cfg.ServerURL, entryKBs)
+		var err error
+		entriesByProvider, err = entriesByProviderForKBs(cfg, targets, cfg.ServerName, cfg.ServerURL, entryKBs)
 		if err != nil {
 			return syncResult{}, err
 		}
+		// Refresh the in-memory cache so the manifest pull below resolves
+		// default bindings against what the server mounts now. Persisting it
+		// is step 6: until the manifest is in hand, nothing on disk changes.
+		cfg.KnownKBs = kbs
+	}
+
+	manifests, err := manifestsForProviders(cfg, targets)
+	if err != nil {
+		return syncResult{}, fmt.Errorf("%w (no configuration was modified)", err)
+	}
+
+	if healthErr == nil {
 		// removeMCPEntries is fed the UNION of every known KB, never a
 		// provider's filtered binding (D170): managedEntryNames derives the
 		// names this client may own from the list it is given, so passing the
 		// filtered one would orphan an unbound KB's entry forever. Only the
 		// targeted providers are touched — a provider skipped by --client keeps
 		// its entries untouched.
-		if _, err := removeMCPEntries(cfg.ServerName, cfg.KnownKBs, targets, dir, cfg.Auth, cfg.TokenEnv, opts.DryRun); err != nil {
+		removedNames, _, err := removeMCPEntries(cfg.ServerName, previousKnownKBs, targets, dir, cfg.Auth, cfg.TokenEnv, opts.DryRun)
+		if err != nil {
 			return syncResult{}, err
 		}
 		_, warnings, err := applyMCPEntries(entriesByProvider, targets, dir, cfg.Auth, cfg.TokenEnv, opts.DryRun)
@@ -125,27 +166,23 @@ func runSync(dir string, cfg *clientconfig.Config, opts syncOptions) (syncResult
 		for _, w := range warnings {
 			fmt.Fprintf(os.Stderr, "warning: %s\n", w)
 		}
+		printMCPEntryRemovals(targets, removedNames, allEntryNames(entriesByProvider), opts.DryRun)
 		printMCPEntryLines(targets, allEntryNames(entriesByProvider), opts.DryRun)
-		// Refresh the in-memory cache unconditionally so the manifest pull
-		// below resolves default bindings against what the server mounts now;
-		// only the persistence is skipped on a dry run.
-		cfg.KnownKBs = kbs
-		if !opts.DryRun {
-			if err := clientconfig.Save(dir, cfg); err != nil {
-				return syncResult{}, err
-			}
-		}
-	}
-
-	manifests, err := manifestsForProviders(cfg, targets)
-	if err != nil {
-		return syncResult{}, err
 	}
 
 	// Do not write even the local bootstrap hook until the complete remote
 	// manifest has passed its content and signature checks.
 	if err := ensureBootstrapForProviders(targets, dir, opts.DryRun); err != nil {
 		return syncResult{}, err
+	}
+
+	if healthErr == nil {
+		printKnownKBsChange(previousKnownKBs, kbs, opts.DryRun)
+		if !opts.DryRun {
+			if err := clientconfig.Save(dir, cfg); err != nil {
+				return syncResult{}, err
+			}
+		}
 	}
 
 	results, err := materializeForProviders(manifests, targets, dir, facts.Version, cfg.Trust || opts.AutoTrust, opts.DryRun, opts.NoHeal, portabilityOptions{SearchRoots: cfg.SearchRoots, SearchDepth: cfg.SearchDepth, Paths: cfg.Paths}, cfg.ApprovedMCPHashes())

--- a/cmd/cartographer/tui.go
+++ b/cmd/cartographer/tui.go
@@ -155,6 +155,17 @@ type probeDoneMsg struct {
 	err      error
 }
 
+// syncAllDoneMsg carries the result of one sequential sync-all run: the
+// providers that completed, and the one that failed if any. A partial result
+// is reported as such — the providers already synced keep their lockfile
+// entries (D172).
+type syncAllDoneMsg struct {
+	done    []string
+	applied map[string]provisioning.AppliedResult
+	failed  string
+	err     error
+}
+
 // syncDoneMsg carries the result of a syncCmd run.
 type syncDoneMsg struct {
 	provider string
@@ -391,24 +402,63 @@ func connectCmd(provider, dir, serverURL, name, tokenEnv string, auth, trust boo
 // honor the persisted cfg.Trust (D54), same as `cartographer sync`.
 func syncCmd(provider, dir string) tea.Cmd {
 	return func() tea.Msg {
-		cfg, err := clientconfig.Load(dir)
+		release, err := provisioning.LockClientState(dir, provisioning.DefaultClientLockTimeout)
 		if err != nil {
 			return syncDoneMsg{provider: provider, err: err}
 		}
-		manifests, err := manifestsForProviders(cfg, []string{provider})
-		if err != nil {
-			return syncDoneMsg{provider: provider, err: err}
-		}
-		// The server version recorded in the lockfile (D142). A failed probe
-		// leaves it empty, which preserves the previously recorded value
-		// instead of erasing it.
-		facts, _ := enumerateKBs(cfg.ServerURL, cfg.Auth, cfg.TokenEnv)
-		applied, err := materializeForProviders(manifests, []string{provider}, dir, facts.Version, cfg.Trust, false, false /* noHeal */, portabilityOptions{SearchRoots: cfg.SearchRoots, SearchDepth: cfg.SearchDepth, Paths: cfg.Paths}, cfg.ApprovedMCPHashes())
-		if err != nil {
-			return syncDoneMsg{provider: provider, err: err}
-		}
-		return syncDoneMsg{provider: provider, applied: applied[provider]}
+		defer release()
+		return syncOneProvider(provider, dir)
 	}
+}
+
+// syncAllCmd syncs every connected provider SEQUENTIALLY under one client
+// lock (D172). It used to fan out one syncCmd per provider through tea.Batch;
+// with the lock in place each goroutine would only queue behind the others,
+// buying nothing and making the progress message incoherent — and before the
+// lock existed, those concurrent writers lost one another's lockfile entries.
+func syncAllCmd(providers []string, dir string) tea.Cmd {
+	return func() tea.Msg {
+		release, err := provisioning.LockClientState(dir, provisioning.DefaultClientLockTimeout)
+		if err != nil {
+			return syncAllDoneMsg{err: err}
+		}
+		defer release()
+
+		out := syncAllDoneMsg{applied: make(map[string]provisioning.AppliedResult, len(providers))}
+		for _, p := range providers {
+			res := syncOneProvider(p, dir)
+			if res.err != nil {
+				out.failed, out.err = p, res.err
+				return out
+			}
+			out.done = append(out.done, p)
+			out.applied[p] = res.applied
+		}
+		return out
+	}
+}
+
+// syncOneProvider is the body of a single-provider sync. The caller holds the
+// client lock: taking it here would deadlock syncAllCmd, since flock is held
+// per file description and this process would block on itself.
+func syncOneProvider(provider, dir string) syncDoneMsg {
+	cfg, err := clientconfig.Load(dir)
+	if err != nil {
+		return syncDoneMsg{provider: provider, err: err}
+	}
+	manifests, err := manifestsForProviders(cfg, []string{provider})
+	if err != nil {
+		return syncDoneMsg{provider: provider, err: err}
+	}
+	// The server version recorded in the lockfile (D142). A failed probe
+	// leaves it empty, which preserves the previously recorded value
+	// instead of erasing it.
+	facts, _ := enumerateKBs(cfg.ServerURL, cfg.Auth, cfg.TokenEnv)
+	applied, err := materializeForProviders(manifests, []string{provider}, dir, facts.Version, cfg.Trust, false, false /* noHeal */, portabilityOptions{SearchRoots: cfg.SearchRoots, SearchDepth: cfg.SearchDepth, Paths: cfg.Paths}, cfg.ApprovedMCPHashes())
+	if err != nil {
+		return syncDoneMsg{provider: provider, err: err}
+	}
+	return syncDoneMsg{provider: provider, applied: applied[provider]}
 }
 
 // disconnectCmd runs doDisconnect for a single provider (the shared logic
@@ -626,6 +676,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.loading = true
 		return m, loadRemoteStatusCmd(m.dir)
 
+	case syncAllDoneMsg:
+		m.loading = false
+		m.rows = buildRows(m.dir)
+		if msg.err != nil {
+			m.err = msg.err
+			if len(msg.done) > 0 {
+				m.message = fmt.Sprintf("sync %s failed after syncing %s: %v", msg.failed, strings.Join(msg.done, ", "), msg.err)
+			} else {
+				m.message = fmt.Sprintf("sync %s failed: %v", msg.failed, msg.err)
+			}
+			return m, nil
+		}
+		m.err = nil
+		m.message = fmt.Sprintf("synced %s", strings.Join(msg.done, ", "))
+		m.loading = true
+		return m, loadRemoteStatusCmd(m.dir)
+
 	case disconnectDoneMsg:
 		m.disconnecting = false
 		m.screen = screenList
@@ -675,19 +742,19 @@ func (m Model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case "S":
-		var cmds []tea.Cmd
+		var providers []string
 		for _, row := range m.rows {
 			if row.Connected {
-				cmds = append(cmds, syncCmd(string(row.Provider), m.dir))
+				providers = append(providers, string(row.Provider))
 			}
 		}
-		if len(cmds) == 0 {
+		if len(providers) == 0 {
 			return m, nil
 		}
 		m.loading = true
 		m.message = "syncing all connected providers…"
 		m.err = nil
-		return m, tea.Batch(cmds...)
+		return m, syncAllCmd(providers, m.dir)
 
 	case "enter", "s":
 		if len(m.rows) == 0 {

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -55,6 +55,17 @@ automatic deletion**: the directory may hold a real operator rebase, or an autos
 copy of uncommitted work, and deleting another writer's state is the class of action that caused the
 incident in the first place.
 
+## The advisory client lock
+
+The client side has its own advisory lock, for the same reason and with a different scope:
+`.cartographer-client.lock` in the client's target directory, taken by every path that
+read-modify-writes the lockfile or `.cartographer.yaml` (`sync`, `disconnect`,
+`doctor --repair-hashes`, the TUI's sync actions). The concurrent writers are separate
+`cartographer sync` **processes** — the session-start bootstrap hook starts one per agent session —
+and before D172 the loser of that race silently dropped another provider's lockfile entry. It is an
+`flock`, released on every exit path, with a bounded 30s wait that fails naming the file rather than
+proceeding. Details and the surrounding order of operations: `sync.md` §The client lock.
+
 ## Git profiles
 
 `git.profile: local` is the default and the historical behavior. When

--- a/docs/decisions/sync-provisioning.md
+++ b/docs/decisions/sync-provisioning.md
@@ -825,11 +825,12 @@ binding creates a collision, and `doctor` gains a `kb-collisions` check.
   Configuring a machine must not require the network, and the sync-time refusal
   is the backstop.
 
-**Known limitation, deliberately not fixed here.** `runSync` writes the
-providers' MCP entries *before* fetching the manifest, so a refused merge still
-leaves those rewritten. Only artifacts and the lockfile are protected. Reordering
-the sync is a separate change; a test pins the current behaviour so that when the
-reorder lands it fails loudly instead of changing silently.
+**Known limitation, since closed by [D172](#d172).** As written here, `runSync`
+rewrote the providers' MCP entries *before* fetching the manifest, so a refused
+merge still left those rewritten; only artifacts and the lockfile were protected.
+A test pinned that behaviour so the reorder could not land silently. D172
+reordered `runSync` and inverted the assertion: a refused merge now leaves the
+MCP entries untouched as well.
 
 **Consequences.** A deployment with two colliding KBs — working today, silently
 and arbitrarily — starts failing its sync with a report and a remedy. That is the
@@ -902,3 +903,61 @@ unchanged for anyone who declares no binding. `statusManifestFn` became
 `statusManifestsFn` (per provider); `materializeForProviders` takes a
 per-provider manifest map, with `uniformManifests` for the callers that
 legitimately have one.
+
+---
+
+<a id="d172"></a>
+## D172 — Sync ordering, per-provider checkpoints, and a client lock
+
+**Decision.** `runSync` writes nothing before the manifest is fetched and
+verified; `materializeForProviders` checkpoints the lockfile after every
+provider; every path that mutates client state takes an advisory OS file lock;
+and `--dry-run` covers the removals and the `known_kbs` rewrite it used to hide.
+
+**Context.** Three distinct defects, none of which is "the sync is not atomic" in
+general — that framing hides which write is actually unprotected.
+
+- **Order.** `runSync` removed and rewrote the providers' MCP entries and saved
+  `.cartographer.yaml` *before* `fetchMergedManifest`. A failed `sync_pull`, an
+  unverifiable signature or a cross-KB collision ([D171](#d171)) left those
+  writes in place, and the error said nothing about it. The artifact writes were
+  already correctly ordered — `ensureBootstrapForProviders` sits after the
+  manifest check deliberately, and stays there. The fix moves the configuration
+  writes to the same side of that line and makes the failure message say that
+  nothing changed, because a user who cannot tell what state the machine is in
+  will re-run blind.
+- **Checkpoints.** `Apply` ran per provider while the lockfile was written once
+  at the end, so a failure on provider N left providers 1..N−1 with files on disk
+  and **no lock entry**: unmanaged files that pruning never removes and `doctor`
+  cannot see. The lockfile is now written after each provider, and the error
+  names the ones already recorded so a rerun is informed. N atomic renames
+  instead of one, with at most five providers: a deliberate trade of I/O for
+  safety.
+- **The guarantee, stated rather than implied.** A failure *between* steps leaves
+  a consistent state and a completed provider is always recorded. This does
+  **not** make a single `Apply` atomic — the failed provider's own partial files
+  are still possible, which is [D178](#d178)'s subject. Saying so is the point:
+  the alternative was a generalized snapshot-and-rollback, and rolling back the
+  native configs of four providers is more dangerous code than it removes.
+- **The lock is at OS level.** Nothing serialized concurrent syncs, and every
+  path did a read-modify-write of the lockfile, so two of them lost each other's
+  provider entries, last writer wins. This is not hypothetical: the bootstrap
+  hook runs `cartographer sync` at session start, so several agent sessions
+  opening at once produce concurrent *processes* — which an in-process mutex
+  would not see. `.cartographer-client.lock`, `flock`, released on every exit
+  path, with a bounded wait that fails naming the file: a sync that silently
+  loses an entry is worse than one that asks to be rerun. A dry run writes
+  nothing and takes none.
+- **The TUI stops fanning out.** `S` ran one `syncCmd` per provider through
+  `tea.Batch`. With the lock in place each goroutine would only queue behind the
+  others, buying nothing while making the progress reporting incoherent, so it
+  runs them sequentially under one lock and reports a partial failure as such.
+- **A plan that hides its removals is not a plan.** `--dry-run` showed the files
+  and the MCP entries it would add, but not the ones it would remove nor the
+  `known_kbs` rewrite — exactly the destructive half. Both are now printed, and a
+  `--client`-restricted plan says so in its header, since read without the
+  command line that produced it a partial plan looks complete.
+
+**Consequences.** No interface change. Failure behaviour is more conservative,
+and there is one new failure mode: two overlapping syncs, where the second now
+reports the lock instead of silently corrupting the first one's state.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -227,9 +227,31 @@ D138). Keeping them separate is also a fix: previously the expanded hash was sto
 `content_hash`, so any artifact containing a placeholder compared unequal against the manifest on
 every sync and was reported as permanent drift.
 
+## Order of operations, and what a failure leaves behind (D172)
+
+`runSync` writes nothing before the manifest is fetched and verified:
+
+1. `enumerateKBs` (`/health`);
+2. compute the MCP entries per provider — no writes;
+3. `fetchMergedManifest` → signature verification and cross-KB collision detection ([D171](decisions/sync-provisioning.md#d171));
+4. `removeMCPEntries` + `applyMCPEntries`;
+5. `ensureBootstrapForProviders` — never before the manifest passed its checks;
+6. `clientconfig.Save` of `known_kbs`;
+7. `materializeForProviders`, which **checkpoints the lockfile after every provider**.
+
+A failed `sync_pull`, an unverifiable signature or a refused merge therefore leaves the machine exactly as it was, and the error says so. An unreachable server (`/health` itself failing) skips entry reconciliation entirely, as before.
+
+**The guarantee, stated honestly.** A failure *between* steps leaves a consistent state, and a provider that completed is always recorded in the lockfile — before D172 a failure on provider N left providers 1..N−1 with files on disk and no lock entry, so nothing pruned them and `doctor` could not see them. It does **not** make a single `Apply` atomic: a provider whose `Apply` fails midway can still have partial files on disk. The cost is N atomic lockfile renames instead of one, which with at most five providers is a deliberate trade of I/O for safety.
+
+## The client lock (D172)
+
+Every path that read-modify-writes the lockfile or `.cartographer.yaml` — `sync`, `disconnect`, `doctor --repair-hashes`, and the TUI's sync actions — first takes an **advisory OS file lock** on `.cartographer-client.lock` beside the lockfile. The race is between *processes*, not goroutines: the session-start bootstrap hook runs `cartographer sync` per agent session, so several are routinely in flight, and the loser of that race silently dropped another provider's entry. A blocked acquisition waits up to 30s and then fails naming the file — a sync that quietly loses an entry is worse than one that asks to be rerun. A dry run takes no lock, since it writes nothing.
+
+The TUI's `S` (sync all) runs its providers **sequentially** under one lock rather than fanning out through `tea.Batch`: with the lock in place, concurrent goroutines would only queue behind each other while making the progress reporting incoherent. A partial failure reports which providers completed.
+
 ## Idempotence
 
-`sync_apply`/`provisioning.Apply` applied twice on the same revision are no-ops; `dry_run` shows the diff without writing (`sync_apply(dry_run=true)`, `--dry-run` on the client). The provider JSON config merge remains the non-destructive deep-merge of `configurator.mergeJSON`.
+`sync_apply`/`provisioning.Apply` applied twice on the same revision are no-ops; `dry_run` shows the diff without writing (`sync_apply(dry_run=true)`, `--dry-run` on the client). The client plan covers everything the run would write: per-artifact files, the MCP entries it would add **and the ones it would remove**, and the `known_kbs` rewrite when the set changes; with `--client` it says in its header that the plan is restricted to those providers (D172). The provider JSON config merge remains the non-destructive deep-merge of `configurator.mergeJSON`.
 
 ## Kind × provider matrix
 

--- a/internal/provisioning/clientlock.go
+++ b/internal/provisioning/clientlock.go
@@ -1,0 +1,73 @@
+package provisioning
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// ClientLockFileName is the advisory lock guarding every mutation of this
+// machine's client state — the lockfile and .cartographer.yaml. It sits next
+// to the lockfile it protects.
+const ClientLockFileName = ".cartographer-client.lock"
+
+// DefaultClientLockTimeout bounds how long a caller waits for a concurrent
+// operation to finish. Long enough for an ordinary sync to complete, short
+// enough that a stuck holder is reported rather than waited on forever.
+const DefaultClientLockTimeout = 30 * time.Second
+
+// clientLockPollInterval is how often a blocked acquisition retries. The
+// lock is held for the length of a sync, so polling costs nothing.
+const clientLockPollInterval = 100 * time.Millisecond
+
+// LockClientState takes an exclusive advisory lock on dir's client lock file
+// and returns the release function.
+//
+// The lock is at OS level, not in-process: the case it exists for is several
+// `cartographer sync` PROCESSES running at once — the session-start bootstrap
+// hook fires one per agent session — and an in-process mutex would not see
+// them. Every path that read-modify-writes the lockfile or .cartographer.yaml
+// takes it, because the losing writer of such a race silently drops another
+// provider's entry.
+//
+// A blocked acquisition waits up to timeout and then fails naming the file: a
+// sync that quietly loses an entry is worse than one that asks to be rerun.
+//
+// NOTE: this is an advisory lock between cooperating cartographer processes.
+// It does not protect against an editor rewriting the same files, which is
+// not a race any lock could arbitrate.
+func LockClientState(dir string, timeout time.Duration) (func() error, error) {
+	if timeout <= 0 {
+		timeout = DefaultClientLockTimeout
+	}
+	path := filepath.Join(dir, ClientLockFileName)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open client lock %s: %w", path, err)
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		err := tryLockFile(f)
+		if err == nil {
+			return func() error {
+				unlockErr := unlockFile(f)
+				closeErr := f.Close()
+				if unlockErr != nil {
+					return unlockErr
+				}
+				return closeErr
+			}, nil
+		}
+		if !isLockBusy(err) {
+			f.Close()
+			return nil, fmt.Errorf("lock %s: %w", path, err)
+		}
+		if time.Now().After(deadline) {
+			f.Close()
+			return nil, fmt.Errorf("another cartographer operation is holding %s (waited %s): wait for it to finish, or remove the file if no cartographer process is running", path, timeout)
+		}
+		time.Sleep(clientLockPollInterval)
+	}
+}

--- a/internal/provisioning/clientlock_other.go
+++ b/internal/provisioning/clientlock_other.go
@@ -1,0 +1,14 @@
+//go:build !unix
+
+package provisioning
+
+import "os"
+
+// The supported platforms are darwin and linux (see internal/service's goos
+// switch). Elsewhere the lock degrades to a no-op rather than failing every
+// sync: an unsupported platform gets today's behaviour, not a broken client.
+func tryLockFile(*os.File) error { return nil }
+
+func unlockFile(*os.File) error { return nil }
+
+func isLockBusy(error) bool { return false }

--- a/internal/provisioning/clientlock_test.go
+++ b/internal/provisioning/clientlock_test.go
@@ -1,0 +1,64 @@
+package provisioning_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BeppeTemp/cartographer/internal/provisioning"
+)
+
+// TestLockClientState_Serializes: the second acquisition fails with a message
+// naming the file, rather than proceeding and losing the first writer's
+// entries (D172).
+func TestLockClientState_Serializes(t *testing.T) {
+	dir := t.TempDir()
+	release, err := provisioning.LockClientState(dir, time.Second)
+	if err != nil {
+		t.Fatalf("first acquisition: %v", err)
+	}
+
+	start := time.Now()
+	_, err = provisioning.LockClientState(dir, 300*time.Millisecond)
+	if err == nil {
+		t.Fatal("the second acquisition should have failed while the lock is held")
+	}
+	if waited := time.Since(start); waited < 250*time.Millisecond {
+		t.Errorf("it should wait for the timeout before giving up, waited %s", waited)
+	}
+	if !strings.Contains(err.Error(), provisioning.ClientLockFileName) {
+		t.Errorf("the error must name the lock file: %v", err)
+	}
+
+	if err := release(); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	// Released: the next caller gets it.
+	release2, err := provisioning.LockClientState(dir, time.Second)
+	if err != nil {
+		t.Fatalf("acquisition after release: %v", err)
+	}
+	if err := release2(); err != nil {
+		t.Fatalf("second release: %v", err)
+	}
+
+	if _, err := filepath.Abs(filepath.Join(dir, provisioning.ClientLockFileName)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestLockClientState_SequentialAcquisitions: back-to-back acquisitions all
+// succeed — the lock serializes, it does not accumulate state.
+func TestLockClientState_SequentialAcquisitions(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 3; i++ {
+		release, err := provisioning.LockClientState(dir, time.Second)
+		if err != nil {
+			t.Fatalf("acquisition %d: %v", i, err)
+		}
+		if err := release(); err != nil {
+			t.Fatalf("release %d: %v", i, err)
+		}
+	}
+}

--- a/internal/provisioning/clientlock_unix.go
+++ b/internal/provisioning/clientlock_unix.go
@@ -1,0 +1,25 @@
+//go:build unix
+
+package provisioning
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// tryLockFile takes a non-blocking exclusive flock. The retry loop lives in
+// LockClientState so the wait is bounded and its failure message can name the
+// file.
+func tryLockFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+}
+
+func unlockFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}
+
+// isLockBusy distinguishes "someone else holds it" from a real failure.
+func isLockBusy(err error) bool {
+	return errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN)
+}


### PR DESCRIPTION
Three distinct defects. None of them is "the sync is not atomic" in general — that framing hides which write is actually unprotected.

**WP1 — nothing is written before the manifest is verified**

`runSync` removed and rewrote the providers' MCP entries and saved `.cartographer.yaml` **before** `fetchMergedManifest`, so a failed `sync_pull`, an unverifiable signature or a cross-KB collision (D171) left those writes in place — and the error said nothing about it, leaving the user unable to tell what state the machine was in. The configuration writes move after the fetch, and the error now states that no configuration was modified.

The artifact writes were already ordered correctly: `ensureBootstrapForProviders` sits after the manifest check deliberately and stays there. `TestSyncFailsBeforeMaterializing`'s pinned assertion — which D171 left here for exactly this change — is inverted, and the D171 note updated.

**WP2 — the lockfile is checkpointed after every provider**

`Apply` ran per provider while the lockfile was written once at the end, so a failure on provider N left providers 1..N−1 with files on disk and **no lock entry**: unmanaged files nothing prunes and `doctor` cannot see. The error now names the providers already recorded, so a rerun is informed. N atomic renames instead of one, with at most five providers — a deliberate trade of I/O for safety.

Stated honestly, and in the D entry: this protects **completed** providers. It does not make one `Apply` atomic, and the failed provider's own partial files remain D178's subject.

**WP3 — an advisory OS lock on client state**

Nothing serialized concurrent syncs, and every path read-modify-writes the lockfile, so two of them lost each other's provider entries, last writer wins. Not hypothetical: the bootstrap hook runs `cartographer sync` at session start, so several agent sessions opening at once produce concurrent **processes**, which an in-process mutex would not see. `sync`, `disconnect`, `doctor --repair-hashes` and the TUI take an `flock` on `.cartographer-client.lock`, released on every exit path, with a bounded 30s wait that fails naming the file. A dry run writes nothing and takes none.

The TUI's `S` stops fanning out through `tea.Batch` and runs its providers **sequentially** under one lock: goroutines queuing behind the same lock buy nothing and make the progress reporting incoherent. A partial failure reports which providers completed.

**WP4 — a `--dry-run` plan that covers what it would destroy**

It showed the files and the MCP entries it would add, but neither the ones it would **remove** nor the `known_kbs` rewrite — exactly the destructive half. Both are printed now, and a `--client`-restricted plan says so in its header, since read without the command line that produced it a partial plan looks complete.

Docs: `docs/sync.md` (§order of operations, §the client lock, §idempotence), `docs/concurrency.md` (§the advisory client lock), D172 in `docs/decisions/sync-provisioning.md`.

**Release note**: no interface change; more conservative failure behaviour, plus one new failure mode — two overlapping syncs, where the second now reports the lock instead of silently corrupting the first one's state.

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpK3mMfKpbRVttAmkFnHbh
