### PR TITLE
feat(tui): binding-aware dashboard that says when it does not know (D175)

### DIFF
--- a/cmd/cartographer/tui.go
+++ b/cmd/cartographer/tui.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
@@ -66,6 +67,19 @@ type dashboardAgent struct {
 	// SkillStatus is one of: "not connected", "checking…", "in-sync",
 	// "drift ..." (see formatDiffStatus), "server unreachable", or "error: ...".
 	SkillStatus string
+	// BoundKBs is the set of KBs this provider receives and BindingExplicit
+	// whether the user declared it or it was defaulted (D169/D175 WP1).
+	// Resolved from .cartographer.yaml in buildRows: local data, so the
+	// binding is part of the first frame and never waits on the network.
+	BoundKBs        []string
+	BindingExplicit bool
+	// KindStatus is the per-kind breakdown (formatKindStatus) and KindsKnown
+	// whether it was actually measured (D175 WP2). KindsKnown false means
+	// "not known" — before the first fetch resolves, and after one that
+	// failed — never "nothing to install": a successfully read but empty
+	// manifest is KindsKnown with an empty KindStatus.
+	KindStatus string
+	KindsKnown bool
 }
 
 // mcpConfigState is the three-state mcp-config badge (D120): a connected
@@ -108,6 +122,14 @@ type Model struct {
 	// dashboard one server-level explanation instead of repeating it per row.
 	snapshot *statusSnapshot
 
+	// syncingAll is true between the S keypress and syncAllDoneMsg, and
+	// syncProgress is the channel the sequential run announces each provider
+	// on (D175 WP4). The flag exists so a progress message that arrives after
+	// the outcome — the two travel on different goroutines — cannot overwrite
+	// the result the user needs to read.
+	syncingAll   bool
+	syncProgress chan string
+
 	formProvider string
 	connectForm  connectFormModel
 	// probing is true while the pre-connect reachability probe (D64) is in
@@ -125,14 +147,25 @@ type Model struct {
 	confirmProvider string
 	confirmYes      bool
 	disconnecting   bool
+	// confirmKBs is the confirmed provider's binding, captured when the
+	// screen opens so the prompt can name what is about to be removed
+	// (D175 WP4).
+	confirmKBs []string
 }
 
 // --- messages ---
 
 // remoteStatusMsg carries the result of an async fetchMergedManifest + diff pass,
 // keyed by provider name. Missing keys mean "leave SkillStatus unchanged".
+//
+// kinds is the per-kind breakdown (D175 WP2) and is keyed separately on
+// purpose: a provider is present only when its manifest was actually read, so
+// an absent key is "not known" while a present-but-empty value is a manifest
+// that was read and holds nothing. Collapsing the two would let the dashboard
+// show a breakdown computed against a manifest it never fetched.
 type remoteStatusMsg struct {
 	statuses map[string]string
+	kinds    map[string]string
 	snapshot statusSnapshot
 }
 
@@ -164,6 +197,13 @@ type syncAllDoneMsg struct {
 	applied map[string]provisioning.AppliedResult
 	failed  string
 	err     error
+}
+
+// syncProgressMsg names the provider whose sync is starting, emitted by a
+// sequential sync-all run before each provider (D175 WP4). It is progress
+// only: syncAllDoneMsg remains the single source of the outcome.
+type syncProgressMsg struct {
+	provider string
 }
 
 // syncDoneMsg carries the result of a syncCmd run.
@@ -226,10 +266,11 @@ func buildRows(dir string) []dashboardAgent {
 		row := dashboardAgent{Agent: a}
 		if connected[string(a.Provider)] {
 			row.Connected = true
-			bound := kbs
+			bound, explicit := kbs, false
 			if loaded != nil {
-				bound, _ = loaded.BoundKBs(string(a.Provider))
+				bound, explicit = loaded.BoundKBs(string(a.Provider))
 			}
+			row.BoundKBs, row.BindingExplicit = bound, explicit
 			row.MCPConfigState = mcpConfigStatus(dir, a.Provider, serverName, kbs, bound)
 			row.SkillStatus = "checking…"
 		} else {
@@ -338,12 +379,21 @@ func loadRemoteStatusCmd(dir string) tea.Cmd {
 		}
 		s := snapshotForConfig(dir, cfg, true)
 		statuses := make(map[string]string, len(cfg.Agents))
+		kinds := make(map[string]string, len(cfg.Agents))
 		for _, p := range s.Providers {
-			if p.Connected {
-				statuses[p.Name] = formatTUIProviderStatus(p)
+			if !p.Connected {
+				continue
+			}
+			statuses[p.Name] = formatTUIProviderStatus(p)
+			// "unknown" is the state snapshotForConfig assigns when the
+			// health check or the manifest fetch failed: there is no
+			// manifest to break down, so the provider is left out of the
+			// map rather than recorded as having nothing.
+			if p.State != "unknown" {
+				kinds[p.Name] = p.Kinds
 			}
 		}
-		return remoteStatusMsg{statuses: statuses, snapshot: s}
+		return remoteStatusMsg{statuses: statuses, kinds: kinds, snapshot: s}
 	}
 }
 
@@ -416,8 +466,16 @@ func syncCmd(provider, dir string) tea.Cmd {
 // with the lock in place each goroutine would only queue behind the others,
 // buying nothing and making the progress message incoherent — and before the
 // lock existed, those concurrent writers lost one another's lockfile entries.
-func syncAllCmd(providers []string, dir string) tea.Cmd {
+// progress, when non-nil, receives the name of each provider just before its
+// sync starts (D175 WP4) and is closed when the run ends. It must be buffered
+// for at least len(providers): a send that blocked would stall the run while
+// it holds the client lock, so progress reporting can never be a reason a sync
+// does not finish.
+func syncAllCmd(providers []string, dir string, progress chan<- string) tea.Cmd {
 	return func() tea.Msg {
+		if progress != nil {
+			defer close(progress)
+		}
 		release, err := provisioning.LockClientState(dir, provisioning.DefaultClientLockTimeout)
 		if err != nil {
 			return syncAllDoneMsg{err: err}
@@ -426,6 +484,9 @@ func syncAllCmd(providers []string, dir string) tea.Cmd {
 
 		out := syncAllDoneMsg{applied: make(map[string]provisioning.AppliedResult, len(providers))}
 		for _, p := range providers {
+			if progress != nil {
+				progress <- p
+			}
 			res := syncOneProvider(p, dir)
 			if res.err != nil {
 				out.failed, out.err = p, res.err
@@ -435,6 +496,19 @@ func syncAllCmd(providers []string, dir string) tea.Cmd {
 			out.applied[p] = res.applied
 		}
 		return out
+	}
+}
+
+// waitForSyncProgressCmd blocks on one syncAllCmd announcement and re-arms
+// itself from the handler. A closed channel ends the chain: returning a nil
+// Msg leaves the model untouched, which is what the end of the run means here.
+func waitForSyncProgressCmd(progress <-chan string) tea.Cmd {
+	return func() tea.Msg {
+		provider, ok := <-progress
+		if !ok {
+			return nil
+		}
+		return syncProgressMsg{provider: provider}
 	}
 }
 
@@ -504,8 +578,13 @@ var knownProvisioningKinds = []string{"skill", "agent", "hook", "instructions", 
 // formatKindStatus renders provisioning.KindCounts(m, lock) as a compact per-kind
 // summary string, e.g. "skill 4/5 · agent 2/2 · hook 1/1". Kinds with zero
 // artifacts in the manifest are omitted. Returns "" if there is nothing to show
-// (empty manifest). Used by both `cartographer status` and the TUI dashboard
-// (loadRemoteStatusCmd), alongside — not in place of — formatDiffStatus.
+// (empty manifest) — which is not the same as "not measured", the distinction
+// the dashboard keeps in dashboardAgent.KindsKnown.
+//
+// The single caller is snapshotForConfig (status_snapshot.go): both
+// `cartographer status` and the dashboard read the result off the snapshot, so
+// the two cannot report different breakdowns for the same provider. It stands
+// alongside — not in place of — formatDiffStatus.
 func formatKindStatus(m provisioning.Manifest, lock provisioning.Lock) string {
 	counts := provisioning.KindCounts(m, lock)
 
@@ -617,6 +696,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if s, ok := msg.statuses[string(m.rows[i].Provider)]; ok {
 				m.rows[i].SkillStatus = s
 			}
+			// Assigned unconditionally: a fetch that could not read this
+			// provider's manifest must clear a breakdown left over from an
+			// earlier poll, not leave it standing as if it still held.
+			m.rows[i].KindStatus, m.rows[i].KindsKnown = msg.kinds[string(m.rows[i].Provider)]
 		}
 		return m, nil
 
@@ -663,6 +746,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.loading = true
 		return m, loadRemoteStatusCmd(m.dir)
 
+	case syncProgressMsg:
+		// Ignored once the run is over: the outcome message must survive a
+		// progress message still in flight behind it.
+		if !m.syncingAll {
+			return m, nil
+		}
+		m.message = fmt.Sprintf("syncing %s…", msg.provider)
+		return m, waitForSyncProgressCmd(m.syncProgress)
+
 	case syncDoneMsg:
 		m.loading = false
 		if msg.err != nil {
@@ -678,6 +770,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case syncAllDoneMsg:
 		m.loading = false
+		m.syncingAll = false
 		m.rows = buildRows(m.dir)
 		if msg.err != nil {
 			m.err = msg.err
@@ -752,9 +845,12 @@ func (m Model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.loading = true
-		m.message = "syncing all connected providers…"
+		m.syncingAll = true
+		m.message = fmt.Sprintf("syncing %d providers one at a time: %s", len(providers), strings.Join(providers, ", "))
 		m.err = nil
-		return m, syncAllCmd(providers, m.dir)
+		// Buffered for the whole run so the sync never blocks on the UI.
+		m.syncProgress = make(chan string, len(providers))
+		return m, tea.Batch(syncAllCmd(providers, m.dir, m.syncProgress), waitForSyncProgressCmd(m.syncProgress))
 
 	case "enter", "s":
 		if len(m.rows) == 0 {
@@ -789,6 +885,7 @@ func (m Model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m Model) openConfirmDisconnect(row dashboardAgent) Model {
 	m.screen = screenConfirmDisconnect
 	m.confirmProvider = string(row.Provider)
+	m.confirmKBs = row.BoundKBs
 	m.confirmYes = false // default to the safe option
 	m.disconnecting = false
 	m.message = ""
@@ -946,7 +1043,7 @@ func (m Model) View() string {
 		b.WriteString(styleFooter.Render(wrapForWidth("←/→ select · enter confirm · y/n shortcut · esc cancel · ctrl+c quit", m.width-6)))
 	default:
 		if len(m.rows) > 0 && m.rows[m.cursor].Connected {
-			b.WriteString(styleFooter.Render(wrapForWidth("↑/↓ move · enter/s sync · S sync all · d disconnect · r refresh · q quit", m.width-6)))
+			b.WriteString(styleFooter.Render(wrapForWidth("↑/↓ move · enter/s sync selected · S sync all, one at a time · d disconnect · r refresh · q quit", m.width-6)))
 		} else {
 			b.WriteString(styleFooter.Render(wrapForWidth("↑/↓ move · enter connect · r refresh · q quit", m.width-6)))
 		}
@@ -996,7 +1093,7 @@ func (m Model) viewList() string {
 
 		// Details stacked vertically under each provider.
 		if row.Installed && row.Evidence != "" {
-			lines = append(lines, "      "+styleSubtitle.Render("binary      ")+styleEvidence.Render(row.Evidence))
+			lines = append(lines, m.rowDetail("binary", styleEvidence.Render(row.Evidence)))
 		}
 		if row.Connected {
 			var mcpBadge string
@@ -1012,9 +1109,21 @@ func (m Model) viewList() string {
 			if skill == "checking…" && m.loading {
 				skill = m.spinner.View() + " checking…"
 			}
+			// "unknown" and an empty breakdown are different answers: the
+			// first is a manifest that was never read, the second one that
+			// was read and holds nothing. Reporting the first as the second
+			// would show a clean bill of health computed against nothing.
+			kinds := "unknown"
+			if row.KindsKnown {
+				if kinds = row.KindStatus; kinds == "" {
+					kinds = "no artifacts"
+				}
+			}
 			lines = append(lines,
-				"      "+styleSubtitle.Render("mcp-config  ")+mcpBadge,
-				"      "+styleSubtitle.Render("artifacts   ")+skill)
+				m.rowDetail("mcp-config", mcpBadge),
+				m.rowDetail("kbs", formatBoundKBs(row.BoundKBs, row.BindingExplicit, m.detailWidth())),
+				m.rowDetail("artifacts", skill),
+				m.rowDetail("kinds", truncateForWidth(kinds, m.detailWidth())))
 		}
 		if i < len(m.rows)-1 {
 			lines = append(lines, "")
@@ -1026,26 +1135,176 @@ func (m Model) viewList() string {
 	return strings.Join(lines, "\n")
 }
 
+// rowIndentWidth and rowLabelWidth define the two-column grid of a provider
+// card: every detail line is indented and labelled identically, which is what
+// lets the eye scan down a column instead of reading each line.
+const (
+	rowIndentWidth   = 6
+	rowLabelWidth    = 12
+	serverLabelWidth = 11
+	// boxChromeWidth is the border plus the horizontal padding of styleBorder:
+	// what the frame takes from the terminal before any content is drawn.
+	boxChromeWidth = 4
+)
+
+// rowDetail renders one label/value line of a provider card on the grid.
+func (m Model) rowDetail(label, value string) string {
+	return strings.Repeat(" ", rowIndentWidth) + styleSubtitle.Render(fmt.Sprintf("%-*s", rowLabelWidth, label)) + value
+}
+
+// detailWidth is how many columns a detail value has before it would run past
+// the frame. Zero means the terminal size is not known yet (no WindowSizeMsg):
+// nothing is truncated, because guessing a width would cut text that fits.
+func (m Model) detailWidth() int {
+	if m.width <= 0 {
+		return 0
+	}
+	return m.width - boxChromeWidth - rowIndentWidth - rowLabelWidth
+}
+
+// viewServerPanel renders the server block as a labelled column rather than
+// one long line: with four mounted KBs the single line exceeded any usable
+// width, and a line nobody can scan reports nothing (D175 WP3).
 func (m Model) viewServerPanel() string {
 	s := m.snapshot
 	if s == nil {
 		return ""
 	}
-	state := strings.ReplaceAll(s.State, "_", "-")
-	line := fmt.Sprintf("Server  %s  %s", compactForWidth(s.ServerURL, m.width), state)
+	valueWidth := 0
+	if m.width > 0 {
+		valueWidth = m.width - boxChromeWidth - serverLabelWidth
+	}
+	line := func(label, value string) string {
+		return styleSubtitle.Render(fmt.Sprintf("%-*s", serverLabelWidth, label)) + value
+	}
+
+	head := compactForWidth(s.ServerURL, m.width) + "  " + strings.ReplaceAll(s.State, "_", "-")
 	if s.Reachable {
-		line += fmt.Sprintf("  ready=%s  client %s · server %s", readinessLabel(s.Ready), s.Client, s.Server)
+		head += " · " + readinessLabel(s.Ready)
+	}
+	lines := []string{line("server", head)}
+
+	versions := "client " + s.Client
+	if s.Server != "" {
+		versions += " · server " + s.Server
+	}
+	if s.State == "version_skew" {
+		versions = styleDrift.Render(versions)
+	}
+	lines = append(lines, line("version", versions))
+
+	if svc := serviceLine(s.Service); svc != "" {
+		lines = append(lines, line("service", svc))
 	}
 	if len(s.KBs) > 0 {
-		line += "  KBs " + strings.Join(s.KBs, ", ")
+		lines = append(lines, line("KBs", truncateForWidth(kbBindingSummary(s), valueWidth)))
 	}
 	if s.Error != nil {
-		line += "\n  " + wrapForWidth(s.Error.Message, m.width-8)
+		lines = append(lines, "  "+wrapForWidth(s.Error.Message, m.width-8))
 	}
-	if s.Service != nil {
-		line += fmt.Sprintf("\n  local service: installed=%t running=%t", s.Service.Installed, s.Service.Running)
+	return strings.Join(lines, "\n")
+}
+
+// serviceLine describes the local native service, and only when there is one
+// to describe (D174): with nothing installed the panel says nothing rather
+// than rendering an absence as a failure. "loaded" is what the init system
+// knows about the job, never a claim that a process is alive.
+func serviceLine(svc *serviceSnapshot) string {
+	if svc == nil || !svc.Installed {
+		return ""
 	}
-	return line
+	lifecycle := svc.Lifecycle
+	if lifecycle == "" {
+		// A snapshot from before Lifecycle existed: Running carries the same
+		// (equally weak) claim, so say the same thing rather than nothing.
+		if lifecycle = "not_loaded"; svc.Running {
+			lifecycle = "loaded"
+		}
+	}
+	return "local: installed · " + strings.ReplaceAll(lifecycle, "_", " ")
+}
+
+// kbBindingSummary lists the KBs the server mounts with how many connected
+// providers are bound to each. The number counts BINDINGS: not live sessions,
+// and not a confirmation that a sync has run. A KB the server serves and
+// nobody consumes is the most useful fact this line can carry, and it only
+// carries it if the count means exactly one thing — hence the explicit
+// "bound" on the first entry.
+func kbBindingSummary(s *statusSnapshot) string {
+	bound := map[string]int{}
+	for _, p := range s.Providers {
+		if !p.Connected {
+			continue
+		}
+		for _, kb := range p.BoundKBs {
+			bound[kb]++
+		}
+	}
+	parts := make([]string, 0, len(s.KBs))
+	for i, kb := range s.KBs {
+		if i == 0 {
+			parts = append(parts, fmt.Sprintf("%s (%d bound)", kb, bound[kb]))
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s (%d)", kb, bound[kb]))
+	}
+	return strings.Join(parts, " · ")
+}
+
+// formatBoundKBs renders a provider's KB binding: the names it receives and
+// where that answer came from. The three states BoundKBs distinguishes get
+// three different sentences on purpose — an explicit empty binding and an
+// absent one are opposite instructions, and both would render as an empty
+// list.
+func formatBoundKBs(kbs []string, explicit bool, width int) string {
+	origin := "  (default)"
+	if explicit {
+		origin = "  (explicit)"
+	}
+	var names string
+	switch {
+	case !explicit:
+		names = "all known"
+	case len(kbs) == 0:
+		names = "none"
+	default:
+		names = joinWithCounter(kbs, width-utf8.RuneCountInString(origin))
+	}
+	return names + origin
+}
+
+// joinWithCounter joins names within width columns, replacing those that do
+// not fit with a "+N" counter. It never wraps: the grid is what makes the card
+// readable, and it never cuts a name in half, which would name a KB that does
+// not exist.
+func joinWithCounter(names []string, width int) string {
+	joined := strings.Join(names, ", ")
+	if width <= 0 || utf8.RuneCountInString(joined) <= width {
+		return joined
+	}
+	for i := len(names) - 1; i > 0; i-- {
+		candidate := fmt.Sprintf("%s +%d", strings.Join(names[:i], ", "), len(names)-i)
+		if utf8.RuneCountInString(candidate) <= width {
+			return candidate
+		}
+	}
+	if len(names) == 1 {
+		return "1 KB"
+	}
+	return fmt.Sprintf("%d KBs", len(names))
+}
+
+// truncateForWidth shortens s to width columns with an ellipsis, for values
+// that must stay on one line. Width 0 (terminal size not yet known) means no
+// truncation.
+func truncateForWidth(s string, width int) string {
+	if width <= 0 || utf8.RuneCountInString(s) <= width {
+		return s
+	}
+	if width == 1 {
+		return "…"
+	}
+	return string([]rune(s)[:width-1]) + "…"
 }
 
 func compactForWidth(s string, width int) string {
@@ -1061,7 +1320,7 @@ func compactForWidth(s string, width int) string {
 
 func readinessLabel(ready *bool) string {
 	if ready == nil {
-		return "unknown"
+		return "readiness unknown"
 	}
 	if *ready {
 		return "ready"
@@ -1095,7 +1354,17 @@ func (m Model) viewConfirmDisconnect() string {
 	} else {
 		no = styleSelected.Render("> no <")
 	}
-	return fmt.Sprintf("%s\n\n   %s   %s", wrapForWidth(fmt.Sprintf("Disconnect %s? This removes its MCP config entry and managed artifacts.", m.confirmProvider), m.width-6), yes, no)
+	return fmt.Sprintf("%s\n\n   %s   %s", wrapForWidth(disconnectPrompt(m.confirmProvider, m.confirmKBs), m.width-6), yes, no)
+}
+
+// disconnectPrompt names the KBs whose artifacts the disconnect removes
+// (D175 WP4). "managed artifacts" alone does not tell the user what leaves
+// this machine, which is the one thing the confirmation exists to say.
+func disconnectPrompt(provider string, kbs []string) string {
+	if len(kbs) == 0 {
+		return fmt.Sprintf("Disconnect %s? This removes its MCP config entry and any managed artifacts (it is bound to no KB).", provider)
+	}
+	return fmt.Sprintf("Disconnect %s? This removes its MCP config entry and the artifacts it received from %s.", provider, strings.Join(kbs, ", "))
 }
 
 // displayVersion normalizes the build version for the title bar: the

--- a/cmd/cartographer/tui_test.go
+++ b/cmd/cartographer/tui_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/BeppeTemp/cartographer/internal/agents"
+	"github.com/BeppeTemp/cartographer/internal/clientconfig"
 	"github.com/BeppeTemp/cartographer/internal/configurator"
 	"github.com/BeppeTemp/cartographer/internal/provisioning"
 )
@@ -26,7 +27,7 @@ func TestViewResponsiveServerPanelAndWidth(t *testing.T) {
 		m.width = width
 		m.snapshot = &statusSnapshot{Schema: statusSchema, ServerURL: "https://very-long.example.test/a/really/long/mcp/endpoint", Reachable: true, Ready: &ready, Client: "v1", Server: "v2", State: "version_skew"}
 		out := ansiRE.ReplaceAllString(m.View(), "")
-		if !strings.Contains(out, "Server") || !strings.Contains(out, "ready=ready") {
+		if !strings.Contains(out, "server") || !strings.Contains(out, "ready") {
 			t.Fatalf("width %d misses server/readiness: %s", width, out)
 		}
 		for _, line := range strings.Split(out, "\n") {
@@ -87,6 +88,7 @@ func testModel() Model {
 				Agent:       agents.Agent{Provider: configurator.ProviderOpenCode, Name: "OpenCode", Installed: true},
 				Connected:   true,
 				SkillStatus: "checking…",
+				BoundKBs:    []string{"kb-uno"},
 			},
 		},
 		screen: screenList,
@@ -897,5 +899,387 @@ func TestUpdate_WindowSizeMsgSetsWidth(t *testing.T) {
 	}
 	if cmd != nil {
 		t.Errorf("WindowSizeMsg non deve produrre un cmd")
+	}
+}
+
+// --- D175 WP1: per-provider KB attribution ---------------------------------
+
+// TestFormatBoundKBs pins the three states BoundKBs distinguishes as three
+// different sentences: an explicit empty binding and an absent one are
+// opposite instructions and must never render the same way.
+func TestFormatBoundKBs(t *testing.T) {
+	tests := []struct {
+		name     string
+		kbs      []string
+		explicit bool
+		width    int
+		want     string
+	}{
+		{"explicit list", []string{"kb-uno", "kb-due"}, true, 0, "kb-uno, kb-due  (explicit)"},
+		{"default", []string{"kb-uno", "kb-due"}, false, 0, "all known  (default)"},
+		{"explicit empty", nil, true, 0, "none  (explicit)"},
+		{"truncated with a counter", []string{"kb-uno", "kb-due", "kb-tre", "kb-quattro"}, true, 32, "kb-uno, kb-due +2  (explicit)"},
+		{"not even one name fits", []string{"a-very-long-kb-name", "another-one"}, true, 18, "2 KBs  (explicit)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatBoundKBs(tt.kbs, tt.explicit, tt.width); got != tt.want {
+				t.Errorf("formatBoundKBs = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestJoinWithCounterNeverWraps: the value must stay on one line whatever the
+// width — a wrapped value breaks the column the card is read by.
+func TestJoinWithCounterNeverWraps(t *testing.T) {
+	for _, width := range []int{0, 5, 12, 40, 200} {
+		got := joinWithCounter([]string{"kb-uno", "kb-due", "kb-tre"}, width)
+		if strings.Contains(got, "\n") {
+			t.Fatalf("width %d wrapped: %q", width, got)
+		}
+	}
+}
+
+// TestViewList_KBLineStates renders the three binding states through the real
+// view, on the grid, under mcp-config.
+func TestViewList_KBLineStates(t *testing.T) {
+	tests := []struct {
+		name string
+		row  dashboardAgent
+		want string
+	}{
+		{"explicit", dashboardAgent{Agent: agents.Agent{Name: "Claude Code"}, Connected: true, BoundKBs: []string{"kb-uno", "kb-due"}, BindingExplicit: true}, "kbs         kb-uno, kb-due  (explicit)"},
+		{"default", dashboardAgent{Agent: agents.Agent{Name: "Claude Code"}, Connected: true, BoundKBs: []string{"kb-uno"}}, "kbs         all known  (default)"},
+		{"explicit empty", dashboardAgent{Agent: agents.Agent{Name: "Claude Code"}, Connected: true, BindingExplicit: true}, "kbs         none  (explicit)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := Model{version: "test", rows: []dashboardAgent{tt.row}, screen: screenList}
+			out := ansiRE.ReplaceAllString(m.viewList(), "")
+			if !strings.Contains(out, tt.want) {
+				t.Errorf("viewList missing %q in:\n%s", tt.want, out)
+			}
+		})
+	}
+}
+
+// TestBuildRowsResolvesBindingLocally is the WP1 invariant: the binding is
+// local data (.cartographer.yaml), so it is in the first frame — buildRows
+// contacts nothing.
+func TestBuildRowsResolvesBindingLocally(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &clientconfig.Config{
+		ServerURL: "http://127.0.0.1:1/mcp",
+		Agents:    []string{string(configurator.ProviderClaudeCode), string(configurator.ProviderOpenCode)},
+		KnownKBs:  []string{"kb-uno", "kb-due"},
+		Clients: map[string]clientconfig.ClientBinding{
+			string(configurator.ProviderClaudeCode): {KBs: []string{"kb-due"}},
+		},
+	}
+	if err := clientconfig.Save(dir, cfg); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	for _, row := range buildRows(dir) {
+		if !row.Connected {
+			continue
+		}
+		switch row.Provider {
+		case configurator.ProviderClaudeCode:
+			if !row.BindingExplicit || len(row.BoundKBs) != 1 || row.BoundKBs[0] != "kb-due" {
+				t.Errorf("claude binding = %v explicit=%t, want [kb-due] explicit", row.BoundKBs, row.BindingExplicit)
+			}
+		case configurator.ProviderOpenCode:
+			if row.BindingExplicit || len(row.BoundKBs) != 2 {
+				t.Errorf("opencode binding = %v explicit=%t, want the two known KBs by default", row.BoundKBs, row.BindingExplicit)
+			}
+		}
+	}
+}
+
+// --- D175 WP2: the per-kind breakdown, and honesty about not knowing -------
+
+// TestViewList_KindsUnknownBeforeAndAfterAFailedFetch: an unmeasured breakdown
+// must read as unknown. Showing the previous poll's counts — or nothing, which
+// reads as "clean" — would report a verdict computed against a manifest that
+// was never fetched.
+func TestViewList_KindsUnknownBeforeAndAfterAFailedFetch(t *testing.T) {
+	row := dashboardAgent{Agent: agents.Agent{Name: "Claude Code"}, Connected: true, SkillStatus: "checking…"}
+	m := Model{version: "test", rows: []dashboardAgent{row}, screen: screenList}
+	if out := ansiRE.ReplaceAllString(m.viewList(), ""); !strings.Contains(out, "kinds       unknown") {
+		t.Errorf("before the fetch the breakdown must be unknown:\n%s", out)
+	}
+
+	// A fetch that failed: the provider is absent from the kinds map, so a
+	// breakdown left over from an earlier poll must be cleared.
+	m.rows[0].KindStatus, m.rows[0].KindsKnown = "skill 5/5", true
+	next, _ := m.Update(remoteStatusMsg{
+		statuses: map[string]string{"": "unknown"},
+		kinds:    map[string]string{},
+		snapshot: statusSnapshot{Schema: statusSchema, State: "unavailable"},
+	})
+	m = next.(Model)
+	if m.rows[0].KindsKnown {
+		t.Error("a failed fetch must clear the breakdown, not keep the stale one")
+	}
+	if out := ansiRE.ReplaceAllString(m.viewList(), ""); !strings.Contains(out, "kinds       unknown") {
+		t.Errorf("after a failed fetch the breakdown must be unknown:\n%s", out)
+	}
+}
+
+// TestViewList_KindsAfterFetch: a successful fetch shows the breakdown, and an
+// empty-but-read manifest is not rendered as unknown.
+func TestViewList_KindsAfterFetch(t *testing.T) {
+	m := testModel()
+	next, _ := m.Update(remoteStatusMsg{
+		statuses: map[string]string{string(configurator.ProviderOpenCode): "in-sync"},
+		kinds:    map[string]string{string(configurator.ProviderOpenCode): "skill 5/5 · agent 4/4"},
+	})
+	m = next.(Model)
+	out := ansiRE.ReplaceAllString(m.viewList(), "")
+	if !strings.Contains(out, "kinds       skill 5/5 · agent 4/4") {
+		t.Errorf("missing the breakdown after the fetch:\n%s", out)
+	}
+
+	// Read, and empty: known, with nothing in it.
+	next, _ = m.Update(remoteStatusMsg{
+		statuses: map[string]string{string(configurator.ProviderOpenCode): "in-sync"},
+		kinds:    map[string]string{string(configurator.ProviderOpenCode): ""},
+	})
+	out = ansiRE.ReplaceAllString(next.(Model).viewList(), "")
+	if !strings.Contains(out, "kinds       no artifacts") {
+		t.Errorf("an empty but successfully read manifest must not read as unknown:\n%s", out)
+	}
+}
+
+// TestViewList_SpinnerDuringTheFetch: the artifacts line keeps the spinner
+// while loading, and the breakdown below it says unknown.
+func TestViewList_SpinnerDuringTheFetch(t *testing.T) {
+	m := testModel()
+	m.loading = true
+	out := ansiRE.ReplaceAllString(m.viewList(), "")
+	if !strings.Contains(out, "checking…") || !strings.Contains(out, "kinds       unknown") {
+		t.Errorf("expected the spinner state and an unknown breakdown:\n%s", out)
+	}
+}
+
+// --- D175 WP3: the server panel --------------------------------------------
+
+// TestViewServerPanel_LabelledBlock covers the WP3 acceptance: readable at 100
+// columns with four KBs, one labelled line each, and a binding count per KB
+// including the zero that matters most.
+func TestViewServerPanel_LabelledBlock(t *testing.T) {
+	ready := true
+	m := testModel()
+	m.width = 100
+	m.snapshot = &statusSnapshot{
+		Schema: statusSchema, ServerURL: "http://localhost:39273/mcp", Reachable: true, Ready: &ready,
+		Client: "v0.10.0", Server: "v0.10.0", State: "in_sync",
+		KBs: []string{"kb-uno", "kb-due", "kb-tre", "kb-quattro"},
+		Providers: []providerStatus{
+			{Name: "claude", Connected: true, BoundKBs: []string{"kb-uno", "kb-due"}},
+			{Name: "codex", Connected: true, BoundKBs: []string{"kb-uno"}},
+			{Name: "kiro", Connected: true, BoundKBs: []string{"kb-uno"}},
+			{Name: "hermes", Connected: false, BoundKBs: []string{"kb-tre"}},
+		},
+		Service: &serviceSnapshot{Installed: true, Running: true, Lifecycle: "loaded"},
+	}
+	out := ansiRE.ReplaceAllString(m.viewServerPanel(), "")
+	for _, want := range []string{
+		"server     http://localhost:39273/mcp  in-sync · ready",
+		"version    client v0.10.0 · server v0.10.0",
+		"service    local: installed · loaded",
+		"KBs        kb-uno (3 bound) · kb-due (1) · kb-tre (0) · kb-quattro (0)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("server panel missing %q in:\n%s", want, out)
+		}
+	}
+	for _, line := range strings.Split(ansiRE.ReplaceAllString(m.View(), ""), "\n") {
+		if got := utf8.RuneCountInString(line); got > 100 {
+			t.Errorf("overflow at 100 columns (%d): %q", got, line)
+		}
+	}
+}
+
+// TestViewServerPanel_NoLocalService: with nothing installed the panel says
+// nothing about a service, rather than rendering an absence as a failure
+// (D174).
+func TestViewServerPanel_NoLocalService(t *testing.T) {
+	for _, svc := range []*serviceSnapshot{nil, {Installed: false}} {
+		m := testModel()
+		m.width = 100
+		m.snapshot = &statusSnapshot{Schema: statusSchema, ServerURL: "http://h/mcp", Client: "v1", State: "in_sync", Service: svc}
+		if out := ansiRE.ReplaceAllString(m.viewServerPanel(), ""); strings.Contains(out, "service") {
+			t.Errorf("no local service must produce no service line:\n%s", out)
+		}
+	}
+}
+
+// TestViewServerPanel_VersionSkewKeepsTheDriftStyle
+func TestViewServerPanel_VersionSkewKeepsTheDriftStyle(t *testing.T) {
+	m := testModel()
+	m.width = 100
+	m.snapshot = &statusSnapshot{Schema: statusSchema, ServerURL: "http://h/mcp", Reachable: true, Client: "v0.10.0", Server: "v0.11.0", State: "version_skew"}
+	raw := m.viewServerPanel()
+	if !strings.Contains(ansiRE.ReplaceAllString(raw, ""), "version    client v0.10.0 · server v0.11.0") {
+		t.Errorf("missing the version line:\n%s", raw)
+	}
+	// Asserted through the style itself, so the check holds whether or not
+	// the test environment renders colour: under a no-colour profile
+	// styleDrift.Render is the identity and the assertion degrades to the
+	// text, under a colour profile it pins the escape sequences.
+	if !strings.Contains(raw, styleDrift.Render("client v0.10.0 · server v0.11.0")) {
+		t.Errorf("a version skew must keep the drift style:\n%q", raw)
+	}
+}
+
+// TestViewServerPanel_ReadableAtReducedWidth
+func TestViewServerPanel_ReadableAtReducedWidth(t *testing.T) {
+	for _, width := range []int{60, 80, 100, 120} {
+		m := testModel()
+		m.width = width
+		m.snapshot = &statusSnapshot{
+			Schema: statusSchema, ServerURL: "http://localhost:39273/mcp", Reachable: true, Client: "v0.10.0", Server: "v0.10.0", State: "in_sync",
+			KBs:       []string{"kb-uno", "kb-due", "kb-tre", "kb-quattro"},
+			Providers: []providerStatus{{Name: "claude", Connected: true, BoundKBs: []string{"kb-uno"}}},
+		}
+		for _, line := range strings.Split(ansiRE.ReplaceAllString(m.View(), ""), "\n") {
+			if got := utf8.RuneCountInString(line); got > width {
+				t.Errorf("width %d overflow %d: %q", width, got, line)
+			}
+		}
+	}
+}
+
+// --- D175 WP4: actions consistent with the bindings ------------------------
+
+// TestUpdate_SyncAllIsSequentialAndNamesTheProviderInFlight
+func TestUpdate_SyncAllIsSequentialAndNamesTheProviderInFlight(t *testing.T) {
+	m := testModel()
+	m.rows[0].Connected = true // both rows connected
+
+	next, cmd := m.Update(keyMsg("S"))
+	m = next.(Model)
+	if !m.syncingAll || cmd == nil {
+		t.Fatal("S must start a sync-all run")
+	}
+	if !strings.Contains(m.message, "one at a time") {
+		t.Errorf("the message must say the run is sequential, got %q", m.message)
+	}
+
+	next, cmd = m.Update(syncProgressMsg{provider: "opencode"})
+	m = next.(Model)
+	if m.message != "syncing opencode…" {
+		t.Errorf("progress message = %q, want the provider in flight", m.message)
+	}
+	if cmd == nil {
+		t.Error("the progress listener must re-arm itself")
+	}
+
+	// The outcome must survive a progress message still in flight behind it.
+	next, _ = m.Update(syncAllDoneMsg{done: []string{"claude", "opencode"}})
+	m = next.(Model)
+	if m.syncingAll {
+		t.Error("syncingAll must be cleared by the outcome")
+	}
+	outcome := m.message
+	next, cmd = m.Update(syncProgressMsg{provider: "opencode"})
+	if got := next.(Model).message; got != outcome {
+		t.Errorf("a late progress message overwrote the outcome: %q", got)
+	}
+	if cmd != nil {
+		t.Error("a late progress message must not re-arm the listener")
+	}
+}
+
+// TestWaitForSyncProgressCmd: one announcement per call, nil once the run has
+// closed the channel.
+func TestWaitForSyncProgressCmd(t *testing.T) {
+	ch := make(chan string, 2)
+	ch <- "claude"
+	close(ch)
+
+	if msg := waitForSyncProgressCmd(ch)(); msg != (syncProgressMsg{provider: "claude"}) {
+		t.Errorf("first read = %#v, want the announced provider", msg)
+	}
+	if msg := waitForSyncProgressCmd(ch)(); msg != nil {
+		t.Errorf("a closed channel must end the chain, got %#v", msg)
+	}
+}
+
+// TestSyncAllCmdAnnouncesEveryProviderInOrder: sequential, and reported as
+// such. The sync itself fails here (no config in the temp dir) — the point is
+// that the announcement precedes the work and the run is ordered.
+func TestSyncAllCmdAnnouncesEveryProviderInOrder(t *testing.T) {
+	dir := t.TempDir()
+	progress := make(chan string, 3)
+	msg := syncAllCmd([]string{"claude", "codex", "kiro"}, dir, progress)()
+
+	if _, ok := msg.(syncAllDoneMsg); !ok {
+		t.Fatalf("syncAllCmd returned %#v, want syncAllDoneMsg", msg)
+	}
+	var got []string
+	for p := range progress { // closed by syncAllCmd: this must terminate
+		got = append(got, p)
+	}
+	if len(got) == 0 || got[0] != "claude" {
+		t.Errorf("announcements = %v, want them to start at the first provider", got)
+	}
+}
+
+// TestUpdate_EnterSyncsOnlyTheSelectedProvider: the selection is what gets
+// synced, and no sync-all state is entered.
+func TestUpdate_EnterSyncsOnlyTheSelectedProvider(t *testing.T) {
+	m := testModel()
+	m.cursor = 1 // OpenCode, connected
+
+	next, cmd := m.Update(keyMsg("s"))
+	m = next.(Model)
+	if cmd == nil || !strings.Contains(m.message, "opencode") {
+		t.Errorf("s must sync the selected provider, message = %q", m.message)
+	}
+	if m.syncingAll {
+		t.Error("a single-provider sync must not enter the sync-all run")
+	}
+}
+
+// TestDisconnectPromptNamesTheKBs: the confirmation must say what leaves this
+// machine, which is the one thing it exists to say.
+func TestDisconnectPromptNamesTheKBs(t *testing.T) {
+	if got := disconnectPrompt("opencode", []string{"kb-uno", "kb-due"}); !strings.Contains(got, "kb-uno, kb-due") {
+		t.Errorf("prompt must name the bound KBs, got %q", got)
+	}
+	if got := disconnectPrompt("opencode", nil); !strings.Contains(got, "bound to no KB") {
+		t.Errorf("a provider bound to nothing must be said so, got %q", got)
+	}
+}
+
+// TestUpdate_ConfirmDisconnectCapturesTheBinding
+func TestUpdate_ConfirmDisconnectCapturesTheBinding(t *testing.T) {
+	m := testModel()
+	m.cursor = 1
+	m.rows[1].BoundKBs = []string{"kb-uno", "kb-due"}
+
+	next, _ := m.Update(keyMsg("d"))
+	m = next.(Model)
+	if m.screen != screenConfirmDisconnect {
+		t.Fatalf("screen = %v, want the confirmation", m.screen)
+	}
+	out := ansiRE.ReplaceAllString(m.viewConfirmDisconnect(), "")
+	if !strings.Contains(out, "kb-uno") || !strings.Contains(out, "kb-due") {
+		t.Errorf("the confirmation must name the provider's KBs:\n%s", out)
+	}
+}
+
+// TestFooterDistinguishesTheTwoSyncKeys: s and S do different things and the
+// footer has to say which.
+func TestFooterDistinguishesTheTwoSyncKeys(t *testing.T) {
+	m := testModel()
+	m.cursor = 1 // connected: the footer shows the sync keys
+	out := ansiRE.ReplaceAllString(m.View(), "")
+	if !strings.Contains(out, "sync selected") || !strings.Contains(out, "sync all") {
+		t.Errorf("footer must distinguish the two sync keys:\n%s", out)
 	}
 }

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -196,14 +196,19 @@ failure for each provider.
 ### Dashboard
 
 With no subcommand in a TTY, the dashboard renders the same status snapshot as
-`status`. Its server panel shows the effective URL, reachability/readiness,
-versions, selected KBs and loopback native-service state. `Enter` connects a
-disconnected provider or syncs a connected one; `s` syncs the selected provider,
-`S` syncs all connected providers, `d` opens the disconnect confirmation and
-`r` refreshes. Unavailable actions are omitted from the contextual key map.
-At 60 columns it uses compact labels and shortened endpoints; 80 is the normal
-layout and 120 retains full endpoint and artifact detail. Failures keep the
-current selection and entered connect-form values.
+`status`. Its server panel is a labelled block — endpoint with state and
+readiness, client/server versions, the local native service when one is
+installed, and the KB inventory with, per KB, how many connected providers are
+**bound** to it (a count of bindings: not sessions, and not a confirmation that
+a sync has run, so `kb-tre (0)` means the server serves it and nothing consumes
+it). `Enter` connects a disconnected provider or syncs a connected one; `s`
+syncs the selected provider, `S` syncs every connected provider one at a time
+and names the one in flight, `d` opens the disconnect confirmation — which
+names the KBs whose artifacts will be removed — and `r` refreshes. Unavailable
+actions are omitted from the contextual key map. At 60 columns it uses compact
+labels and shortened endpoints; 80 is the normal layout and 120 retains full
+endpoint and artifact detail. Failures keep the current selection and entered
+connect-form values.
 
 ### `cartographer sync`
 
@@ -764,17 +769,44 @@ automatically migrated on read (`provisioning.ReadLockFile`) into `{"providers":
 ## TUI mode (interactive dashboard)
 
 Running `cartographer` with no arguments in a terminal opens an interactive dashboard
-(`cmd/cartographer/tui.go`, `bubbletea`): it lists the four providers vertically, one card per
-provider with an explicit status (`connected` / `not connected` / `not installed`) and indented
-details below — binary path, MCP config, provisioning artifacts with per-kind counts
-(`formatKindStatus`) — loaded asynchronously against the configured server.
+(`cmd/cartographer/tui.go`, `bubbletea`): a server block, then one card per provider with an
+explicit status (`connected` / `not connected` / `not installed`) and indented details below,
+laid out on a two-column grid:
+
+```
+server     http://localhost:39273/mcp  in-sync · ready
+version    client v0.10.0 · server v0.10.0
+service    local: installed · loaded
+KBs        kb-uno (2 bound) · kb-due (1) · kb-tre (0) · kb-quattro (0)
+
+> Claude Code    connected
+      binary      /opt/homebrew/bin/claude
+      mcp-config  in-sync
+      kbs         kb-uno, kb-due  (explicit)
+      artifacts   in-sync
+      kinds       skill 5/5 · agent 4/4 · hook 2/2 · instructions 1/1
+```
+
+`binary` and `kbs` are local data and are in the first frame; `artifacts` and `kinds` are
+fetched asynchronously against the configured server.
+
+- **`kbs`** is the provider's own binding (D169): the declared names with `(explicit)`,
+  `all known (default)` when nothing was declared, and `none (explicit)` for a binding
+  deliberately emptied. A list too long for the row is truncated with a counter
+  (`kb-uno, kb-due +2`) and never wrapped.
+- **`kinds`** is the per-kind breakdown `formatKindStatus` produces, the same one
+  `cartographer status` prints — both read it off the shared snapshot. It says `unknown`
+  before the first fetch resolves and after one that failed: a breakdown computed against a
+  manifest that was never fetched is not a clean bill of health. `no artifacts` is the
+  distinct case of a manifest that *was* read and holds nothing.
 
 Main keys:
 
 | Key | Action |
 |---|---|
-| `enter` / `s` | Connect (if not connected) or resync |
-| `d` | Disconnect (if connected) — opens an inline `y`/`n` confirmation |
+| `enter` / `s` | Connect (if not connected) or resync the **selected** provider |
+| `S` | Sync every connected provider, one at a time under a single client lock (D172) |
+| `d` | Disconnect (if connected) — opens an inline `y`/`n` confirmation naming its KBs |
 | `r` | Refresh status |
 | `q` / `Esc` | Quit |
 

--- a/docs/decisions/client-configurator.md
+++ b/docs/decisions/client-configurator.md
@@ -732,3 +732,73 @@ written file.
 
 **Consequences.** None observable for a hand-written config: `omitempty` means a
 zero `SearchDepth` still writes no key, so existing files are not churned.
+
+---
+
+<a id="d175"></a>
+## D175 — The dashboard is binding-aware, and says when it does not know
+
+**Decision.** The dashboard stays one list screen and gains four things: a `kbs`
+line per provider carrying its binding and the binding's origin, a `kinds` line
+carrying the per-kind breakdown `cartographer status` already printed, a server
+panel broken into a labelled block whose KB inventory counts bindings per KB,
+and a footer, a sync-all progress report and a disconnect confirmation that
+name what they act on. Every provider detail line goes through one grid helper.
+
+**Rationale.**
+
+- **The screen could not answer the question it exists to ask.** With four KBs
+  mounted every provider rendered identically — three lines, all `in-sync` —
+  and the KB list appeared once, as a property of the server. Which provider
+  receives which KB was unanswerable, and D170 made the answer differ per
+  provider. The binding belongs on the provider, next to what it explains.
+- **The three binding states get three sentences.** `BoundKBs` distinguishes
+  absent, empty and populated; rendering the first two as an empty list would
+  make "receives every known KB" and "receives none" look the same, which is
+  the exact confusion D169 introduced the resolver to prevent. So: the names
+  with `(explicit)`, `all known (default)`, `none (explicit)`.
+- **The TUI showed strictly less than the CLI, and the comment claimed
+  otherwise.** `formatKindStatus`'s doc comment named the dashboard as a caller;
+  it never was one. The breakdown was already on the snapshot both renderers
+  read, so this is a rendering omission, not a new computation — and the fix is
+  reading the field, which is also why the two cannot now drift.
+- **"Not measured" is not "fine".** A breakdown is only shown for a provider
+  whose manifest was actually read: `remoteStatusMsg.kinds` omits a provider
+  whose state came back `unknown`, and the row renders `unknown` rather than
+  keeping the previous poll's counts. A dashboard reporting `in-sync` computed
+  against a manifest it could not fetch is worse than one that admits it does
+  not know. The mirror case is kept apart: a manifest read and found empty is
+  `no artifacts`.
+- **The count in the server panel is a count of bindings.** Not sessions, not
+  proof a sync completed — the label says `bound` for exactly that reason. A KB
+  the server mounts and nobody consumes (`kb-tre (0)`) is the most useful fact
+  the panel can carry, and it can only carry it if the number means one thing.
+- **No new colours, no second pane.** The dashboard is a quick-inspection tool;
+  depth belongs to `status` and `doctor`. Another badge in another colour makes
+  the screen less readable, not more, so the existing styles are reused and the
+  work went into the grid instead.
+- **Progress reporting must never be able to stall a sync.** `S` was already
+  sequential under one lock (D172); it now announces each provider on a channel
+  buffered for the whole run, so a send cannot block while the lock is held. A
+  progress message arriving after the outcome is dropped rather than allowed to
+  overwrite the result the user needs to read.
+- **The confirmation names the KBs.** "Removes managed artifacts" does not say
+  what leaves the machine, which is the only thing a destructive confirmation
+  is for.
+
+**Deviation from the plan.** The plan folded the breakdown under `artifacts` as
+a second, unlabelled line. It became a labelled `kinds` row instead: an
+unlabelled `unknown` floating under a status is ambiguous about *what* is
+unknown, and the two-column grid the plan calls the reason the screen is
+scannable is what makes the label cheap.
+
+**Invariant preserved.** The first frame is still built from local data only —
+the binding is resolved in `buildRows` through `Config.BoundKBs`, alongside
+agent detection and mcp-config presence. Nothing added here waits on the
+network.
+
+**Consequences.** Presentation only; no behaviour outside the dashboard
+changes. The server panel's single line became four, and `ready=ready` became
+`· ready` — cosmetic, but visible to anyone reading a screenshot. The `S`
+behaviour change is the one inherited from D172 and should be described as such
+in the release notes.


### PR DESCRIPTION
Implements the approved D175 plan. Presentation-only change to the dashboard, plus the `S` behaviour already decided in D172.

## What the screen looks like now

```
server     http://localhost:39273/mcp  in-sync · ready
version    client v0.10.0 · server v0.10.0
service    local: installed · loaded
KBs        kb-uno (2 bound) · kb-due (1) · kb-tre (0) · kb-quattro (0)

> Claude Code    connected
      binary      /opt/homebrew/bin/claude
      mcp-config  in-sync
      kbs         kb-uno, kb-due  (explicit)
      artifacts   in-sync
      kinds       skill 5/5 · agent 4/4 · hook 2/2 · instructions 1/1

  Codex CLI      connected
      binary      /opt/homebrew/bin/codex
      mcp-config  partial
      kbs         all known  (default)
      artifacts   drift +2 ~1 -0
      kinds       unknown

  Kiro           connected
      binary      /usr/local/bin/kiro
      mcp-config  in-sync
      kbs         none  (explicit)
      artifacts   in-sync
      kinds       no artifacts
```

## The four work packages

- **WP1** — `kbs` per provider, resolved from `Config.BoundKBs` in `buildRows`. Local data, so it is in the first frame: the invariant that no new information may make the first frame depend on the network is preserved.
- **WP2** — `kinds` renders the breakdown both renderers read off the shared snapshot, so the TUI and `cartographer status` cannot drift. It says `unknown` before the first fetch and after a failed one, and `no artifacts` for a manifest read and found empty. The doc comment on `formatKindStatus` that claimed a TUI call site is corrected.
- **WP3** — the server panel is a labelled block. Its per-KB number counts **bindings** — not sessions, not a sync confirmation — labelled `bound` for that reason.
- **WP4** — `S` announces the provider in flight (buffered channel, so progress can never stall a run holding the client lock; a late announcement is dropped instead of overwriting the outcome), the footer distinguishes `s` from `S`, and the disconnect confirmation names the KBs.

## Deviation from the plan

The breakdown is a labelled `kinds` row, not an unlabelled second line under `artifacts`: a bare `unknown` is ambiguous about what is unknown, and the two-column grid the plan calls the reason the screen is scannable makes the label cheap. Recorded in the D175 entry.

## Verification

`make vet` and `make test` green across every package. New tests cover the three binding states and truncation, `unknown` before/after a failed fetch and the spinner during, the panel with and without a local service, with a zero-binding KB, on version skew and at 60/80/100/120 columns, and the WP4 action/progress/confirmation behaviour.

## Closing checklist

- [x] Current-state docs: `docs/configurator.md` (§Dashboard, §TUI mode)
- [x] Decision record: `docs/decisions/client-configurator.md` (D175)
- [x] Release impact stated in the commit body for release-please

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
