### PR TITLE
fix(repoindex): validate cached clone paths and invalidate on roots change (D181)

### DIFF
--- a/docs/decisions/sync-provisioning.md
+++ b/docs/decisions/sync-provisioning.md
@@ -1016,3 +1016,53 @@ and is reported as needing approval.
 **Consequences.** The first sync after release removes files that were orphaned
 **and** are re-owned by a rewritten artifact; older orphans are reported by
 `doctor`, not deleted. Both belong in the release notes.
+
+---
+
+<a id="d181"></a>
+## D181 — A cached repo path is validated before use, and a change of roots invalidates the cache
+
+**Decision.** `repoindex.lookupIndex` no longer serves a cached candidate path
+as-is: each candidate's paths are filtered down to the ones that currently hold
+a live clone (a directory containing a `.git` entry, checked with the
+symlink-following `stat`, one call per candidate), and ambiguity/emptiness is
+evaluated on the survivors, not on the raw cache. `Resolve` also compares the
+cache's `Index.Roots` against the `roots` argument (each element normalized
+with `expandHome`, order-sensitive) before trusting the cache at all — a
+difference skips `lookupIndex` entirely and falls through to a fresh `Scan`.
+
+**Context.** `Resolve` served a cache hit with no filesystem check: moving a
+clone left every `{{repo:<key>}}` citing it resolving to the old, now-wrong
+location, silently and indefinitely — `service restart` did nothing, since the
+stale value lives in `~/.config/cartographer/repos.json`, not in server memory.
+Only a deliberate miss (resolving a nonexistent key) rewrote the cache, by
+accident. Two adjacent gaps made it worse: `Index.Roots` was persisted and never
+read, so editing `search_roots` didn't invalidate anything either; and with
+multiple clones of the same remote, a dead first-in-root-order entry kept
+winning over a live second one. Worst case, a leftover clone at the old
+path (an old copy, a `.Trash` copy) made the wrong resolution look like a
+correct one — an agent following the placeholder read, or committed into, the
+wrong working tree with nothing to signal it.
+
+- **Refresh-on-miss stays the only refresh path (D75).** No watcher, no daemon,
+  no TTL: a stale hit now degrades to a miss, which was already the trigger for
+  a rescan. The behaviour that repairs staleness is the one D75 already
+  specified — it just never used to fire.
+- **A hit stays cheap.** Validation costs one `stat` per candidate path
+  (following a symlinked clone correctly), never a filesystem walk — the depth
+  cap exists precisely to keep `Scan` off the common resolution path, and this
+  does not reintroduce it.
+- **Root order still decides the winner** among multiple live clones; the
+  filter only removes candidates that are not really there anymore.
+- **An ambiguous short name that is only ambiguous on paper — because one of
+  the colliding remotes has no live clone left — now resolves instead of
+  erroring.** That is the intended fix, not a side effect: the ambiguity was an
+  artefact of a stale index, and D75's "ask for the full form" rule exists to
+  disambiguate remotes that really do coexist on disk.
+- **An empty-vs-nonempty `Roots` counts as a difference.** A cache written
+  before this change carries no `Roots`, so the very first resolution after
+  upgrade always rescans once — an intended, one-time cost, not a bug.
+
+**Consequences.** No interface, configuration, CLI or MCP surface change — this
+is a behavioural fix. The first resolution after upgrading to this version
+rescans once per cache, per the `Roots` edge case above. `fix:` release.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -128,6 +128,14 @@ repositories were invisible and every `{{repo:<key>}}` citing one was unusable. 
 now names the depth it searched, the maximum, and the setting. Keying stays on the **normalised git
 remote**, never on a directory name: that is what makes a `repo:` key identical for every operator.
 
+A cache hit is not trusted blindly (D181): before a cached path is returned, `repoindex` checks
+that it still holds a live clone (a directory with a `.git` entry) — a moved or removed clone
+behaves as a cache miss and triggers a rescan, instead of resolving to a location that no longer
+exists (or, worse, to a leftover clone left behind at the old path). Editing `search_roots` in
+`.cartographer.yaml` also invalidates the cache — a changed root set is a rescan even for a key
+that is still present under the old roots, since root order decides which clone wins when more
+than one exists.
+
 ## The generated instructions block
 
 The client steering file carries one managed block per mounted KB: a generated routing sentence (KB
@@ -330,7 +338,10 @@ Shared content (concepts and provisioning artifacts) must never contain machine-
   handles ssh scp-like, `ssh://`, `https://`, `.git` suffix), identical on every machine of
   the team. `repoindex.Scan` walks `search_roots` (client config, default `~/Documents`) up to
   depth 4, reads each repo's `.git/config` (no `git` exec) and caches the result in
-  `~/.config/cartographer/repos.json`, refreshed on-miss.
+  `~/.config/cartographer/repos.json`, refreshed on-miss. A cache hit is validated before use
+  (D181): the candidate path must still be a directory containing a `.git` entry, or it is
+  treated as a miss and a rescan follows; a change of `search_roots` also invalidates the
+  cache, even for a key whose old path is still perfectly live.
 - `{{path:<name>}}` — manual `paths:` mapping in `.cartographer.yaml`, a fallback for directories that
   aren't git repos (and an override for `{{repo:<key>}}` too: `repoindex.Resolve` checks `paths:`
   before cache/scan).

--- a/internal/repoindex/repoindex.go
+++ b/internal/repoindex/repoindex.go
@@ -151,14 +151,28 @@ func EffectiveDepth(configured int) int {
 	}
 }
 
+// isLiveClone reports whether path currently holds a git clone: a directory
+// containing a .git entry, checked with the stat that follows symlinks (so a
+// symlinked clone keeps working). It defines "is a clone" in one place, used
+// both by walkDir when discovering repos during a Scan and by lookupIndex
+// when validating a cached path before serving it (D181) — a cache hit must
+// not paper over a clone that moved or was removed.
+func isLiveClone(path string) bool {
+	fi, err := os.Stat(path)
+	if err != nil || !fi.IsDir() {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(path, ".git")); err != nil {
+		return false
+	}
+	return true
+}
+
 func walkDir(dir string, depth, maxDepth int, idx *Index) {
 	if depth > maxDepth {
 		return
 	}
-	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
-		return
-	}
-	if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+	if isLiveClone(dir) {
 		if key, ok := readOriginRemote(dir); ok {
 			idx.Repos[key] = append(idx.Repos[key], dir)
 		}
@@ -257,10 +271,14 @@ var errNotIndexed = errors.New("repoindex: not indexed")
 
 // lookupIndex resolves key against idx alone: key containing "/" is treated
 // as a full canonical RemoteKey, otherwise as a short name matched against
-// every indexed key's ShortName(). Multiple distinct repos matching a short
-// name is an ambiguity error (spec: ask for the full form). Multiple local
-// clones of the same repo resolve to the first root-order match, with a
-// warning.
+// every indexed key's ShortName(). A candidate whose every local path has
+// moved or vanished is dropped before ambiguity or emptiness is evaluated
+// (D181): a cached entry pointing at a dead clone behaves as a miss, not as
+// an answer, so Resolve's caller falls through to a rescan. Among the
+// candidates with at least one live clone, multiple distinct repos matching
+// a short name is an ambiguity error (spec: ask for the full form), and
+// multiple live local clones of the same repo resolve to the first
+// root-order match, with a warning.
 func lookupIndex(idx *Index, key string) (string, []string, error) {
 	var candidates []RemoteKey
 	if strings.Contains(key, "/") {
@@ -274,25 +292,38 @@ func lookupIndex(idx *Index, key string) (string, []string, error) {
 			}
 		}
 	}
-	if len(candidates) == 0 {
+
+	livePaths := map[RemoteKey][]string{}
+	var survivors []RemoteKey
+	for _, c := range candidates {
+		var paths []string
+		for _, p := range idx.Repos[c] {
+			if isLiveClone(p) {
+				paths = append(paths, p)
+			}
+		}
+		if len(paths) > 0 {
+			livePaths[c] = paths
+			survivors = append(survivors, c)
+		}
+	}
+
+	if len(survivors) == 0 {
 		return "", nil, errNotIndexed
 	}
-	if len(candidates) > 1 {
-		sort.Slice(candidates, func(i, j int) bool { return candidates[i] < candidates[j] })
-		names := make([]string, len(candidates))
-		for i, c := range candidates {
+	if len(survivors) > 1 {
+		sort.Slice(survivors, func(i, j int) bool { return survivors[i] < survivors[j] })
+		names := make([]string, len(survivors))
+		for i, c := range survivors {
 			names[i] = string(c)
 		}
 		return "", nil, fmt.Errorf("repoindex: %q is ambiguous between %s — use the full host/owner/name form", key, strings.Join(names, ", "))
 	}
 
-	paths := idx.Repos[candidates[0]]
-	if len(paths) == 0 {
-		return "", nil, errNotIndexed
-	}
+	paths := livePaths[survivors[0]]
 	var warnings []string
 	if len(paths) > 1 {
-		warnings = append(warnings, fmt.Sprintf("repoindex: multiple local clones of %s, using %s", candidates[0], paths[0]))
+		warnings = append(warnings, fmt.Sprintf("repoindex: multiple local clones of %s, using %s", survivors[0], paths[0]))
 	}
 	return paths[0], warnings, nil
 }
@@ -308,7 +339,7 @@ func Resolve(key string, manualPaths map[string]string, roots []string, maxDepth
 		return expandHome(p), nil, nil
 	}
 
-	if idx, err := LoadCache(); err == nil {
+	if idx, err := LoadCache(); err == nil && rootsMatch(idx.Roots, roots) {
 		path, warnings, lookupErr := lookupIndex(idx, key)
 		if lookupErr == nil {
 			return path, warnings, nil
@@ -332,6 +363,27 @@ func Resolve(key string, manualPaths map[string]string, roots []string, maxDepth
 		return "", nil, err
 	}
 	return path, warnings, nil
+}
+
+// rootsMatch reports whether the cached search roots are still the ones
+// Resolve was called with, once each element is normalized with expandHome
+// so that "~/Documents" and its expanded form compare equal (D181). The
+// comparison is ordered: root order is what decides the winner among
+// multiple live clones in lookupIndex, so a reorder is a semantic change and
+// must invalidate the cache exactly like an addition or removal. A cache
+// written before Roots was compared this way carries an empty slice, which
+// differs from any nonempty configured roots — costing exactly one rescan on
+// first use after upgrade.
+func rootsMatch(cached, configured []string) bool {
+	if len(cached) != len(configured) {
+		return false
+	}
+	for i := range cached {
+		if expandHome(cached[i]) != expandHome(configured[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // expandHome expands a leading "~" (alone or as "~/...") to the user's home

--- a/internal/repoindex/repoindex_test.go
+++ b/internal/repoindex/repoindex_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -125,15 +126,23 @@ func TestLookupIndexAmbiguousShortName(t *testing.T) {
 }
 
 func TestLookupIndexMultipleClonesWarns(t *testing.T) {
+	root := t.TempDir()
+	first := filepath.Join(root, "first")
+	second := filepath.Join(root, "second")
+	os.MkdirAll(first, 0o755)
+	os.MkdirAll(second, 0o755)
+	writeGitRepo(t, first, "git@github.com:acme/tools.git")
+	writeGitRepo(t, second, "git@github.com:acme/tools.git")
+
 	idx := &Index{Repos: map[RemoteKey][]string{
-		"github.com/acme/tools": {"/first", "/second"},
+		"github.com/acme/tools": {first, second},
 	}}
 	path, warnings, err := lookupIndex(idx, "tools")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if path != "/first" {
-		t.Errorf("path = %q, want /first", path)
+	if path != first {
+		t.Errorf("path = %q, want %q", path, first)
 	}
 	if len(warnings) != 1 {
 		t.Errorf("expected 1 warning, got %v", warnings)
@@ -141,16 +150,24 @@ func TestLookupIndexMultipleClonesWarns(t *testing.T) {
 }
 
 func TestLookupIndexFullKey(t *testing.T) {
+	root := t.TempDir()
+	a := filepath.Join(root, "a")
+	b := filepath.Join(root, "b")
+	os.MkdirAll(a, 0o755)
+	os.MkdirAll(b, 0o755)
+	writeGitRepo(t, a, "git@github.com:acme/tools.git")
+	writeGitRepo(t, b, "git@gitlab.com:other/tools.git")
+
 	idx := &Index{Repos: map[RemoteKey][]string{
-		"github.com/acme/tools":  {"/a"},
-		"gitlab.com/other/tools": {"/b"},
+		"github.com/acme/tools":  {a},
+		"gitlab.com/other/tools": {b},
 	}}
 	path, _, err := lookupIndex(idx, "gitlab.com/other/tools")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if path != "/b" {
-		t.Errorf("path = %q, want /b", path)
+	if path != b {
+		t.Errorf("path = %q, want %q", path, b)
 	}
 }
 
@@ -200,8 +217,10 @@ func TestResolveRescanOnMiss(t *testing.T) {
 		t.Errorf("path = %q, want %q", path, repo)
 	}
 
-	// The cache should now be populated, resolving from cache without roots.
-	path2, _, err := Resolve("myrepo", nil, nil, 0)
+	// The cache should now be populated: resolving again with the same roots
+	// (D181: matching roots is what makes the cache eligible at all) must hit
+	// the cache rather than rescan, and still return repo.
+	path2, _, err := Resolve("myrepo", nil, []string{root}, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,6 +238,179 @@ func TestResolveNotFound(t *testing.T) {
 	_, _, err := Resolve("nope", nil, []string{root}, 0)
 	if err == nil {
 		t.Fatal("expected not-found error")
+	}
+}
+
+// TestResolveStaleHitRescans covers D181: a cache entry whose path no longer
+// holds a clone must behave as a miss, so a moved repo resolves to its new
+// location and the cache is rewritten to match.
+func TestResolveStaleHitRescans(t *testing.T) {
+	home := t.TempDir()
+	userHomeDir = func() (string, error) { return home, nil }
+	defer func() { userHomeDir = os.UserHomeDir }()
+
+	root := t.TempDir()
+	oldPath := filepath.Join(root, "myrepo")
+	os.MkdirAll(oldPath, 0o755)
+	writeGitRepo(t, oldPath, "git@github.com:acme/myrepo.git")
+
+	// Populate the cache at oldPath.
+	if _, _, err := Resolve("myrepo", nil, []string{root}, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Move the clone within the same roots: the cache still points at oldPath.
+	newPath := filepath.Join(root, "moved", "myrepo")
+	os.MkdirAll(filepath.Join(root, "moved"), 0o755)
+	if err := os.Rename(oldPath, newPath); err != nil {
+		t.Fatal(err)
+	}
+
+	path, _, err := Resolve("myrepo", nil, []string{root}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != newPath {
+		t.Errorf("path = %q, want %q (new location)", path, newPath)
+	}
+
+	got, err := LoadCache()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if paths := got.Repos["github.com/acme/myrepo"]; len(paths) != 1 || paths[0] != newPath {
+		t.Errorf("cache not rewritten to new location: %v", paths)
+	}
+}
+
+// TestLookupIndexFirstCloneGoneSecondAliveNoWarning covers D181: when the
+// first clone in root order is gone, the surviving one resolves cleanly with
+// no multiple-clones warning — there is, in fact, only one clone left.
+func TestLookupIndexFirstCloneGoneSecondAliveNoWarning(t *testing.T) {
+	root := t.TempDir()
+	gone := filepath.Join(root, "gone")
+	alive := filepath.Join(root, "alive")
+	os.MkdirAll(alive, 0o755)
+	writeGitRepo(t, alive, "git@github.com:acme/tools.git")
+	// gone is never created: it never existed at this path, or was removed.
+
+	idx := &Index{Repos: map[RemoteKey][]string{
+		"github.com/acme/tools": {gone, alive},
+	}}
+	path, warnings, err := lookupIndex(idx, "tools")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != alive {
+		t.Errorf("path = %q, want %q", path, alive)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("expected no multiple-clones warning, got %v", warnings)
+	}
+}
+
+// TestLookupIndexAmbiguousOnlyOnPaper covers D181: two remotes share a short
+// name in the cache, but only one still has a live clone — resolution
+// succeeds instead of raising the ambiguity error.
+func TestLookupIndexAmbiguousOnlyOnPaper(t *testing.T) {
+	root := t.TempDir()
+	alive := filepath.Join(root, "alive")
+	os.MkdirAll(alive, 0o755)
+	writeGitRepo(t, alive, "git@github.com:acme/tools.git")
+	missing := filepath.Join(root, "missing")
+	// missing is never created.
+
+	idx := &Index{Repos: map[RemoteKey][]string{
+		"github.com/acme/tools":  {alive},
+		"gitlab.com/other/tools": {missing},
+	}}
+	path, _, err := lookupIndex(idx, "tools")
+	if err != nil {
+		t.Fatalf("expected successful resolution, got error: %v", err)
+	}
+	if path != alive {
+		t.Errorf("path = %q, want %q", path, alive)
+	}
+}
+
+// TestResolveEveryCloneGoneNotFound covers D181: a cache entry whose every
+// path is dead falls through to a rescan same as an ordinary miss, and — when
+// the rescan finds nothing either — the not-found error keeps its
+// search_depth guidance.
+func TestResolveEveryCloneGoneNotFound(t *testing.T) {
+	home := t.TempDir()
+	userHomeDir = func() (string, error) { return home, nil }
+	defer func() { userHomeDir = os.UserHomeDir }()
+
+	root := t.TempDir()
+	idx := &Index{Roots: []string{root}, Repos: map[RemoteKey][]string{
+		"github.com/acme/myrepo": {filepath.Join(root, "myrepo")}, // never created
+	}}
+	if err := SaveCache(idx); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := Resolve("myrepo", nil, []string{root}, 0)
+	if err == nil {
+		t.Fatal("expected not-found error")
+	}
+	if !strings.Contains(err.Error(), "search_depth") {
+		t.Errorf("error missing search_depth guidance: %v", err)
+	}
+}
+
+// TestLookupIndexLivePathNotARepo covers D181: a cached path that still
+// exists as a directory but no longer contains a .git entry is treated as
+// dead, the same outcome as a path that vanished entirely.
+func TestLookupIndexLivePathNotARepo(t *testing.T) {
+	root := t.TempDir()
+	emptied := filepath.Join(root, "emptied")
+	os.MkdirAll(emptied, 0o755) // directory present, but no .git subdirectory
+
+	idx := &Index{Repos: map[RemoteKey][]string{
+		"github.com/acme/myrepo": {emptied},
+	}}
+	_, _, err := lookupIndex(idx, "myrepo")
+	if err != errNotIndexed {
+		t.Errorf("err = %v, want errNotIndexed", err)
+	}
+}
+
+// TestResolveRootsChangedInvalidatesCache covers D181: a change of
+// search_roots invalidates the cache even for a key present under the old
+// roots at a path that is still perfectly live — root order decides the
+// winner among clones, so a reorder or replacement of roots is a semantic
+// change, not a cosmetic one.
+func TestResolveRootsChangedInvalidatesCache(t *testing.T) {
+	home := t.TempDir()
+	userHomeDir = func() (string, error) { return home, nil }
+	defer func() { userHomeDir = os.UserHomeDir }()
+
+	rootA := t.TempDir()
+	pathA := filepath.Join(rootA, "myrepo")
+	os.MkdirAll(pathA, 0o755)
+	writeGitRepo(t, pathA, "git@github.com:acme/myrepo.git")
+
+	// Populate the cache scanning rootA: Roots == [rootA], key -> pathA.
+	if _, _, err := Resolve("myrepo", nil, []string{rootA}, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// A second, distinct root also carries a clone of the same remote, at a
+	// different path. pathA is untouched and still perfectly live.
+	rootB := t.TempDir()
+	pathB := filepath.Join(rootB, "myrepo")
+	os.MkdirAll(pathB, 0o755)
+	writeGitRepo(t, pathB, "git@github.com:acme/myrepo.git")
+
+	// search_roots now points only at rootB: the cached entry (Roots=[rootA],
+	// path=pathA) must not be trusted even though pathA is still live.
+	path, _, err := Resolve("myrepo", nil, []string{rootB}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != pathB {
+		t.Errorf("path = %q, want %q (roots change must force a rescan)", path, pathB)
 	}
 }
 


### PR DESCRIPTION
## Summary

`repoindex.Resolve` trusted a cache hit with no filesystem check: a moved or
removed clone kept `{{repo:<key>}}` resolving to the old, now-wrong (or even
misleading, if a leftover clone sat there) location — silently and
indefinitely, since the stale value lives in `~/.config/cartographer/repos.json`,
not in server memory.

- **WP1** — `lookupIndex` filters each candidate's cached paths down to live
  clones (directory + `.git` entry) before evaluating ambiguity/emptiness, via
  a new `isLiveClone` helper shared with `walkDir`. A dead cache entry now
  behaves as a miss and falls through to `Resolve`'s rescan.
- **WP2** — `Resolve` compares the cache's persisted `Index.Roots` against the
  configured `roots` (order-sensitive, `expandHome`-normalized) before
  trusting the cache: a changed `search_roots` invalidates it, even for a key
  whose old path is still perfectly live.
- **WP3** — six new tests in `internal/repoindex/repoindex_test.go` cover the
  staleness paths: moved clone, first-of-two clones gone, ambiguous-only-on-
  paper, every clone gone, a live directory with `.git` removed, and a
  `search_roots` change. Three pre-existing tests were updated to use real
  live clone directories instead of literal placeholder paths, since they now
  fail liveness validation otherwise.
- Docs updated in this same PR: `docs/sync.md` (both the placeholder-writing
  section and the D75 §Path portability section) and a new `D181` entry in
  `docs/decisions/sync-provisioning.md`.

No interface, configuration, CLI or MCP surface change — behavioural fix only.
The first resolution after upgrade may trigger one extra rescan per cache
(empty-vs-nonempty `Roots` edge case), the intended one-off cost.

## Test plan

- [x] `make fmt && make vet && make test` — green
- [x] Six new WP3 test cases pass, plus all pre-existing `internal/repoindex` tests

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)