### PR TITLE
feat(provisioning): detect conflicting session-global directives declared by two KBs (D183)

### DIFF
--- a/docs/decisions/sync-provisioning.md
+++ b/docs/decisions/sync-provisioning.md
@@ -1154,6 +1154,98 @@ content is modified, ever — only wrapped.
 
 ---
 
+<a id="d183"></a>
+## D183 — Keyed session-global directives make a cross-KB prose conflict detectable
+
+**Decision.** A curated `instructions.md` may declare a session-global
+directive with a key anywhere in its body: `<!-- cartographer:directive:<key>:<value>
+-->`, recognised as a full line (after trimming) so a KB can document the
+syntax itself without triggering it — the same defensive shape as
+`preambleNoneRe` and D182's `cartographer:kb:<name>:begin/end` markers, and
+the same D163 metasyntax trap both had to account for. `<key>` and `<value>`
+are each required to be non-empty and to contain no `:`, so the split stays
+unambiguous; a malformed line (empty key or value, an extra `:` inside either
+part) is not recognised and is left as ordinary prose. Lines inside a fenced
+code block (` ``` `/`~~~`) are never eligible either, so a marker shown alone
+on its own line as a worked example — the natural way to document the syntax
+— does not declare anything; full-line matching alone only protects a marker
+embedded mid-paragraph. `DetectDirectiveCollisions`
+scans every `kind: instructions` artifact's generated content for these lines
+and groups the declared `(key, value)` pairs by key; `MergeArtifactsStrict`
+fails with a `*CollisionError` naming the key, every declared value, and the
+KB that declared each, when two `kb:` sources in the same merge disagree on a
+key's value. Two sources declaring the same key with the same value are not
+reported — they agree, there is nothing to adjudicate. The recognised line is
+**not** stripped from the rendered block: unlike `preamble: none`, which is a
+control signal meaningful only to the generator, a directive's value is
+content an agent reading the block may want to see verbatim, and stripping it
+would cut against D182/D154's byte-identical delivery of the curated body.
+
+**Context.** D182 made a cross-KB prose conflict *attributable* — an agent
+reading the block now knows which KB said what — but left it undetectable by
+the server or the client: for `kind: instructions`, `Name` is the KB name,
+unique by construction, so `DetectCollisions` ([D171](#d171)) can never see
+two KBs claim it. #233 asked for a narrower, mechanisable slice of that gap:
+not adjudicating arbitrary conflicting prose (still not mechanisable, still
+left to "the more specific source wins"), but letting a KB opt a specific
+fact into structured comparison by giving it a key.
+
+**Rationale.**
+
+- **Comparison happens on the already-provider-scoped slice, no new
+  plumbing.** `DetectDirectiveCollisions` takes the same `[]Artifact`
+  `DetectCollisions` does, and every caller already narrows that slice to one
+  provider's bound KBs before calling `MergeArtifactsStrict`
+  ([D170](#d170)/[D171](#d171)); two KBs that never reach the same client
+  already cannot collide on `kind`+`name` for the same reason, and directives
+  inherit it for free.
+- **Extraction reads `Artifact.Files`, not a new wire field.** The `kind:
+  instructions` artifact's content — generated per KB, curated body included
+  — already travels through `sync_pull` in `Files[0].Content` for the on-disk
+  write. Re-scanning that content at merge time needed no change to the
+  `Artifact` struct, the `sync_pull` JSON shape, or a KB's materialized
+  files: strictly additive. The generated wrapper prose around the curated
+  body (fixed, hardcoded English, no HTML comments) can never itself match
+  the marker, so scanning the whole generated artifact is equivalent to
+  scanning only the curated section.
+- **Fence-aware, not just full-line.** Full-line matching alone stops a
+  marker embedded mid-paragraph but not one shown alone on its own line
+  inside a fenced code block — the natural way to document a syntax by
+  example. `extractDirectives` tracks fence state with the same pragmatic
+  CommonMark subset `okf.headingEligibleLines` uses for the identical
+  problem with markdown headings (kept as a small local duplicate rather
+  than an export from `okf`: one caller, no other reason for the two
+  scanners to share code).
+- **Last declaration wins within one KB's own prose.** A KB repeating the
+  same key twice with two different values in its own `instructions.md` is
+  not a cross-KB collision — there is only one author to ask, and
+  `extractDirectives` keeps the last one, silently, the same way a later
+  assignment would read in ordinary prose.
+- **Error, not warning, matching D171.** A warning about a directive the
+  agent then actually reads is worse than a failed sync, for the same reason
+  D171 gives for a structural collision: at that point the wrong answer is
+  already silent. `CollisionError` grew a second section instead of a second
+  error type, so a caller printing "Error: %v" still gets one self-contained,
+  actionable report even when both kinds of collision fire in the same
+  merge.
+- **Visible, not stripped.** `preamble: none` is removed because it is a
+  control signal aimed at the generator, not at the reader — leaving it would
+  read as a stray, uninterpreted instruction. A directive's value is the
+  opposite: it is the KB's own claim about a session-wide fact, and hiding it
+  would make the rendered block disagree with what
+  `DetectDirectiveCollisions` just verified about it.
+
+**Consequences.** `feat:` — new authoring convention, and no existing curated
+body matches it by accident (the marker's tight `<key>:<value>` shape, no
+extra `:` or empty part tolerated, keeps a KB's own prose about markers from
+tripping it, same as D163/D182). A deployment with two KBs bound to the same
+provider that declare the same directive key with different values — working
+today, silently, left to a human to notice and resolve via "the more specific
+source wins" — starts failing its sync with a report naming the key, both
+values and both KBs. Everything else is unchanged.
+
+---
+
 <a id="d184"></a>
 ## D184 — `sync` reports the revision each provider recorded, not the one it fetched
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -155,7 +155,28 @@ directives or with a repository's own instruction file. Before this, a directive
 perimeter reached the agent as an unqualified, session-wide rule, with nothing marking where one KB's
 voice ended and the next began, and nothing to prefer when two KBs disagreed. `DetectCollisions`
 (D171) cannot catch this: for kind `instructions`, `Name` *is* the KB name, unique by construction, so
-two KBs can never collide on it — the strict merge is structurally blind to this class of conflict.
+two KBs can never collide on it — the strict merge is structurally blind to this class of conflict. A
+KB can still opt a specific fact into structured comparison by giving it a key (D183, below).
+
+**A KB may declare a session-global directive with a key** to make a conflict with another KB
+*detectable*, not just attributable (D183): a line of the shape
+`<!-- cartographer:directive:<key>:<value> -->`, matched as a full line (after trimming) anywhere in
+the curated body — not only the first line — asserts a session-wide fact the KB stands behind, such as
+a working timezone or environment name. `<key>` and `<value>` must each be non-empty and contain no
+`:`, the same strict-not-clever shape as every other Cartographer marker; a malformed or partial line
+(an extra `:`, an empty key or value) is left as ordinary prose, and a KB documenting the syntax itself
+never triggers it, the same D163 metasyntax trap `preambleNoneRe` and the `cartographer:kb:` markers
+already account for — including the marker shown alone on its own line inside a fenced code block, the
+natural way to document a syntax: `extractDirectives` tracks fence state (` ``` `/`~~~`) and never
+matches inside one. Unlike `preamble: none`, the recognised line is **not** stripped — it stays in the
+rendered block exactly as authored, since it is the KB's own content, not a control signal aimed at the
+generator. `DetectDirectiveCollisions` scans every `kind: instructions` artifact in the same
+provider-scoped set `MergeArtifactsStrict` already compares (D170/D171) for declared `(key, value)`
+pairs: two KBs agreeing on a key's value are not reported, two KBs declaring different values for the
+same key fail the sync with a `*CollisionError` naming the key, every declared value, and which KB
+declared each — the same "error, not warning" stance D171 takes for a structural `kind`+`name`
+collision. Two KBs bound to two different providers cannot collide on a directive, for the same reason
+they cannot collide on `kind`+`name`.
 
 **Section order follows the provider's KB binding, with an alphabetical fallback** (D182 WP2):
 a provider with an explicit binding (`clientconfig.ClientBinding.KBs`, D170) gets its sections in that

--- a/internal/provisioning/provisioning.go
+++ b/internal/provisioning/provisioning.go
@@ -816,6 +816,92 @@ func kbCuratedInstructionsWithPreamble(kbRoot string) (body string, skipPreamble
 	return strings.TrimSpace(content), skipPreamble
 }
 
+// directiveRe matches a session-global directive declaration line (D183):
+// "<!-- cartographer:directive:<key>:<value> -->", matched as a full line
+// (after trimming) so a KB can document the syntax in its own prose without
+// declaring anything — the same defensive shape as preambleNoneRe and D182's
+// "cartographer:kb:<name>:begin/end" markers, and the same D163 metasyntax
+// trap both of those had to account for. Unlike preambleNoneRe, a directive
+// may appear anywhere in the curated body, not only the first line.
+//
+// <key> and <value> are each required to be non-empty and to contain no ':',
+// so the split stays unambiguous — a line with an extra ':' inside either
+// part, or an empty key/value, is simply not recognised: strict rather than
+// clever. <key> additionally excludes whitespace (it names a machine token,
+// like "language" or "timezone"); <value> may contain internal spaces.
+var directiveRe = regexp.MustCompile(`(?i)^<!--\s*cartographer:\s*directive:\s*([^:\s]+):([^:]+?)\s*-->\s*$`)
+
+// directiveFenceMarkers are the code-fence delimiters extractDirectives
+// recognises (pragmatic CommonMark subset) — the same pair
+// okf.headingEligibleLines uses for the identical "documenting the syntax"
+// concern with markdown headings. Kept local rather than exported from okf:
+// this is the only caller, and the two scanners have no other reason to
+// share code.
+var directiveFenceMarkers = [...]string{"```", "~~~"}
+
+// directiveFenceOpenMarker returns the fence marker ("```" or "~~~") if the
+// trimmed line opens a code fence, or "" otherwise.
+func directiveFenceOpenMarker(trimmed string) string {
+	for _, m := range directiveFenceMarkers {
+		if strings.HasPrefix(trimmed, m) {
+			return m
+		}
+	}
+	return ""
+}
+
+// extractDirectives scans every line of content — the generated content of a
+// KB's "instructions" artifact, curated body included — for directive
+// declarations and returns the key→value pairs found. Only the curated body
+// can ever match: the generated wrapper text around it (the routing
+// sentence, the operational bullets, the D182 scope sentence) is fixed,
+// hardcoded English prose that never takes the "<!-- cartographer:...-->"
+// shape, so scanning the whole artifact content is equivalent to scanning
+// only the curated section.
+//
+// Lines inside a fenced code block are never eligible: an operator
+// documenting the marker's syntax with a worked example — the marker alone
+// on its own line inside a ``` fence, the natural way to show it — must not
+// declare anything either. Full-line matching alone only protects a marker
+// embedded mid-paragraph (D163's metasyntax trap); a standalone example line
+// inside a fence needs this additional check.
+//
+// A key declared twice within the SAME content keeps its LAST value,
+// silently: there is only one author to ask, so there is nothing to
+// adjudicate the way there is between two KBs (DetectDirectiveCollisions).
+func extractDirectives(content string) map[string]string {
+	var out map[string]string
+	inFence := false
+	fenceMarker := ""
+	for _, l := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(l)
+		if inFence {
+			if strings.HasPrefix(trimmed, fenceMarker) {
+				inFence = false
+			}
+			continue
+		}
+		if marker := directiveFenceOpenMarker(trimmed); marker != "" {
+			inFence = true
+			fenceMarker = marker
+			continue
+		}
+		m := directiveRe.FindStringSubmatch(trimmed)
+		if m == nil {
+			continue
+		}
+		key, value := m[1], strings.TrimSpace(m[2])
+		if key == "" || value == "" {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]string)
+		}
+		out[key] = value
+	}
+	return out
+}
+
 // contentHashFile computes the versioned artifact hash of a single,
 // non-executable file (agents and MCP descriptors).
 func contentHashFile(path string) (string, error) {
@@ -929,33 +1015,117 @@ func DetectCollisions(artifacts []Artifact) []Collision {
 	return out
 }
 
-// CollisionError reports the collisions that stopped a merge. It renders as a
+// DirectiveValue pairs one declared value of a session-global directive with
+// the KB source that declared it ("kb:<name>").
+type DirectiveValue struct {
+	Value  string
+	Source string
+}
+
+// DirectiveCollision is one session-global directive key (D183, the
+// "<!-- cartographer:directive:<key>:<value> -->" marker recognised by
+// directiveRe) declared with two or more different values among the KBs
+// compared. Values are sorted by Source, so a report is deterministic.
+type DirectiveCollision struct {
+	Key    string
+	Values []DirectiveValue
+}
+
+// DetectDirectiveCollisions reports every session-global directive key
+// declared with two or more different values among the given artifacts'
+// kind "instructions" entries.
+//
+// Scoped the same way DetectCollisions is: it inspects exactly the artifacts
+// it is given, and every caller already narrows that slice to one provider's
+// bound KBs before calling MergeArtifactsStrict (D170/D171) — two KBs that
+// never reach the same client cannot collide on a directive either, for the
+// same reason they cannot collide on kind+name.
+//
+// Same key + same value across two (or more) KBs is not reported: they
+// agree, there is nothing to adjudicate. Same key + different value is —
+// consistent with D171's "error, not warning" stance for the structural
+// kind+name collision.
+func DetectDirectiveCollisions(artifacts []Artifact) []DirectiveCollision {
+	// key -> source -> value
+	bySource := make(map[string]map[string]string)
+	for _, a := range artifacts {
+		if a.Kind != "instructions" || !strings.HasPrefix(a.Source, "kb:") || len(a.Files) == 0 {
+			continue
+		}
+		for key, value := range extractDirectives(string(a.Files[0].Content)) {
+			if bySource[key] == nil {
+				bySource[key] = make(map[string]string)
+			}
+			bySource[key][a.Source] = value
+		}
+	}
+
+	var out []DirectiveCollision
+	for key, bySrc := range bySource {
+		values := make(map[string]bool, len(bySrc))
+		for _, v := range bySrc {
+			values[v] = true
+		}
+		if len(values) < 2 {
+			continue
+		}
+		dvs := make([]DirectiveValue, 0, len(bySrc))
+		for source, value := range bySrc {
+			dvs = append(dvs, DirectiveValue{Value: value, Source: source})
+		}
+		sort.Slice(dvs, func(i, j int) bool { return dvs[i].Source < dvs[j].Source })
+		out = append(out, DirectiveCollision{Key: key, Values: dvs})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	return out
+}
+
+// CollisionError reports the collisions that stopped a merge — structural
+// (kind+name, D171) and/or directive (key+value, D183). It renders as a
 // multi-line report rather than one line: a caller printing "Error: <err>" must
 // still produce something an operator can act on without a second command.
 type CollisionError struct {
 	Collisions []Collision
+	Directives []DirectiveCollision
 }
 
 func (e *CollisionError) Error() string {
 	var sb strings.Builder
-	sb.WriteString("the same artifact is claimed by more than one KB:\n")
-	for _, c := range e.Collisions {
-		fmt.Fprintf(&sb, "  %s/%s: claimed by %s\n", c.Kind, c.Name, strings.Join(c.Sources, ", "))
+	if len(e.Collisions) > 0 {
+		sb.WriteString("the same artifact is claimed by more than one KB:\n")
+		for _, c := range e.Collisions {
+			fmt.Fprintf(&sb, "  %s/%s: claimed by %s\n", c.Kind, c.Name, strings.Join(c.Sources, ", "))
+		}
+		sb.WriteString("rename the artifact in all but one of those KBs, or stop binding them to the same client\n")
 	}
-	sb.WriteString("rename the artifact in all but one of those KBs, or stop binding them to the same client")
-	return sb.String()
+	if len(e.Directives) > 0 {
+		sb.WriteString("the same session-global directive key is declared with different values by more than one KB:\n")
+		for _, d := range e.Directives {
+			parts := make([]string, len(d.Values))
+			for i, v := range d.Values {
+				parts[i] = fmt.Sprintf("%s=%q by %s", d.Key, v.Value, v.Source)
+			}
+			fmt.Fprintf(&sb, "  %s: %s\n", d.Key, strings.Join(parts, ", "))
+		}
+		sb.WriteString("change the directive's value to agree in all but one of those KBs, or stop binding them to the same client\n")
+	}
+	return strings.TrimRight(sb.String(), "\n")
 }
 
-// MergeArtifactsStrict is MergeArtifacts with the KB↔KB collision turned into
-// an error instead of an alphabetical coin flip. It is what the client uses:
-// a warning about an artifact the agent then actually loads is worse than a
-// failed sync, because at that point the wrong answer is silent.
+// MergeArtifactsStrict is MergeArtifacts with the KB↔KB collision — structural
+// (kind+name, D171) or directive (key+value, D183) — turned into an error
+// instead of an alphabetical coin flip or a silently unresolved disagreement.
+// It is what the client uses: a warning about an artifact or a directive the
+// agent then actually reads is worse than a failed sync, because at that
+// point the wrong answer is silent.
 //
 // BuildManifest keeps using MergeArtifacts: server-side a manifest is built for
 // one KB plus the bundle, where a KB↔KB collision cannot arise by construction.
 func MergeArtifactsStrict(artifacts []Artifact) (Manifest, error) {
-	if collisions := DetectCollisions(artifacts); len(collisions) > 0 {
-		return Manifest{}, &CollisionError{Collisions: collisions}
+	collisions := DetectCollisions(artifacts)
+	directives := DetectDirectiveCollisions(artifacts)
+	if len(collisions) > 0 || len(directives) > 0 {
+		return Manifest{}, &CollisionError{Collisions: collisions, Directives: directives}
 	}
 	return MergeArtifacts(artifacts), nil
 }

--- a/internal/provisioning/provisioning_instructions_test.go
+++ b/internal/provisioning/provisioning_instructions_test.go
@@ -8,6 +8,7 @@ package provisioning_test
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1019,6 +1020,93 @@ func TestGenerateKBInstructions_DirectiveNotOnFirstLineIsContent(t *testing.T) {
 	content := string(findInstructionsArtifact(t, m, "homelab").Files[0].Content)
 	if !strings.Contains(content, "Operational instructions:") {
 		t.Errorf("a directive that is not on the first line must be content:\n%s", content)
+	}
+}
+
+// --- D183: keyed session-global directives ---
+
+// A directive may appear anywhere in the curated body, not only the first
+// line (unlike preamble:none), and — this implementation's choice — stays
+// VISIBLE in the rendered block: Cartographer recognises and extracts the
+// key/value, but never rewrites the KB's prose.
+func TestGenerateKBInstructions_DirectiveDeclaredAndVisible(t *testing.T) {
+	kbRoot := makeKBWithArchives(t, map[string][]string{"entities": {"a.md"}})
+	writeFile(t, filepath.Join(kbRoot, "instructions.md"),
+		"Some notes first.\n\n<!-- cartographer:directive:timezone:UTC+2 -->\n\nMore notes after.\n")
+
+	m, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, provisioning.BuildOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := findInstructionsArtifact(t, m, "homelab")
+	content := string(a.Files[0].Content)
+
+	if !strings.Contains(content, "<!-- cartographer:directive:timezone:UTC+2 -->") {
+		t.Errorf("the directive line must stay visible in the rendered block:\n%s", content)
+	}
+	if !strings.Contains(content, "Some notes first.") || !strings.Contains(content, "More notes after.") {
+		t.Errorf("the surrounding curated prose is missing:\n%s", content)
+	}
+
+	got := provisioning.DetectDirectiveCollisions([]provisioning.Artifact{a})
+	if len(got) != 0 {
+		t.Errorf("a single KB's own directive is never a collision: %+v", got)
+	}
+}
+
+// End-to-end: two KBs built through BuildManifest (not hand-built fixtures)
+// declaring the same key with different values collide when merged strictly
+// — the exact path cmd/cartographer/clientsync.go exercises per provider.
+func TestBuildManifest_DirectiveCollision_EndToEnd(t *testing.T) {
+	oneRoot := makeKBWithArchives(t, map[string][]string{"entities": {"a.md"}})
+	writeFile(t, filepath.Join(oneRoot, "instructions.md"), "<!-- cartographer:directive:timezone:UTC+2 -->\n")
+	twoRoot := makeKBWithArchives(t, map[string][]string{"entities": {"a.md"}})
+	writeFile(t, filepath.Join(twoRoot, "instructions.md"), "<!-- cartographer:directive:timezone:UTC-5 -->\n")
+
+	mOne, err := provisioning.BuildManifest(nil, map[string]string{"one": oneRoot}, provisioning.BuildOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mTwo, err := provisioning.BuildManifest(nil, map[string]string{"two": twoRoot}, provisioning.BuildOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	candidates := append(append([]provisioning.Artifact{}, mOne.Artifacts...), mTwo.Artifacts...)
+	_, err = provisioning.MergeArtifactsStrict(candidates)
+	if err == nil {
+		t.Fatal("MergeArtifactsStrict accepted two KBs disagreeing on a directive")
+	}
+	var ce *provisioning.CollisionError
+	if !errors.As(err, &ce) {
+		t.Fatalf("error = %T, want *CollisionError", err)
+	}
+	if len(ce.Directives) != 1 || ce.Directives[0].Key != "timezone" {
+		t.Fatalf("directives = %+v, want one collision on %q", ce.Directives, "timezone")
+	}
+}
+
+// A directive's syntax documented in a KB's own prose — mid-paragraph or
+// inside a fenced code block — must never declare anything (D163's
+// metasyntax trap).
+func TestGenerateKBInstructions_DirectiveDocumentedInProseIsNotDeclared(t *testing.T) {
+	kbRoot := makeKBWithArchives(t, map[string][]string{"entities": {"a.md"}})
+	writeFile(t, filepath.Join(kbRoot, "instructions.md"),
+		"To declare a directive, write a line like:\n```\n<!-- cartographer:directive:timezone:UTC+2 -->\n```\n"+
+			"or inline: `<!-- cartographer:directive:timezone:UTC+2 -->`.\n")
+
+	m, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, provisioning.BuildOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := findInstructionsArtifact(t, m, "homelab")
+
+	got := provisioning.DetectDirectiveCollisions([]provisioning.Artifact{
+		a,
+		instructionsArtifact("other", "<!-- cartographer:directive:timezone:UTC-5 -->\n"),
+	})
+	if len(got) != 0 {
+		t.Errorf("documenting the syntax must not declare the directive: %+v", got)
 	}
 }
 

--- a/internal/provisioning/provisioning_test.go
+++ b/internal/provisioning/provisioning_test.go
@@ -1249,6 +1249,221 @@ func TestMergeArtifactsStrict(t *testing.T) {
 	}
 }
 
+// --- D183: keyed session-global directives ---
+
+func TestDetectDirectiveCollisions(t *testing.T) {
+	cases := []struct {
+		name      string
+		artifacts []provisioning.Artifact
+		wantKeys  []string // Key of each expected collision, in order
+	}{
+		{
+			name: "no directives declared",
+			artifacts: []provisioning.Artifact{
+				instructionsArtifact("one", "Plain prose, no directive.\n"),
+				instructionsArtifact("two", "More prose.\n"),
+			},
+		},
+		{
+			name: "same key, same value: no collision",
+			artifacts: []provisioning.Artifact{
+				instructionsArtifact("one", "<!-- cartographer:directive:timezone:UTC+2 -->\n"),
+				instructionsArtifact("two", "<!-- cartographer:directive:timezone:UTC+2 -->\n"),
+			},
+		},
+		{
+			name: "same key, different value: collision",
+			artifacts: []provisioning.Artifact{
+				instructionsArtifact("one", "<!-- cartographer:directive:timezone:UTC+2 -->\n"),
+				instructionsArtifact("two", "<!-- cartographer:directive:timezone:UTC-5 -->\n"),
+			},
+			wantKeys: []string{"timezone"},
+		},
+		{
+			name: "different keys: no collision",
+			artifacts: []provisioning.Artifact{
+				instructionsArtifact("one", "<!-- cartographer:directive:timezone:UTC+2 -->\n"),
+				instructionsArtifact("two", "<!-- cartographer:directive:language:it -->\n"),
+			},
+		},
+		{
+			name: "one KB silent on the key: no collision",
+			artifacts: []provisioning.Artifact{
+				instructionsArtifact("one", "<!-- cartographer:directive:timezone:UTC+2 -->\n"),
+				instructionsArtifact("two", "No directive here.\n"),
+			},
+		},
+		{
+			name: "several keys per KB, only the disagreement is reported",
+			artifacts: []provisioning.Artifact{
+				instructionsArtifact("one", "<!-- cartographer:directive:timezone:UTC+2 -->\n<!-- cartographer:directive:language:it -->\n"),
+				instructionsArtifact("two", "<!-- cartographer:directive:timezone:UTC+2 -->\n<!-- cartographer:directive:language:en -->\n"),
+			},
+			wantKeys: []string{"language"},
+		},
+		{
+			name: "three KBs, three values, one collision naming all three",
+			artifacts: []provisioning.Artifact{
+				instructionsArtifact("a", "<!-- cartographer:directive:env:staging -->\n"),
+				instructionsArtifact("b", "<!-- cartographer:directive:env:prod -->\n"),
+				instructionsArtifact("c", "<!-- cartographer:directive:env:dev -->\n"),
+			},
+			wantKeys: []string{"env"},
+		},
+		{
+			name: "documenting the syntax mid-paragraph does not trigger it",
+			artifacts: []provisioning.Artifact{
+				instructionsArtifact("one", "See the marker syntax, `<!-- cartographer:directive:timezone:UTC+2 -->`, for details.\n"),
+				instructionsArtifact("two", "<!-- cartographer:directive:timezone:UTC-5 -->\n"),
+			},
+		},
+		{
+			name: "documenting the syntax inside a fenced code block does not trigger it",
+			artifacts: []provisioning.Artifact{
+				instructionsArtifact("one", "Example:\n```\n<!-- cartographer:directive:timezone:UTC+2 -->\n```\n"),
+				instructionsArtifact("two", "<!-- cartographer:directive:timezone:UTC-5 -->\n"),
+			},
+		},
+		{
+			name: "malformed marker: empty value is not recognised",
+			artifacts: []provisioning.Artifact{
+				instructionsArtifact("one", "<!-- cartographer:directive:timezone: -->\n"),
+				instructionsArtifact("two", "<!-- cartographer:directive:timezone:UTC-5 -->\n"),
+			},
+		},
+		{
+			name: "malformed marker: extra colon in the value is not recognised",
+			artifacts: []provisioning.Artifact{
+				instructionsArtifact("one", "<!-- cartographer:directive:time:10:30 -->\n"),
+				instructionsArtifact("two", "<!-- cartographer:directive:time:UTC-5 -->\n"),
+			},
+		},
+		{
+			name: "a KB that opted out of the preamble may still declare a directive",
+			artifacts: []provisioning.Artifact{
+				instructionsArtifact("one", "<!-- cartographer: preamble: none -->\n<!-- cartographer:directive:timezone:UTC+2 -->\n"),
+				instructionsArtifact("two", "<!-- cartographer:directive:timezone:UTC-5 -->\n"),
+			},
+			wantKeys: []string{"timezone"},
+		},
+		{
+			name: "non-instructions artifacts are ignored even if their content matches",
+			artifacts: []provisioning.Artifact{
+				{Kind: "skill", Name: "one", Source: "kb:one", Files: []provisioning.ArtifactFile{
+					{Path: "SKILL.md", Content: []byte("<!-- cartographer:directive:timezone:UTC+2 -->\n")},
+				}},
+				{Kind: "skill", Name: "two", Source: "kb:two", Files: []provisioning.ArtifactFile{
+					{Path: "SKILL.md", Content: []byte("<!-- cartographer:directive:timezone:UTC-5 -->\n")},
+				}},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := provisioning.DetectDirectiveCollisions(tc.artifacts)
+			if len(got) != len(tc.wantKeys) {
+				t.Fatalf("DetectDirectiveCollisions = %+v, want keys %v", got, tc.wantKeys)
+			}
+			for i, wantKey := range tc.wantKeys {
+				if got[i].Key != wantKey {
+					t.Errorf("collision %d key = %q, want %q", i, got[i].Key, wantKey)
+				}
+				if len(got[i].Values) < 2 {
+					t.Errorf("collision %d has %d values, want at least 2: %+v", i, len(got[i].Values), got[i])
+				}
+			}
+		})
+	}
+}
+
+// TestMergeArtifactsStrict_DirectiveCollision covers the acceptance path: a
+// directive collision alone fails the merge with a *CollisionError naming the
+// key, both values and both KBs, without a kind+name collision in the mix.
+func TestMergeArtifactsStrict_DirectiveCollision(t *testing.T) {
+	colliding := []provisioning.Artifact{
+		instructionsArtifact("one", "<!-- cartographer:directive:timezone:UTC+2 -->\n"),
+		instructionsArtifact("two", "<!-- cartographer:directive:timezone:UTC-5 -->\n"),
+	}
+	_, err := provisioning.MergeArtifactsStrict(colliding)
+	if err == nil {
+		t.Fatal("MergeArtifactsStrict accepted a directive collision")
+	}
+	var ce *provisioning.CollisionError
+	if !errors.As(err, &ce) {
+		t.Fatalf("error = %T, want *CollisionError", err)
+	}
+	if len(ce.Collisions) != 0 {
+		t.Errorf("unexpected structural collisions: %+v", ce.Collisions)
+	}
+	msg := ce.Error()
+	for _, want := range []string{"timezone", "UTC+2", "UTC-5", "kb:one", "kb:two"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("collision report missing %q:\n%s", want, msg)
+		}
+	}
+
+	// Agreeing on the value must still merge cleanly.
+	agreeing := []provisioning.Artifact{
+		instructionsArtifact("one", "<!-- cartographer:directive:timezone:UTC+2 -->\n"),
+		instructionsArtifact("two", "<!-- cartographer:directive:timezone:UTC+2 -->\n"),
+	}
+	if _, err := provisioning.MergeArtifactsStrict(agreeing); err != nil {
+		t.Fatalf("MergeArtifactsStrict on agreeing directives: %v", err)
+	}
+}
+
+// TestMergeArtifactsStrict_BothCollisionKinds: a structural collision and a
+// directive collision in the same merge are both reported in one error.
+func TestMergeArtifactsStrict_BothCollisionKinds(t *testing.T) {
+	artifacts := []provisioning.Artifact{
+		{Kind: "skill", Name: "alpha", Source: "kb:one", ContentHash: "h1"},
+		{Kind: "skill", Name: "alpha", Source: "kb:two", ContentHash: "h2"},
+		instructionsArtifact("one", "<!-- cartographer:directive:timezone:UTC+2 -->\n"),
+		instructionsArtifact("two", "<!-- cartographer:directive:timezone:UTC-5 -->\n"),
+	}
+	_, err := provisioning.MergeArtifactsStrict(artifacts)
+	if err == nil {
+		t.Fatal("MergeArtifactsStrict accepted a mixed collision")
+	}
+	var ce *provisioning.CollisionError
+	if !errors.As(err, &ce) {
+		t.Fatalf("error = %T, want *CollisionError", err)
+	}
+	if len(ce.Collisions) != 1 || len(ce.Directives) != 1 {
+		t.Fatalf("ce = %+v, want one of each kind", ce)
+	}
+	msg := ce.Error()
+	for _, want := range []string{"skill/alpha", "timezone"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("mixed collision report missing %q:\n%s", want, msg)
+		}
+	}
+}
+
+// TestDetectDirectiveCollisions_ScopedToWhatItIsGiven demonstrates D183's
+// provider scoping: DetectDirectiveCollisions (like DetectCollisions before
+// it) only ever compares the artifacts it is handed. Two KBs bound to two
+// different providers never appear in the same MergeArtifactsStrict call —
+// cmd/cartographer/clientsync.go already narrows the candidate slice to one
+// provider's bound KBs before calling it (D170/D171) — so they cannot
+// collide on a directive either, without any extra plumbing here.
+func TestDetectDirectiveCollisions_ScopedToWhatItIsGiven(t *testing.T) {
+	one := instructionsArtifact("one", "<!-- cartographer:directive:timezone:UTC+2 -->\n")
+	two := instructionsArtifact("two", "<!-- cartographer:directive:timezone:UTC-5 -->\n")
+
+	// Provider A is bound only to "one": no other KB's directive is ever in
+	// the slice it merges, so there is nothing to collide with.
+	if got := provisioning.DetectDirectiveCollisions([]provisioning.Artifact{one}); len(got) != 0 {
+		t.Errorf("provider bound only to kb:one reported a collision: %+v", got)
+	}
+
+	// Provider B is bound to both: the same two artifacts now collide.
+	if got := provisioning.DetectDirectiveCollisions([]provisioning.Artifact{one, two}); len(got) != 1 {
+		t.Errorf("provider bound to both KBs did not report the collision: %+v", got)
+	}
+}
+
 // TestMergeArtifactsStaysTolerant: BuildManifest merges one KB plus the bundle,
 // where a KB↔KB collision cannot arise, and must keep its existing behaviour.
 func TestMergeArtifactsStaysTolerant(t *testing.T) {


### PR DESCRIPTION
## Summary

- A curated `instructions.md` may now declare a session-global directive with a key anywhere in its body: `<!-- cartographer:directive:<key>:<value> -->`, recognised as a full line and fence-aware (a worked example inside the KB's own prose, mid-paragraph or in a fenced code block, never triggers it — D163's metasyntax trap).
- `DetectDirectiveCollisions` scans every `kind: instructions` artifact's generated content for these lines; `MergeArtifactsStrict` now fails with an attributable `*CollisionError` (naming the key, every declared value, and which KB declared each) when two `kb:` sources being merged declare the same key with different values. Two KBs agreeing on the value is not a collision — nothing to adjudicate.
- Scoping is free: comparison happens on whatever `[]Artifact` slice is passed in, the same one `DetectCollisions` already inspects, and every existing caller (`cmd/cartographer/clientsync.go`) already narrows that slice to one provider's bound KBs before calling `MergeArtifactsStrict` (D170/D171) — two KBs bound to different providers cannot conflict on a directive.
- No wire format change: directives are extracted from the `instructions` artifact's already-transmitted `Files[0].Content` (the same bytes `sync_pull` sends for the on-disk write), so `Artifact`, the sync_pull JSON shape and materialized files are untouched.
- The recognised marker line is **not** stripped from the rendered block — it stays visible exactly as authored, unlike the `preamble: none` opt-out (a design choice explained in the new D183 entry).

Extends D171's "error, not warning" stance to the class of cross-KB prose conflict D182 made attributable (an agent knows which KB said what) but left undetectable by the server/client.

## Documentation

- `docs/sync.md`: new paragraph on the keyed directive convention, in the generated-instructions-block section next to D182's scope-sentence and opt-out paragraphs.
- `docs/decisions/sync-provisioning.md`: new `## D183` entry, cross-referencing D171 and D182, appended at the end of the file.

## Test plan

- [x] `make fmt && make vet && make test` green
- [x] `TestDetectDirectiveCollisions` (table): same key/same value (no collision), same key/different value (collision), different keys, one KB silent, several keys per KB, three KBs/three values, syntax documented mid-paragraph and inside a fenced code block (neither triggers), malformed markers (empty value, extra `:` in value), a KB that opted out of the preamble still declaring a directive, non-`instructions` artifacts ignored
- [x] `TestMergeArtifactsStrict_DirectiveCollision`, `TestMergeArtifactsStrict_BothCollisionKinds` (structural + directive collision reported together)
- [x] `TestDetectDirectiveCollisions_ScopedToWhatItIsGiven` (provider-scoping demonstration)
- [x] `TestGenerateKBInstructions_DirectiveDeclaredAndVisible`, `TestBuildManifest_DirectiveCollision_EndToEnd`, `TestGenerateKBInstructions_DirectiveDocumentedInProseIsNotDeclared` (end-to-end through `BuildManifest`, not just hand-built fixtures)

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)