### PR TITLE
docs(readme): make the agent compatibility matrix accurate and say what fires a re-sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,18 +71,36 @@ cartographer connect        # detects installed clients and configures all of th
 
 That single command writes, per client and in the format that client expects:
 
-| | claude | opencode | codex | kiro | hermes | antigravity |
+| | claude | opencode | codex | kiro | antigravity | hermes |
 |---|---|---|---|---|---|---|
-| **MCP endpoint** | `.claude.json` | `opencode.json` | `config.toml` block | `.kiro/settings/mcp.json` | *rendered by its own deploy* | `.gemini/config/mcp_config.json` |
-| **Skills** | `.claude/skills/` | `.opencode/skills/` | `.codex/skills/` | `.kiro/skills/` | delivered to its inbox | `.gemini/config/skills/` |
-| **Subagents** | `.claude/agents/*.md` | `.opencode/agent/*.md` | `.codex/agents/*.toml` | — | — | `.gemini/config/agents/*.md` |
-| **Hooks** | `settings.json` | generated JS plugin | `config.toml` block | — | — | `.gemini/config/hooks.json` |
-| **Instructions** | block in `CLAUDE.md` | block in `AGENTS.md` | block in `AGENTS.md` | `.kiro/steering/` | — | block in `GEMINI.md` |
+| **MCP endpoint** | `~/.claude.json` | `~/opencode.json` | block in `~/.codex/config.toml` | `~/.kiro/settings/mcp.json` | `~/.gemini/config/mcp_config.json` | — |
+| **Instructions** | block in `~/.claude/CLAUDE.md` | block in `~/.config/opencode/AGENTS.md` | block in `~/.codex/AGENTS.md` | `~/.kiro/steering/cartographer.md` | block in `~/.gemini/GEMINI.md` | — |
+| **Skills** | `~/.claude/skills/` | `~/.opencode/skills/` | `~/.codex/skills/` | `~/.kiro/skills/` | `~/.gemini/config/skills/` | delivered to its inbox |
+| **Subagents** | `~/.claude/agents/*.md` | `~/.opencode/agent/*.md` | `~/.codex/agents/*.toml` | — | `~/.gemini/config/agents/*.md` | — |
+| **Hooks** | `~/.claude/hooks/`, registered in `settings.json` | `~/.opencode/hooks/`, run by a generated JS plugin | `~/.codex/hooks/`, registered in `config.toml` | — | `~/.gemini/config/hooks/`, registered in `hooks.json` | — |
+| **Re-sync trigger** | `SessionStart` hook | `SessionStart` hook | `SessionStart` hook | scheduled timer | scheduled timer | scheduled timer |
 
 Subagents and hooks are **translated**, not copied: the same KB artifact becomes a Markdown agent
-for Claude Code, a TOML one for Codex, Antigravity-native Markdown, and a generated JavaScript plugin where a hook has no declarative
-equivalent. Cells that cannot exist are `unsupported` by explicit declaration, never by silent
-omission — and a cell missing from the table fails a test.
+for Claude Code, a TOML one for Codex, Antigravity-native Markdown, and a generated JavaScript
+plugin where a hook has no declarative equivalent.
+
+Every `—` is an `unsupported` cell **declared for a stated reason**, never a silent omission — and a
+cell missing from the table fails a test:
+
+- **kiro** — its hooks live inside an *agent* configuration and fire only for the agent that
+  declares them, so no hook Cartographer owns can fire for the agent the user actually runs; and its
+  agents are top-level personas you select yourself, not delegates a main agent can invoke. Kiro 3.0
+  changes both facts — standalone machine-wide hooks, and any custom agent invocable as a sub-agent
+  — and [#248](https://github.com/BeppeTemp/cartographer/issues/248) tracks the work.
+- **hermes** — its MCP endpoints and its always-on instruction slot are rendered by its own Ansible
+  role and recreated on the next playbook run, and it has no subagent directory and no hook engine.
+  Skills are *delivered*, not installed: they land in an inbox with a generated `SOURCE.md` and the
+  agent's own curator adopts them, because overwriting what that curator owns would destroy its
+  learning.
+
+Where there is no session hook, the **scheduled trigger** takes over
+(`cartographer service sync-timer install`): opt-in, explicit, and never installed as a side effect
+of connecting.
 
 What keeps it true after the first run:
 


### PR DESCRIPTION
## Summary

The "One KB, every agent" matrix was the first concrete thing a reader sees, and it was both incomplete and wrong in places.

**Corrected destinations.** Checked cell by cell against `destinationMatrix` (`internal/provisioning/provisioning.go:2579-2638`):

- instructions were listed as four bare file names (`CLAUDE.md`, `AGENTS.md`, `AGENTS.md`, `.kiro/steering/`); the real destinations are `~/.claude/CLAUDE.md`, `~/.config/opencode/AGENTS.md`, `~/.codex/AGENTS.md` and `~/.kiro/steering/cartographer.md`
- the hook cells named only the registration point (`settings.json`, `config.toml` block) and hid the materialized directory, which is where the script the reader would go looking for actually lives
- every path is now anchored at `~`, so the table states the scope instead of leaving it to inference

**New row: re-sync trigger.** The paragraph under the table already claimed the system re-syncs by itself — "a `SessionStart` hook on every client that has one, a scheduled timer for those that don't" — while the table gave no way to tell which client is which. That distinction is the single most practical thing on the page for someone choosing a client, so it is now a row.

**The em-dashes say why.** An `unsupported` cell is a declared decision with a reason recorded in the matrix comments and in D140/D141; a README showing a bare dash reads as an unfinished implementation. Both providers now get one sentence: Kiro's per-agent hooks and its top-level personas, Hermes' Ansible-rendered config and inbox delivery. The Kiro bullet points at #248, which retires both limits on Kiro 3.0.

**Column order.** Hermes moves last: it is the one provider whose artifacts are *delivered* rather than installed, so it stops interrupting the four that behave alike.

Documentation only — no code, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)