### PR TITLE
fix(configurator): stop reporting shadowed instructions as installed (D189)

### DIFF
--- a/cmd/cartographer/doctor.go
+++ b/cmd/cartographer/doctor.go
@@ -502,6 +502,25 @@ func checkInstructionsBlock(dir string, providers []string, lockFile provisionin
 				Message: fmt.Sprintf("[%s] the managed instructions block is not terminated", p),
 				Fix:     "cartographer reconnect",
 			})
+		case managed:
+			// The block is well-formed. That says Cartographer wrote what it
+			// meant to write; it does not say the provider reads that file
+			// (D189). A file earlier in the provider's own precedence chain
+			// replaces it, and then the operator is told the KB directives are
+			// in force while the agent has never seen them.
+			baseDir := provisioning.LockBaseDir(lock, dir)
+			shadowing, shadowed, ok := configurator.ShadowedInstructions(provider, baseDir)
+			if !ok {
+				break
+			}
+			out = append(out, doctorFinding{
+				Check: "instructions", Severity: doctorError,
+				Path: filepath.Join(baseDir, shadowing),
+				Message: fmt.Sprintf("[%s] %s takes precedence over %s and is not merged with it, so the managed instructions block never reaches the model",
+					p, shadowing, shadowed),
+				Fix: fmt.Sprintf("move your own content into a section of %s and let Cartographer own %s, or keep the override and scope Cartographer's instructions to a project instead",
+					shadowing, shadowed),
+			})
 		}
 	}
 	return out

--- a/cmd/cartographer/doctor_test.go
+++ b/cmd/cartographer/doctor_test.go
@@ -617,3 +617,130 @@ func TestCheckOrphanedFiles(t *testing.T) {
 		t.Errorf("a fully accounted directory produced findings: %+v", got)
 	}
 }
+
+// --- shadowed instructions (D189) ---
+
+// withManagedInstructions puts the fixture in the state the shadowing check
+// cares about: a well-formed managed block in the provider's instructions file,
+// recorded in the lockfile. doctorFixture's stub server serves an empty
+// manifest, so connect materializes no instructions on its own.
+func withManagedInstructions(t *testing.T, dir, provider string) string {
+	t.Helper()
+	rel := provisioning.InstructionsFile(configurator.Provider(provider))
+	if rel == "" {
+		t.Fatalf("%s has no instructions destination", provider)
+	}
+	path := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	block := "<!-- cartographer:instructions:begin -->\nx\n<!-- cartographer:instructions:end -->\n"
+	if err := os.WriteFile(path, []byte(block), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lf, err := provisioning.ReadLockFile(lockFilePath(dir))
+	if err != nil {
+		t.Fatalf("ReadLockFile: %v", err)
+	}
+	lock := lf.ForProvider(provider)
+	lock.Managed = append(lock.Managed, provisioning.ManagedFile{
+		Kind: "instructions", Name: "alpha", Path: rel, ContentHash: "h1",
+	})
+	if lf.Providers == nil {
+		lf.Providers = map[string]provisioning.Lock{}
+	}
+	lf.Providers[provider] = lock
+	if err := provisioning.WriteLockFile(lockFilePath(dir), lf); err != nil {
+		t.Fatalf("WriteLockFile: %v", err)
+	}
+	return path
+}
+
+// An instructions block written correctly into a file the provider does not
+// read is not installed. Codex resolves the global scope to AGENTS.override.md
+// when it exists and does not merge it with AGENTS.md, so the managed block
+// never reaches the model — while every other check reports a healthy tree.
+func TestRunDoctor_ShadowedInstructions(t *testing.T) {
+	doctorStubs(t, []string{"codex"}, false)
+	dir := doctorFixture(t, "codex")
+	withManagedInstructions(t, dir, "codex")
+
+	if f := findingsFor(runDoctor(dir, ""), "instructions"); len(f) != 0 {
+		t.Fatalf("fixture must start clean, got %d instructions finding(s): %+v", len(f), f)
+	}
+
+	override := filepath.Join(dir, ".codex", "AGENTS.override.md")
+	if err := os.WriteFile(override, []byte("# My own rules\n"), 0o644); err != nil {
+		t.Fatalf("write override: %v", err)
+	}
+
+	report := runDoctor(dir, "")
+	findings := findingsFor(report, "instructions")
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly one instructions finding, got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Severity != doctorError {
+		t.Errorf("severity = %v; want error: the operator's stated intent is not met", f.Severity)
+	}
+	if !strings.Contains(f.Message, "AGENTS.override.md") || !strings.Contains(f.Message, "AGENTS.md") {
+		t.Errorf("message must name both files, got: %s", f.Message)
+	}
+	if f.Fix == "" {
+		t.Error("finding must name a way out")
+	}
+	if doctorExitCode(report) == 0 {
+		t.Error("an error-severity finding must produce a non-zero exit code")
+	}
+}
+
+// An empty override still shadows: Codex reads it and finds nothing.
+func TestRunDoctor_ShadowedInstructions_EmptyOverride(t *testing.T) {
+	doctorStubs(t, []string{"codex"}, false)
+	dir := doctorFixture(t, "codex")
+	withManagedInstructions(t, dir, "codex")
+
+	if err := os.WriteFile(filepath.Join(dir, ".codex", "AGENTS.override.md"), nil, 0o644); err != nil {
+		t.Fatalf("write override: %v", err)
+	}
+	if f := findingsFor(runDoctor(dir, ""), "instructions"); len(f) != 1 {
+		t.Fatalf("an empty override still shadows, got %d finding(s): %+v", len(f), f)
+	}
+}
+
+// The managed file absent *and* shadowed is one finding, not two: the absence
+// wins, because that is the one the operator must fix first.
+func TestRunDoctor_ShadowedInstructions_AbsentManagedFileWins(t *testing.T) {
+	doctorStubs(t, []string{"codex"}, false)
+	dir := doctorFixture(t, "codex")
+	managed := withManagedInstructions(t, dir, "codex")
+
+	if err := os.WriteFile(filepath.Join(dir, ".codex", "AGENTS.override.md"), []byte("x\n"), 0o644); err != nil {
+		t.Fatalf("write override: %v", err)
+	}
+	if err := os.Remove(managed); err != nil {
+		t.Fatalf("remove managed file: %v", err)
+	}
+	findings := findingsFor(runDoctor(dir, ""), "instructions")
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly one finding, got %d: %+v", len(findings), findings)
+	}
+	if strings.Contains(findings[0].Message, "takes precedence") {
+		t.Errorf("the absence must win over the shadowing: %s", findings[0].Message)
+	}
+}
+
+// A provider with no declared precedence chain is unaffected, even with a
+// same-named file sitting next to its instructions.
+func TestRunDoctor_NoPrecedenceChain_NoFinding(t *testing.T) {
+	doctorStubs(t, []string{"claude"}, false)
+	dir := doctorFixture(t, "claude")
+	withManagedInstructions(t, dir, "claude")
+
+	if err := os.WriteFile(filepath.Join(dir, ".claude", "CLAUDE.override.md"), []byte("x\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if f := findingsFor(runDoctor(dir, ""), "instructions"); len(f) != 0 {
+		t.Fatalf("claude declares no chain: expected no finding, got %+v", f)
+	}
+}

--- a/cmd/cartographer/status.go
+++ b/cmd/cartographer/status.go
@@ -99,6 +99,7 @@ func renderStatus(output string, s statusSnapshot, code int) int {
 			if p.Kinds != "" {
 				fmt.Printf("  %s\n", p.Kinds)
 			}
+			printShadowedInstructionsLine(p)
 			continue
 		}
 		if p.State != "drift" {
@@ -110,6 +111,7 @@ func renderStatus(output string, s statusSnapshot, code int) int {
 		if p.Kinds != "" {
 			fmt.Printf("  %s\n", p.Kinds)
 		}
+		printShadowedInstructionsLine(p)
 		for _, d := range p.Diverged {
 			fmt.Printf("  diverged on disk (%s): %s/%s at %s\n", d.Trust, d.Kind, d.Name, d.Path)
 		}
@@ -198,4 +200,17 @@ func printBindingLine(p providerStatus) {
 		parts = append(parts, fmt.Sprintf("%s %d", source, p.KBCounts[source]))
 	}
 	fmt.Printf("  from %s\n", strings.Join(parts, " · "))
+}
+
+// printShadowedInstructionsLine reports an instructions block that was written
+// correctly into a file the provider does not read (D189). It reads as a fact
+// about the provider's own precedence, not as a Cartographer failure, because
+// that is what it is — and it says what is in force instead, since "not active"
+// on its own leaves the operator without a next step.
+func printShadowedInstructionsLine(p providerStatus) {
+	if p.ShadowedInstructions == "" {
+		return
+	}
+	fmt.Printf("  instructions not active: %s takes precedence and is not merged — run `cartographer doctor` for the two ways out\n",
+		p.ShadowedInstructions)
 }

--- a/cmd/cartographer/status_snapshot.go
+++ b/cmd/cartographer/status_snapshot.go
@@ -26,16 +26,21 @@ type statusError struct {
 }
 
 type providerStatus struct {
-	Name         string           `json:"name"`
-	Installed    bool             `json:"installed"`
-	Connected    bool             `json:"connected"`
-	State        string           `json:"state"`
-	Revision     string           `json:"revision,omitempty"`
-	LockRevision string           `json:"lock_revision,omitempty"`
-	Kinds        string           `json:"kind_status,omitempty"`
-	Added        []statusArtifact `json:"added,omitempty"`
-	Updated      []statusArtifact `json:"updated,omitempty"`
-	Removed      []statusArtifact `json:"removed,omitempty"`
+	Name         string `json:"name"`
+	Installed    bool   `json:"installed"`
+	Connected    bool   `json:"connected"`
+	State        string `json:"state"`
+	Revision     string `json:"revision,omitempty"`
+	LockRevision string `json:"lock_revision,omitempty"`
+	Kinds        string `json:"kind_status,omitempty"`
+	// ShadowedInstructions names the provider-owned file that takes precedence
+	// over the instructions file Cartographer manages, when one exists (D189).
+	// A block written correctly into a file the provider does not read is not
+	// installed, so it is excluded from the Kinds count and reported here.
+	ShadowedInstructions string           `json:"shadowed_instructions,omitempty"`
+	Added                []statusArtifact `json:"added,omitempty"`
+	Updated              []statusArtifact `json:"updated,omitempty"`
+	Removed              []statusArtifact `json:"removed,omitempty"`
 	// Diverged lists managed artifacts whose files on disk no longer match
 	// what was materialized (D139): edited by hand, deleted, or with their
 	// managed key/block removed from a shared file. `cartographer sync`
@@ -217,7 +222,14 @@ func snapshotForConfig(dir string, cfg *clientconfig.Config, includeService bool
 		p := &s.Providers[i]
 		p.Revision = pm.Revision
 		p.LockRevision = lockFile.ForProvider(p.Name).AppliedRevision
-		p.Kinds = formatKindStatus(pm, lockFile.ForProvider(p.Name))
+		if shadowing, _, ok := configurator.ShadowedInstructions(
+			configurator.Provider(p.Name),
+			provisioning.LockBaseDir(lockFile.ForProvider(p.Name), dir),
+		); ok {
+			p.ShadowedInstructions = shadowing
+		}
+		p.Kinds = formatKindStatus(pm, lockFile.ForProvider(p.Name), p.ShadowedInstructions != "")
+
 		// On-disk verification (D139): the manifest↔lockfile comparison says
 		// nothing about what is actually on disk, so an artifact edited or
 		// deleted locally used to report in-sync.

--- a/cmd/cartographer/status_test.go
+++ b/cmd/cartographer/status_test.go
@@ -179,3 +179,69 @@ func TestStatus_OnDiskDriftExitsOne(t *testing.T) {
 		t.Errorf("output = %q, want the divergence reported", out)
 	}
 }
+
+// D189: a managed instructions block written into a file the provider does not
+// read is not installed. `instructions n/n` must not count it, and status must
+// say so — the previous behaviour printed `instructions 1/1` while the agent had
+// never seen the directives.
+func TestStatus_ShadowedInstructionsNotCountedAsInstalled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := clientconfig.Save(home, &clientconfig.Config{ServerURL: "https://cartographer.example/mcp", Agents: []string{"codex"}, Trust: true}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	rel := provisioning.InstructionsFile(configurator.ProviderCodex)
+	path := filepath.Join(home, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	block := []byte("<!-- cartographer:instructions:begin -->\nx\n<!-- cartographer:instructions:end -->\n")
+	if err := os.WriteFile(path, block, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	served := provisioning.Manifest{Revision: "rev1", Artifacts: []provisioning.Artifact{
+		{Kind: "instructions", Name: "wiki", Source: "kb:wiki", ContentHash: "source-hash", Signed: true},
+	}}
+	appliedRev := provisioning.FilterForProvider(served, configurator.ProviderCodex).Revision
+	lock := provisioning.Lock{Provider: "codex", AppliedRevision: appliedRev, Managed: []provisioning.ManagedFile{{
+		Kind: "instructions", Name: "wiki", Path: rel, ContentHash: "source-hash",
+	}}}
+	if err := provisioning.WriteLockFile(lockFilePath(home), provisioning.LockFile{Providers: map[string]provisioning.Lock{"codex": lock}}); err != nil {
+		t.Fatalf("write lockfile: %v", err)
+	}
+
+	oldVersion, oldHealth, oldManifest, oldService := version, statusHealthFn, statusManifestsFn, statusServiceFn
+	version = "v1.0.0"
+	statusHealthFn = func(*clientconfig.Config) (*client.Health, error) { return &client.Health{Version: "v1.0.0"}, nil }
+	statusManifestsFn = func(_ *clientconfig.Config, providers []string) (map[string]provisioning.Manifest, error) {
+		return uniformManifests(served, providers), nil
+	}
+	statusServiceFn = func() (service.Status, error) { return service.Status{}, nil }
+	t.Cleanup(func() {
+		version, statusHealthFn, statusManifestsFn, statusServiceFn = oldVersion, oldHealth, oldManifest, oldService
+	})
+
+	out := withStdout(t, func() { cmdStatus(nil) })
+	if !strings.Contains(out, "instructions 1/1") {
+		t.Fatalf("without an override the block is installed; output = %q", out)
+	}
+	if strings.Contains(out, "not active") {
+		t.Errorf("nothing shadows it yet: %q", out)
+	}
+
+	// The user's own override appears. Codex reads it *instead of* AGENTS.md.
+	if err := os.WriteFile(filepath.Join(home, ".codex", "AGENTS.override.md"), []byte("# mine\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out = withStdout(t, func() { cmdStatus(nil) })
+	if strings.Contains(out, "instructions 1/1") {
+		t.Errorf("a shadowed block must not count as installed: %q", out)
+	}
+	if !strings.Contains(out, "instructions 0/1") {
+		t.Errorf("expected instructions 0/1: %q", out)
+	}
+	if !strings.Contains(out, "not active") || !strings.Contains(out, "AGENTS.override.md") {
+		t.Errorf("status must name the shadowing file: %q", out)
+	}
+}

--- a/cmd/cartographer/tui.go
+++ b/cmd/cartographer/tui.go
@@ -585,8 +585,18 @@ var knownProvisioningKinds = []string{"skill", "agent", "hook", "instructions", 
 // `cartographer status` and the dashboard read the result off the snapshot, so
 // the two cannot report different breakdowns for the same provider. It stands
 // alongside — not in place of — formatDiffStatus.
-func formatKindStatus(m provisioning.Manifest, lock provisioning.Lock) string {
+func formatKindStatus(m provisioning.Manifest, lock provisioning.Lock, instructionsShadowed bool) string {
 	counts := provisioning.KindCounts(m, lock)
+
+	// A block written into a file the provider does not read is not installed
+	// (D189). Counting it would make the figure the operator trusts the most
+	// the one that lies.
+	if instructionsShadowed {
+		if c, ok := counts["instructions"]; ok {
+			c.Installed = 0
+			counts["instructions"] = c
+		}
+	}
 
 	seen := make(map[string]bool, len(counts))
 	var parts []string

--- a/cmd/cartographer/tui_test.go
+++ b/cmd/cartographer/tui_test.go
@@ -648,7 +648,7 @@ func TestFormatKindStatus(t *testing.T) {
 		},
 	}
 
-	got := formatKindStatus(m, lock)
+	got := formatKindStatus(m, lock, false)
 	want := "skill 1/2 · agent 2/2 · hook 0/1"
 	if got != want {
 		t.Errorf("formatKindStatus: got %q, want %q", got, want)
@@ -656,7 +656,7 @@ func TestFormatKindStatus(t *testing.T) {
 }
 
 func TestFormatKindStatus_Empty(t *testing.T) {
-	if got := formatKindStatus(provisioning.Manifest{}, provisioning.Lock{}); got != "" {
+	if got := formatKindStatus(provisioning.Manifest{}, provisioning.Lock{}, false); got != "" {
 		t.Errorf("formatKindStatus on empty manifest: got %q, want \"\"", got)
 	}
 }
@@ -668,7 +668,7 @@ func TestFormatKindStatus_UnknownKindAppendedAlphabetically(t *testing.T) {
 			{Kind: "zzz-future-kind", Name: "f1", ContentHash: "h2"},
 		},
 	}
-	got := formatKindStatus(m, provisioning.Lock{})
+	got := formatKindStatus(m, provisioning.Lock{}, false)
 	want := "skill 0/1 · zzz-future-kind 0/1"
 	if got != want {
 		t.Errorf("formatKindStatus: got %q, want %q", got, want)

--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -107,6 +107,17 @@ Expected output: a version, then health JSON containing `"ready":true`, then in-
 exit code 0. Restart the connected agent session after this check so it loads the MCP tools and
 provisioned skills.
 
+Confirm the instructions actually reach the model, not just the disk. `cartographer status` and
+`cartographer doctor` now check the provider's own precedence chain (D189), but the provider's own
+tooling is the ground truth — for Codex:
+
+```bash
+codex debug prompt-input
+```
+
+Expected output: a `cartographer:kb:*` section. If it is absent while `status` reports the
+instructions installed, report it: a provider precedence rule Cartographer does not model yet.
+
 `connect` provisioned the bundled skills, including `cartographer-ops`. Use that skill for ongoing
 operations, diagnosis, upgrades, and synchronization after installation.
 

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -320,7 +320,7 @@ The checks:
 | `lockfile` | present, readable, and in the v2 format — a v1 file on disk is migrated *in memory* by every read, but stays v1 until something rewrites it |
 | `managed-files` | the on-disk verification of D139, per provider: `missing`, `modified`, `unregistered`; plus files sitting inside a managed skill/hook directory that no lock entry accounts for (D178) — reported only, since doctor cannot prove Cartographer wrote them |
 | `mcp-entries` | the Cartographer entries in the provider's native config match the KBs recorded in `.cartographer.yaml` — an entry for a KB the server no longer mounts, or a missing one |
-| `instructions` | exactly one well-formed managed block per provider that has instructions materialized (begin recognized by prefix, so a block written by an older version still counts) |
+| `instructions` | exactly one well-formed managed block per provider that has instructions materialized (begin recognized by prefix, so a block written by an older version still counts), **and** that the provider actually reads the file it was written into (D189) |
 | `hooks` | one native registration per managed hook — the D99 double-fire is a registration left outside the managed block by Codex's own rewrite |
 | `server` | `/health` reachable; the recorded `server_version` (D142) against the live one; client binary against server. When an unreachable server is loopback **and** no local native service is installed, the finding names that cause and the two remedies instead of pointing at `service status`, which would only repeat `installed: false` (D174) |
 | `trigger` | every connected provider has a session hook, or the scheduled trigger is installed (D140) |

--- a/docs/decisions/client-configurator.md
+++ b/docs/decisions/client-configurator.md
@@ -881,3 +881,65 @@ recorded here so that work covers Antigravity from the start rather than discove
 - `cartographer status` and `sync` track drift and synchronize skills, subagents, hooks, MCP endpoints, and instructions.
 - An Antigravity config carrying comments now fails `connect`/`sync` with a named error instead of
   being rewritten. This is the intended behaviour, and the message says what to do.
+
+
+## D189 — Instructions written correctly are not reported as installed until the provider reads them
+
+**Status: implemented.** Closes #243.
+
+**Context.** Cartographer reported instructions as installed when it had written the file it
+intended to write. It never checked whether the provider actually reads that file. On a real
+machine the two diverge, and the reporting is a false positive of the worst kind: the operator is
+told the KB directives are in force while the agent has never seen them.
+
+Verified locally against Codex 0.153.4:
+
+- Cartographer writes the Codex instructions block to `~/.codex/AGENTS.md`.
+- The machine also had a user-owned `~/.codex/AGENTS.override.md`.
+- Codex's documented rule for the global scope is that `AGENTS.override.md` wins **and the two are
+  not concatenated** (<https://developers.openai.com/codex/guides/agents-md>).
+- `codex debug prompt-input` found the user's own heading and **no** `cartographer:kb:*` section.
+- Meanwhile `cartographer status` printed `instructions 4/4` and `cartographer doctor` reported
+  0 errors and 0 warnings.
+
+Both surfaces verified presence and hash of the file they wrote, and neither modelled the
+provider's precedence chain.
+
+**Decision.**
+
+- **Detect and report; never write into the user's file.** `AGENTS.override.md` is user-owned.
+  Materializing the block there is a separate, explicit choice, not a repair performed on the
+  operator's behalf. Silently editing a file the operator owns is worse than a clear "not active"
+  finding.
+- **A shadowed instructions artifact is not "installed".** `status` excludes it from the
+  `instructions n/n` figure and reports it on its own line; `doctor` emits a finding at severity
+  **error**, not warning — the operator's stated intent is not met, and the exit code should say so.
+- **The chain is declared per provider, as data.** `Descriptor.InstructionsPrecedence` lists the
+  provider's global instructions files in the order the provider resolves them, and only where a
+  file earlier in the list **replaces** the managed one rather than being merged with it. Providers
+  with no documented shadowing rule declare none and behave exactly as before: an invented
+  precedence produces a false "not active" finding, which is the same class of defect this check
+  exists to remove. Each declaration cites its vendor source in a comment — these are external
+  contracts that change outside this project's release cycle.
+- **Antigravity declares no chain, deliberately.** It reads both `~/.gemini/GEMINI.md` and the
+  cross-tool `~/.gemini/AGENTS.md`, and GEMINI.md — the file Cartographer manages — wins where they
+  conflict (<https://antigravity.google/docs/rules-workflows/>). Nothing shadows it. This was the
+  open question [D194](#d194) recorded when Antigravity landed; it is now answered.
+- **Remediation is instructions, not automation.** The finding names the shadowing file, the
+  shadowed one, and the two ways out: move the personal content into a section of the override and
+  let Cartographer own the managed file, or keep the override and scope Cartographer's instructions
+  to a project. Which one is the operator's call.
+- **The chain ends at the managed file**, by construction, and a test asserts that its last entry
+  equals `provisioning.InstructionsFile(provider)`. Drift between the two declarations would make
+  the check compare a file against itself, or against one nobody writes.
+
+**Invariants kept.** Cartographer writes only the files it owns. The hash/drift verification of the
+written file is unchanged and the new check is **additional**, not a replacement — a file can be
+both correct and inactive. The managed file absent *and* shadowed yields one finding, not two: the
+absence wins, because that is what the operator must fix first. `doctor --only <provider>` scoping
+applies to the new finding like any other.
+
+**Consequences.** `doctor` can now fail on installations that previously reported clean — that is
+the point. `docs/agent-install.md` gains a verification step (`codex debug prompt-input`) so the
+runbook does not rely on `status` alone for this, and an instruction to report a case where the two
+disagree: that would be a provider precedence rule not yet modelled here.

--- a/internal/configurator/configurator_test.go
+++ b/internal/configurator/configurator_test.go
@@ -536,3 +536,66 @@ func TestApplyWrite(t *testing.T) {
 		}
 	}
 }
+
+// --- instructions precedence (D189) ---
+
+// Only providers with a documented shadowing rule declare a chain. An invented
+// one produces a false "not active" finding, which is the same class of defect
+// the check exists to remove.
+func TestInstructionsPrecedence_DeclaredOnlyWhereDocumented(t *testing.T) {
+	want := map[configurator.Provider]bool{configurator.ProviderCodex: true}
+	for _, d := range configurator.Providers() {
+		declared := len(d.InstructionsPrecedence) > 0
+		if declared != want[d.Provider] {
+			t.Errorf("%s: declares a precedence chain = %v; want %v", d.Provider, declared, want[d.Provider])
+		}
+	}
+}
+
+func TestShadowedInstructions(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		provider      configurator.Provider
+		files         []string
+		wantShadowing string
+	}{
+		{"override present shadows the managed file", configurator.ProviderCodex,
+			[]string{".codex/AGENTS.override.md", ".codex/AGENTS.md"}, ".codex/AGENTS.override.md"},
+		{"override present, managed file absent", configurator.ProviderCodex,
+			[]string{".codex/AGENTS.override.md"}, ".codex/AGENTS.override.md"},
+		{"only the managed file", configurator.ProviderCodex,
+			[]string{".codex/AGENTS.md"}, ""},
+		{"nothing on disk", configurator.ProviderCodex, nil, ""},
+		{"provider without a chain", configurator.ProviderClaudeCode,
+			[]string{".claude/CLAUDE.override.md", ".claude/CLAUDE.md"}, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for _, rel := range tc.files {
+				path := filepath.Join(dir, filepath.FromSlash(rel))
+				if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, []byte("x\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			shadowing, shadowed, ok := configurator.ShadowedInstructions(tc.provider, dir)
+			if tc.wantShadowing == "" {
+				if ok {
+					t.Fatalf("expected no shadowing, got %q over %q", shadowing, shadowed)
+				}
+				return
+			}
+			if !ok {
+				t.Fatal("expected shadowing")
+			}
+			if shadowing != filepath.FromSlash(tc.wantShadowing) {
+				t.Errorf("shadowing = %q; want %q", shadowing, tc.wantShadowing)
+			}
+			if shadowed == "" {
+				t.Error("the shadowed file must be named too: the finding has to state both")
+			}
+		})
+	}
+}

--- a/internal/configurator/registry.go
+++ b/internal/configurator/registry.go
@@ -81,6 +81,22 @@ type Descriptor struct {
 	// last on darwin only.
 	DarwinAppDir string
 
+	// InstructionsPrecedence lists the provider's global instructions files in
+	// the order the provider itself resolves them, relative to the client base
+	// dir, when a file earlier in the list **replaces** the one Cartographer
+	// manages rather than being concatenated with it (D189). Cartographer
+	// writing its block correctly is not the same as the provider reading it:
+	// a file earlier in this chain that exists means the managed block never
+	// reaches the model.
+	//
+	// Empty for a provider with no documented shadowing rule — including one
+	// whose several instructions files are all read, or where the managed file
+	// wins. Do not guess a chain: an invented precedence produces a false
+	// finding, which is the same class of defect this field exists to remove.
+	// Cite the vendor source next to each declaration; these are external
+	// contracts that change outside this project's release cycle.
+	InstructionsPrecedence [][]string
+
 	// emit renders one MCP server entry for this provider. The provider output
 	// formats genuinely differ, so this stays a function, not data.
 	emit func(name string, spec ServerSpec) (*EmitResult, error)
@@ -110,7 +126,12 @@ var descriptors = []Descriptor{
 		SupportsMCPHeaders: true,
 		Binaries:           []string{"codex"},
 		ConfigDirs:         [][]string{{".codex"}},
-		emit:               emitCodexServer,
+		// Codex resolves the global scope to AGENTS.override.md when it exists,
+		// and does **not** concatenate it with AGENTS.md — so an override on the
+		// machine makes the block Cartographer writes to AGENTS.md unreachable.
+		// https://developers.openai.com/codex/guides/agents-md
+		InstructionsPrecedence: [][]string{{".codex", "AGENTS.override.md"}, {".codex", "AGENTS.md"}},
+		emit:                   emitCodexServer,
 	},
 	{
 		Provider:           ProviderKiro,
@@ -162,7 +183,11 @@ var descriptors = []Descriptor{
 		Binaries:           []string{"agy"},
 		ConfigDirs:         [][]string{{".gemini", "config"}, {".gemini", "antigravity"}, {".gemini", "antigravity-cli"}},
 		DarwinAppDir:       "/Applications/Antigravity.app",
-		emit:               emitAntigravityServer,
+		// No InstructionsPrecedence: Antigravity reads both ~/.gemini/GEMINI.md
+		// and the cross-tool ~/.gemini/AGENTS.md, and GEMINI.md — the file
+		// Cartographer manages — wins where they conflict. Nothing shadows it.
+		// https://antigravity.google/docs/rules-workflows/
+		emit: emitAntigravityServer,
 	},
 }
 
@@ -244,4 +269,35 @@ func ProviderList() []Provider {
 		out = append(out, d.Provider)
 	}
 	return out
+}
+
+// ShadowedInstructions reports whether the instructions file Cartographer
+// manages for provider is shadowed under baseDir: a file earlier in the
+// provider's declared precedence chain exists, and the provider reads that one
+// instead (D189).
+//
+// It returns the shadowing file and the shadowed (managed) one, both relative
+// to baseDir. ok is false when the provider declares no chain, when the managed
+// file is the first existing entry, or when nothing in the chain exists at all
+// — the last case is the provider's own problem, not a shadowing one, and the
+// absence of the managed file is already reported by its own check.
+func ShadowedInstructions(provider Provider, baseDir string) (shadowing, shadowed string, ok bool) {
+	d, found := Lookup(provider)
+	if !found || len(d.InstructionsPrecedence) == 0 {
+		return "", "", false
+	}
+	// The managed file is the last entry of the chain by construction: the
+	// chain lists what takes precedence over it, then it.
+	managedRel := filepath.Join(d.InstructionsPrecedence[len(d.InstructionsPrecedence)-1]...)
+	for _, segments := range d.InstructionsPrecedence {
+		rel := filepath.Join(segments...)
+		if _, err := os.Lstat(filepath.Join(baseDir, rel)); err != nil {
+			continue
+		}
+		if rel == managedRel {
+			return "", "", false
+		}
+		return rel, managedRel, true
+	}
+	return "", "", false
 }

--- a/internal/provisioning/registry_test.go
+++ b/internal/provisioning/registry_test.go
@@ -101,3 +101,19 @@ func TestDestDirPaths(t *testing.T) {
 		}
 	}
 }
+
+// The precedence chain's last entry is the file Cartographer manages, by
+// construction: the chain lists what takes precedence over it, then it. Drift
+// between the two declarations would make the shadowing check compare a file
+// against itself, or against one nobody writes (D189).
+func TestInstructionsPrecedenceEndsAtTheManagedFile(t *testing.T) {
+	for _, d := range configurator.Providers() {
+		if len(d.InstructionsPrecedence) == 0 {
+			continue
+		}
+		last := filepath.Join(d.InstructionsPrecedence[len(d.InstructionsPrecedence)-1]...)
+		if got := InstructionsFile(d.Provider); got != last {
+			t.Errorf("%s: precedence chain ends at %q but InstructionsFile says %q", d.Provider, last, got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #243

## The false positive

Cartographer reported instructions as installed when it had written the file it *intended* to write. It never checked whether the provider actually reads that file.

Verified locally against Codex 0.153.4:

- the block goes to `~/.codex/AGENTS.md`
- the machine also had a user-owned `~/.codex/AGENTS.override.md`
- Codex's documented rule for the global scope is that `AGENTS.override.md` wins **and the two are not concatenated** ([source](https://developers.openai.com/codex/guides/agents-md))
- `codex debug prompt-input` found the user's own heading and **no** `cartographer:kb:*` section

Meanwhile `cartographer status` printed `instructions 4/4` and `cartographer doctor` reported 0 errors and 0 warnings. Both surfaces verified presence and hash of the file they wrote; neither modelled the provider's precedence chain. The operator was told the KB directives were in force while the agent had never seen them.

## What changed

- **`Descriptor.InstructionsPrecedence`** declares the chain per provider, as data, and only where a file earlier in it **replaces** the managed one rather than being merged with it. Codex declares it; everyone else declares none and behaves exactly as before. A guessed precedence would produce a false "not active" finding — the same class of defect this removes — so the field's doc comment says not to invent one, and each declaration cites its vendor source.
- **`status`** excludes a shadowed artifact from the `instructions n/n` figure and reports it on its own line, in the tone of the existing `diverged on disk` line.
- **`doctor`** emits an error-severity finding naming the shadowing file, the shadowed one, and the two ways out.
- **Cartographer never writes into the user-owned override.** Detecting and saying so is the fix; silently editing a file the operator owns would be worse than the false positive.

## Antigravity's case, settled

D194 recorded an open question when Antigravity landed: `~/.gemini/GEMINI.md` is shared with Gemini CLI and Antigravity also reads a cross-tool `~/.gemini/AGENTS.md`. Researched and answered: Antigravity reads **both**, and GEMINI.md — the file we manage — wins where they conflict ([source](https://antigravity.google/docs/rules-workflows/)). Nothing shadows it, so it declares no chain. The D189 entry records this so nobody re-opens it.

## Invariants kept

The hash/drift verification of the written file is unchanged and the new check is **additional** — a file can be both correct and inactive. The managed file absent *and* shadowed yields one finding, not two: the absence wins, because that is what the operator must fix first. A test pins that the chain's last entry equals `provisioning.InstructionsFile(provider)`, so the two declarations cannot drift into comparing a file against itself.

`docs/agent-install.md` gains a verification step (`codex debug prompt-input`) so the runbook does not rely on `status` alone, and asks the operator to report a disagreement between the two — that would be a precedence rule not yet modelled here.

`make vet && make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)