### PR TITLE
feat(client)!: choose the KBs before the first connect writes anything (D190)

### DIFF
--- a/cmd/cartographer/connect.go
+++ b/cmd/cartographer/connect.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -25,6 +26,79 @@ type repeatedString []string
 
 func (r *repeatedString) String() string         { return strings.Join(*r, ",") }
 func (r *repeatedString) Set(value string) error { *r = append(*r, value); return nil }
+
+// splitCommaList flattens a repeatable flag that also accepts comma-separated
+// values, so --kb a --kb b and --kb a,b are the same selection. An empty
+// element is preserved rather than dropped: `--kb ""` asked for something and
+// the caller must be able to reject it, not silently receive "nothing given".
+func splitCommaList(values []string) []string {
+	var out []string
+	for _, v := range values {
+		for _, part := range strings.Split(v, ",") {
+			out = append(out, strings.TrimSpace(part))
+		}
+	}
+	return out
+}
+
+// kbSelectionAll is the sentinel that selects every mounted KB. It is recorded
+// as an explicit binding to their names, never as the implicit default: that
+// difference is what keeps a KB mounted later from widening a client that
+// already exists.
+const kbSelectionAll = "all"
+
+// resolveKBSelection turns the operator's --kb (or form) choice into the list
+// of KBs this connect may deliver, validated against what the server actually
+// mounts (D190).
+//
+// selection empty is "not chosen", which is an error with two or more KBs
+// mounted: defaulting to all of them is the over-exposure this exists to close,
+// and it is sticky, because "all known" silently grows with the server.
+func resolveKBSelection(selection, mounted []string, listed bool) ([]string, error) {
+	if len(selection) == 0 {
+		switch {
+		case !listed || len(mounted) == 0:
+			// The server did not answer, or mounts nothing: there is no
+			// catalogue to narrow and nothing to materialize either.
+			return nil, nil
+		case len(mounted) == 1:
+			return append([]string(nil), mounted...), nil
+		default:
+			return nil, fmt.Errorf("this server mounts %d KBs (%s): choose which ones this client receives with --kb <name> (repeatable, or comma-separated), or --kb all",
+				len(mounted), strings.Join(mounted, ", "))
+		}
+	}
+
+	if len(selection) == 1 && selection[0] == kbSelectionAll {
+		if !listed {
+			return nil, fmt.Errorf("--kb all needs the server's KB list, which could not be read: name the KBs explicitly")
+		}
+		return append([]string(nil), mounted...), nil
+	}
+
+	seen := map[string]bool{}
+	var out []string
+	for _, name := range selection {
+		if name == "" {
+			return nil, fmt.Errorf("--kb was given an empty name: pass a KB name, or --kb all")
+		}
+		if name == kbSelectionAll {
+			return nil, fmt.Errorf("--kb all cannot be combined with a KB name: it already means every mounted KB")
+		}
+		if listed && !slices.Contains(mounted, name) {
+			if len(mounted) == 0 {
+				return nil, fmt.Errorf("--kb %q: this server mounts no KB", name)
+			}
+			return nil, fmt.Errorf("--kb %q: this server mounts %s", name, strings.Join(mounted, ", "))
+		}
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	return out, nil
+}
 
 // probeTimeout bounds probeServer's reachability check (D64): short enough
 // that a down server fails fast in the interactive form/CLI, well under the
@@ -253,6 +327,8 @@ func cmdConnect(args []string) int {
 	fs.Var(&pinKeys, "pin-key", "Pin a KB Ed25519 public key as KB=PUBLIC_KEY (repeatable)")
 	noInput := fs.Bool("no-input", false, "Never open the interactive form, even in a TTY")
 	agentsCSV := fs.String("agents", "", "Comma-separated agent subset: claude,codex")
+	var kbSel repeatedString
+	fs.Var(&kbSel, "kb", "KB this client may receive (repeatable, or comma-separated; 'all' for every mounted KB)")
 	fs.Parse(rest)
 
 	interactive := wantsConnectForm(fs, *noInput)
@@ -296,6 +372,7 @@ func cmdConnect(args []string) int {
 		AutoTrust: *autoTrust,
 		Trust:     settings.Trust,
 		PinKeys:   pinKeys,
+		KBs:       splitCommaList(kbSel),
 	}
 
 	if interactive {
@@ -363,6 +440,26 @@ func cmdConnect(args []string) int {
 			providers = formOpts.Providers
 			opts.Providers, opts.ServerURL, opts.Name, opts.Auth, opts.TokenEnv, opts.Trust =
 				providers, formOpts.ServerURL, formOpts.Name, formOpts.Auth, formOpts.TokenEnv, formOpts.Trust
+
+			// The KB choice (D190) comes after the probe, because that is when
+			// the names exist, and before doConnect, because that is when the
+			// first artifact would be written. Only asked when there is a
+			// choice to make and the operator has not already made it.
+			if len(opts.KBs) == 0 {
+				facts, ferr := enumerateKBs(opts.ServerURL, opts.Auth, opts.TokenEnv)
+				if ferr == nil && facts.Listed && len(facts.Names) > 1 && !allProvidersBound(existingOrDefault(dir), providers) {
+					selection, ok, err := runKBSelectForm(facts.Names)
+					if err != nil {
+						fmt.Fprintln(os.Stderr, "Error:", err)
+						return 2
+					}
+					if !ok {
+						fmt.Println("cancelled")
+						return 1
+					}
+					opts.KBs = selection
+				}
+			}
 
 			res, err := doConnect(opts)
 			if err != nil {
@@ -502,6 +599,13 @@ type connectOptions struct {
 	// Trust applies to every future sync until changed again.
 	Trust   bool
 	PinKeys []string
+	// KBs is the operator's explicit KB selection for this connect (D190),
+	// from --kb or the form. Empty means "not chosen": with two or more KBs
+	// mounted and no existing binding that is an error, not a silent
+	// fall-back to all of them. The single sentinel "all" selects every
+	// mounted KB and is recorded as an explicit binding to their names, which
+	// is what stops a KB mounted later from widening this client.
+	KBs []string
 }
 
 // connectResult is the outcome of doConnect: which providers were connected, the
@@ -558,6 +662,36 @@ func doConnect(opts connectOptions) (connectResult, error) {
 	}
 	facts, healthErr := enumerateKBs(opts.ServerURL, opts.Auth, opts.TokenEnv)
 	kbs := facts.Names
+
+	// 1a. Resolve and persist the KB selection BEFORE the first MCP entry or
+	// artifact is written (D190). `client bind` can only narrow a provider
+	// after it is connected, so any ordering of the old commands delivered
+	// every skill, agent, hook, instructions block and MCP descriptor of every
+	// known KB first. The window is closed by making the choice part of
+	// connect, not by moving bind earlier.
+	selected, err := resolveConnectKBs(existing, opts, facts, healthErr)
+	if err != nil {
+		return connectResult{}, err
+	}
+	if selected != nil {
+		// In memory in every mode, including --dry-run: the projection the run
+		// reports must be the one the selection produces. The write itself is
+		// already guarded at step 3.
+		for _, provider := range opts.Providers {
+			existing.ResetBinding(provider)
+			for _, kb := range selected {
+				if err := existing.Bind(provider, kb); err != nil {
+					return connectResult{}, err
+				}
+			}
+		}
+	}
+
+	// entryKBs stays the server's full mount list: it tells entriesForKBs that
+	// the endpoint must be scoped with ?kb= at all. Which of them this provider
+	// receives comes from the binding persisted just above — passing the
+	// selection here instead would collapse a single-KB choice to the bare,
+	// unscoped entry, which reaches every KB on the server.
 	entryKBs := kbs
 	if healthErr != nil || !facts.Listed {
 		entryKBs = nil
@@ -741,4 +875,43 @@ func providersManagingMCP(providers []string) []string {
 		}
 	}
 	return out
+}
+
+// resolveConnectKBs decides which KBs this connect binds the target providers
+// to (D190).
+//
+// A provider that already carries an explicit binding is not a first connect:
+// its recorded choice stands, and a `reconnect` or a re-run never silently
+// re-opens a catalogue the operator narrowed. Only a provider with no binding
+// yet must choose, and only when there is something to choose between.
+func resolveConnectKBs(cfg *clientconfig.Config, opts connectOptions, facts serverFacts, healthErr error) ([]string, error) {
+	if len(opts.KBs) == 0 && allProvidersBound(cfg, opts.Providers) {
+		// Every target already declared its own binding: preserve it verbatim.
+		return nil, nil
+	}
+	mounted := facts.Names
+	listed := healthErr == nil && facts.Listed
+	return resolveKBSelection(opts.KBs, mounted, listed)
+}
+
+// allProvidersBound reports whether every provider already has an explicit
+// binding recorded — the difference between "these KBs" and "whatever is
+// known", which BoundKBs is the only place allowed to resolve.
+func allProvidersBound(cfg *clientconfig.Config, providers []string) bool {
+	for _, p := range providers {
+		if _, explicit := cfg.BoundKBs(p); !explicit {
+			return false
+		}
+	}
+	return true
+}
+
+// existingOrDefault loads the client config for dir, falling back to the
+// defaults when there is none yet — a first connect has no file, and that is
+// exactly the case the KB selection exists for.
+func existingOrDefault(dir string) *clientconfig.Config {
+	if c, err := clientconfig.Load(dir); err == nil {
+		return c
+	}
+	return clientconfig.Default()
 }

--- a/cmd/cartographer/kbselectform.go
+++ b/cmd/cartographer/kbselectform.go
@@ -1,0 +1,120 @@
+// kbselectform.go (D190) — the interactive KB selection shown between the
+// connect form and the first write, when the server mounts more than one KB
+// and the operator did not name any with --kb.
+//
+// It is a second step rather than a field of connectform.go because the KB
+// names are not known until the server has been probed, and the probe happens
+// after that form. Making it a step keeps the choice where the information is,
+// instead of asking the form to render a list it cannot have yet.
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type kbSelectModel struct {
+	kbs      []string
+	selected []bool
+	cursor   int
+	done     bool
+	cancel   bool
+	errMsg   string
+}
+
+func newKBSelectModel(kbs []string) kbSelectModel {
+	// Nothing is pre-selected: the whole point is that the operator states a
+	// choice, and a pre-ticked list is how "all of them" becomes the answer
+	// again by default.
+	return kbSelectModel{kbs: kbs, selected: make([]bool, len(kbs))}
+}
+
+func (m kbSelectModel) Init() tea.Cmd { return nil }
+
+func (m kbSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+	switch key.String() {
+	case "ctrl+c", "esc":
+		m.cancel = true
+		return m, tea.Quit
+	case "up", "k":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case "down", "j":
+		if m.cursor < len(m.kbs)-1 {
+			m.cursor++
+		}
+	case " ", "x":
+		m.selected[m.cursor] = !m.selected[m.cursor]
+		m.errMsg = ""
+	case "a":
+		// Selecting every KB is a legitimate answer — it is the difference
+		// between an explicit binding to these names and the old implicit
+		// "whatever is known", which silently widened as the server grew.
+		for i := range m.selected {
+			m.selected[i] = true
+		}
+		m.errMsg = ""
+	case "enter":
+		if len(m.chosen()) == 0 {
+			m.errMsg = "select at least one KB (space to toggle, a for all, esc to cancel)"
+			return m, nil
+		}
+		m.done = true
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m kbSelectModel) chosen() []string {
+	var out []string
+	for i, ok := range m.selected {
+		if ok {
+			out = append(out, m.kbs[i])
+		}
+	}
+	return out
+}
+
+func (m kbSelectModel) View() string {
+	var b strings.Builder
+	b.WriteString("Which Knowledge Bases should this client receive?\n")
+	b.WriteString("Only the ones you pick are delivered — skills, subagents, hooks and instructions included.\n\n")
+	for i, kb := range m.kbs {
+		cursor := "  "
+		if i == m.cursor {
+			cursor = "> "
+		}
+		mark := " "
+		if m.selected[i] {
+			mark = "x"
+		}
+		fmt.Fprintf(&b, "%s[%s] %s\n", cursor, mark, kb)
+	}
+	if m.errMsg != "" {
+		fmt.Fprintf(&b, "\n%s\n", m.errMsg)
+	}
+	b.WriteString("\n↑/↓ move · space toggle · a all · enter confirm · esc cancel\n")
+	return b.String()
+}
+
+// runKBSelectForm asks which of kbs this client may receive. ok is false when
+// the operator cancelled, which the caller treats as "do not connect": writing
+// a projection nobody chose is the thing this step exists to prevent.
+func runKBSelectForm(kbs []string) (selection []string, ok bool, err error) {
+	result, err := tea.NewProgram(newKBSelectModel(kbs)).Run()
+	if err != nil {
+		return nil, false, err
+	}
+	m, _ := result.(kbSelectModel)
+	if m.cancel || !m.done {
+		return nil, false, nil
+	}
+	return m.chosen(), true, nil
+}

--- a/cmd/cartographer/multikb_test.go
+++ b/cmd/cartographer/multikb_test.go
@@ -65,7 +65,9 @@ func TestDoConnect_PerKBEntries_AllProviders(t *testing.T) {
 	defer srv.Close()
 	dir := t.TempDir()
 	providers := []string{"claude", "codex", "kiro", "opencode"}
-	res, err := doConnect(connectOptions{Providers: providers, Dir: dir, ServerURL: srv.URL + "/mcp", Name: "cartographer", TokenEnv: "TOKEN", Trust: true})
+	// D190: a first multi-KB connect must name its KBs; "all" is the explicit
+	// way to say "every mounted one", which is what this case is about.
+	res, err := doConnect(connectOptions{Providers: providers, Dir: dir, ServerURL: srv.URL + "/mcp", Name: "cartographer", TokenEnv: "TOKEN", Trust: true, KBs: []string{"all"}})
 	if err != nil {
 		t.Fatalf("doConnect: %v", err)
 	}
@@ -167,7 +169,7 @@ func TestDoConnect_Kiro_MultiKB_WarnsFlatNamespace(t *testing.T) {
 	srv := multiKBServer(t, `{"status":"ok","kbs":[{"name":"alpha"},{"name":"beta"}]}`)
 	defer srv.Close()
 	dir := t.TempDir()
-	res, err := doConnect(connectOptions{Providers: []string{"kiro"}, Dir: dir, ServerURL: srv.URL + "/mcp", Name: "cartographer", TokenEnv: "TOKEN", Trust: true})
+	res, err := doConnect(connectOptions{Providers: []string{"kiro"}, Dir: dir, ServerURL: srv.URL + "/mcp", Name: "cartographer", TokenEnv: "TOKEN", Trust: true, KBs: []string{"all"}})
 	if err != nil {
 		t.Fatalf("doConnect: %v", err)
 	}
@@ -590,5 +592,194 @@ func TestManagedEntryNamesCoversEveryKnownKB(t *testing.T) {
 		if !found {
 			t.Errorf("managedEntryNames missing %q: %v", want, names)
 		}
+	}
+}
+
+// --- least-privilege first connect (D190) ---
+
+func TestResolveKBSelection(t *testing.T) {
+	mounted := []string{"alpha", "beta", "gamma"}
+	for _, tc := range []struct {
+		name      string
+		selection []string
+		mounted   []string
+		listed    bool
+		want      []string
+		wantErr   string
+	}{
+		{name: "one KB needs no choice", mounted: []string{"alpha"}, listed: true, want: []string{"alpha"}},
+		{name: "several KBs and no choice is an error", mounted: mounted, listed: true,
+			wantErr: "choose which ones this client receives"},
+		{name: "all is explicit and expands to the mounted names", selection: []string{"all"},
+			mounted: mounted, listed: true, want: mounted},
+		{name: "named KBs", selection: []string{"alpha", "gamma"}, mounted: mounted, listed: true,
+			want: []string{"alpha", "gamma"}},
+		{name: "duplicates collapse", selection: []string{"alpha", "alpha"}, mounted: mounted, listed: true,
+			want: []string{"alpha"}},
+		{name: "unknown KB names the mounted ones", selection: []string{"delta"}, mounted: mounted, listed: true,
+			wantErr: "this server mounts alpha, beta, gamma"},
+		{name: "empty value is an error, not none", selection: []string{""}, mounted: mounted, listed: true,
+			wantErr: "empty name"},
+		{name: "all cannot be combined", selection: []string{"all", "alpha"}, mounted: mounted, listed: true,
+			wantErr: "cannot be combined"},
+		{name: "all needs a KB list", selection: []string{"all"}, mounted: nil, listed: false,
+			wantErr: "could not be read"},
+		{name: "unreachable server with no selection is not an error", mounted: nil, listed: false},
+		{name: "an unlisted server does not validate names", selection: []string{"alpha"}, listed: false,
+			want: []string{"alpha"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveKBSelection(tc.selection, tc.mounted, tc.listed)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected an error containing %q, got %v", tc.wantErr, got)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error = %v; want it to contain %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if strings.Join(got, ",") != strings.Join(tc.want, ",") {
+				t.Errorf("selection = %v; want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// The core guarantee: no ordering of commands can materialize an artifact from
+// a KB the operator did not name. A scripted first connect against a multi-KB
+// server fails, and writes nothing at all.
+func TestDoConnect_MultiKB_WithoutSelection_FailsAndWritesNothing(t *testing.T) {
+	srv := multiKBServer(t, `{"status":"ok","kbs":[{"name":"alpha"},{"name":"beta"},{"name":"gamma"}]}`)
+	defer srv.Close()
+	dir := t.TempDir()
+
+	_, err := doConnect(connectOptions{Providers: []string{"claude"}, Dir: dir, ServerURL: srv.URL + "/mcp", Name: "cartographer", TokenEnv: "TOKEN", Trust: true})
+	if err == nil {
+		t.Fatal("a first multi-KB connect with no --kb must fail")
+	}
+	for _, want := range []string{"alpha", "beta", "gamma", "--kb"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error must name %q: %v", want, err)
+		}
+	}
+
+	entries, rerr := os.ReadDir(dir)
+	if rerr != nil {
+		t.Fatalf("read dir: %v", rerr)
+	}
+	if len(entries) != 0 {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("nothing may be written before the choice is made, found: %v", names)
+	}
+}
+
+func TestDoConnect_KBSelection_BindsOnlyWhatWasNamed(t *testing.T) {
+	srv := multiKBServer(t, `{"status":"ok","kbs":[{"name":"alpha"},{"name":"beta"},{"name":"gamma"}]}`)
+	defer srv.Close()
+	dir := t.TempDir()
+
+	res, err := doConnect(connectOptions{Providers: []string{"claude"}, Dir: dir, ServerURL: srv.URL + "/mcp", Name: "cartographer", TokenEnv: "TOKEN", Trust: true, KBs: []string{"beta"}})
+	if err != nil {
+		t.Fatalf("doConnect: %v", err)
+	}
+	if got, want := strings.Join(res.MCPEntries, ","), "cartographer-beta"; got != want {
+		t.Errorf("MCPEntries = %q, want %q", got, want)
+	}
+
+	cfg, err := clientconfig.Load(dir)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	bound, explicit := cfg.BoundKBs("claude")
+	if !explicit {
+		t.Fatal("the binding must be explicit, not the implicit 'all known' default")
+	}
+	if strings.Join(bound, ",") != "beta" {
+		t.Errorf("bound = %v; want [beta]", bound)
+	}
+}
+
+// --kb all records the names, not the implicit default: that is what stops a
+// KB mounted later from widening a client that already exists.
+func TestDoConnect_KBSelectionAll_IsExplicit(t *testing.T) {
+	srv := multiKBServer(t, `{"status":"ok","kbs":[{"name":"alpha"},{"name":"beta"}]}`)
+	defer srv.Close()
+	dir := t.TempDir()
+
+	if _, err := doConnect(connectOptions{Providers: []string{"claude"}, Dir: dir, ServerURL: srv.URL + "/mcp", Name: "cartographer", TokenEnv: "TOKEN", Trust: true, KBs: []string{"all"}}); err != nil {
+		t.Fatalf("doConnect: %v", err)
+	}
+	cfg, err := clientconfig.Load(dir)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	bound, explicit := cfg.BoundKBs("claude")
+	if !explicit || strings.Join(bound, ",") != "alpha,beta" {
+		t.Errorf("bound = %v (explicit=%v); want an explicit [alpha beta]", bound, explicit)
+	}
+}
+
+// A single-KB server needs no flag: there is nothing to choose.
+func TestDoConnect_SingleKB_NeedsNoSelection(t *testing.T) {
+	srv := multiKBServer(t, `{"status":"ok","kbs":[{"name":"alpha"}]}`)
+	defer srv.Close()
+	dir := t.TempDir()
+
+	if _, err := doConnect(connectOptions{Providers: []string{"claude"}, Dir: dir, ServerURL: srv.URL + "/mcp", Name: "cartographer", TokenEnv: "TOKEN", Trust: true}); err != nil {
+		t.Fatalf("doConnect on a single-KB server: %v", err)
+	}
+	cfg, err := clientconfig.Load(dir)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if bound, explicit := cfg.BoundKBs("claude"); !explicit || strings.Join(bound, ",") != "alpha" {
+		t.Errorf("bound = %v (explicit=%v); want an explicit [alpha]", bound, explicit)
+	}
+}
+
+// An already-bound provider is not a first connect: its recorded choice stands
+// and a re-run never re-opens a catalogue the operator narrowed.
+func TestDoConnect_ExistingBinding_IsPreserved(t *testing.T) {
+	srv := multiKBServer(t, `{"status":"ok","kbs":[{"name":"alpha"},{"name":"beta"},{"name":"gamma"}]}`)
+	defer srv.Close()
+	dir := t.TempDir()
+
+	if _, err := doConnect(connectOptions{Providers: []string{"claude"}, Dir: dir, ServerURL: srv.URL + "/mcp", Name: "cartographer", TokenEnv: "TOKEN", Trust: true, KBs: []string{"beta"}}); err != nil {
+		t.Fatalf("first doConnect: %v", err)
+	}
+	// The same command again, with no --kb: it must neither fail nor widen.
+	if _, err := doConnect(connectOptions{Providers: []string{"claude"}, Dir: dir, ServerURL: srv.URL + "/mcp", Name: "cartographer", TokenEnv: "TOKEN", Trust: true}); err != nil {
+		t.Fatalf("second doConnect: %v", err)
+	}
+	cfg, err := clientconfig.Load(dir)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if bound, _ := cfg.BoundKBs("claude"); strings.Join(bound, ",") != "beta" {
+		t.Errorf("bound = %v; want it unchanged at [beta]", bound)
+	}
+}
+
+func TestDoConnect_UnknownKB_FailsBeforeAnyWrite(t *testing.T) {
+	srv := multiKBServer(t, `{"status":"ok","kbs":[{"name":"alpha"},{"name":"beta"}]}`)
+	defer srv.Close()
+	dir := t.TempDir()
+
+	if _, err := doConnect(connectOptions{Providers: []string{"claude"}, Dir: dir, ServerURL: srv.URL + "/mcp", Name: "cartographer", TokenEnv: "TOKEN", Trust: true, KBs: []string{"delta"}}); err == nil {
+		t.Fatal("an unmounted KB name must fail")
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("a rejected selection must write nothing, found %d entries", len(entries))
 	}
 }

--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -93,7 +93,21 @@ cartographer connect --agents codex
 ```
 
 Expected output: the generated MCP configuration paths and a reminder to restart the agent session.
-With two or more mounted KBs, Cartographer automatically creates one MCP entry per KB.
+With two or more mounted KBs, Cartographer creates one MCP entry per KB the client is bound to.
+
+**Ask which KBs this client should receive.** On a first connect against a server mounting two or
+more KBs, `connect` requires the choice — it will not deliver all of them by default (D190), because
+everything a KB carries (skills, subagents, hooks, instructions, MCP descriptors) is delivered with
+it:
+
+```bash
+cartographer connect --agents codex --kb <name>          # repeatable, or comma-separated
+cartographer connect --agents codex --kb all             # every mounted KB, recorded explicitly
+```
+
+In an interactive terminal the same choice is offered as a list after the connect form. Prefer the
+narrowest selection that does the job, and verify the result with `cartographer status`: the bound
+KBs are printed per provider, with `explicit` next to them.
 
 ## 5. Verify the installation
 

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -96,6 +96,7 @@ cartographer connect all --auto-trust --dry-run
 |------|---------|-------------|
 | (positional) | `all` | `claude` \| `opencode` \| `codex` \| `kiro` \| `hermes` \| `antigravity` \| `all` (all detected agents) |
 | `--agents` | *(unset)* | Comma-separated subset (`claude,codex`); cannot be combined with the positional provider |
+| `--kb` | *(unset)* | Which KBs this client may receive (repeatable, or comma-separated; `all` for every mounted KB). Required on a **first** connect against a server mounting two or more KBs — see below (D190) |
 | `--server-url` | `http://localhost:39273/mcp` | Cartographer server URL |
 | `--auth` | `false` | Enables the Bearer header in generated configs |
 | `--token-env` | `CARTOGRAPHER_TOKENS` | Env var holding the Bearer token |

--- a/docs/decisions/client-configurator.md
+++ b/docs/decisions/client-configurator.md
@@ -943,3 +943,65 @@ applies to the new finding like any other.
 the point. `docs/agent-install.md` gains a verification step (`codex debug prompt-input`) so the
 runbook does not rely on `status` alone for this, and an instruction to report a case where the two
 disagree: that would be a provider precedence rule not yet modelled here.
+
+
+## D190 — The KBs are chosen before the first write, not narrowed after it
+
+**Status: implemented.** Closes #244.
+
+**Context.** A first `connect` against a multi-KB server had an over-exposure window that no
+ordering of the existing commands could avoid:
+
+1. a fresh `.cartographer.yaml` carries no explicit per-provider binding, so `BoundKBs` resolves to
+   "every known KB";
+2. `doConnect` enumerated the mounted KBs, wrote the MCP entries and materialized every artifact of
+   that default projection;
+3. `cartographer client bind` refuses a provider that is not connected yet — correctly, since a
+   binding nobody reads would be meaningless.
+
+So the operator could only narrow a provider **after** the first `connect`, which is after every
+skill, agent, hook, instructions block and MCP descriptor of every known KB had already been
+delivered. On the machine that produced this audit, that is how a DANTE-specific skill reached a
+HomeLab-only client. [D169](#d169)/[D170](#d170)'s binding fixes the steady state, not the first
+write.
+
+The default was also **sticky**: "all known" includes KBs mounted later, so a projection chosen
+implicitly on day one silently widened as the server grew.
+
+**Decision.**
+
+- **The selection is part of `connect`, and it is applied before anything is written.** `--kb`
+  (repeatable or comma-separated) is resolved and validated immediately after the KB enumeration and
+  persisted into the provider bindings **before** the MCP entries and before materialization. The
+  window is closed by moving the choice, not by moving `bind` earlier.
+- **A *new* multi-KB connect fails rather than defaults.** With two or more KBs mounted, no `--kb`
+  and no provider already bound, `connect` errors naming the mounted KBs and the flag, and writes
+  **nothing** — a test asserts the target directory is untouched. A single-KB server keeps working
+  with no flag: there is nothing to choose.
+- **A provider that already carries an explicit binding is not a first connect.** Its recorded
+  choice stands and a re-run or a `reconnect` never re-opens a catalogue the operator narrowed. This
+  is also what keeps existing installations working unchanged: nobody is migrated, and no existing
+  binding changes meaning on upgrade.
+- **`--kb all` is a real, recordable value.** It is persisted as an explicit binding to the
+  currently mounted names, not as the implicit default. That difference is the whole point: a KB
+  mounted tomorrow does not widen a client that already exists.
+- **The selection is validated against what the server mounts, before any write.** A typo is an
+  error naming the available KBs, not an empty projection. `--kb ""` is an error rather than
+  "none", and `--kb all` cannot be combined with a name.
+- **The interactive choice is a step after the probe, not a field of the connect form.** The KB
+  names do not exist until the server has been probed, and the probe runs after that form. A
+  separate selection step keeps the choice where the information is; nothing is pre-selected,
+  because a pre-ticked list is how "all of them" quietly becomes the answer again.
+- **`--dry-run` applies the binding in memory** so the projection it reports is the one the
+  selection would produce. Only the write is skipped.
+
+**Invariants kept.** `requireConnected` still refuses bindings for unconnected providers — this
+removes the *need* to call `bind` after `connect`, it does not weaken `bind`. The bootstrap hook
+stays independent of the server manifest. Stale MCP entries are still removed before the new ones
+are written. The MCP entry naming still keys off the server's **full** mount list, not the
+selection: collapsing a single-KB choice to the bare, unscoped entry would have produced a client
+that reaches every KB on the server — the opposite of the intent, and caught by a test.
+
+**Consequences.** A scripted first `connect` against a multi-KB server now requires `--kb`;
+that is breaking for automation and belongs in the release notes. No ordering of commands can
+produce a materialized artifact from a KB the operator did not name.

--- a/test/e2e/scenarios/16_prefixed_multikb.sh
+++ b/test/e2e/scenarios/16_prefixed_multikb.sh
@@ -101,7 +101,10 @@ fi
 echo ""
 echo "--- Phase 3: client connect writes one entry per KB ---"
 
-(cd "$SANDBOX" && HOME="$SANDBOX" "$BIN" connect opencode --server-url "$SERVER_URL" --auto-trust) >"${DIR}/connect.log" 2>&1 || true
+# --kb all: this scenario is about a client that receives both KBs, and since
+# D190 a first connect against a multi-KB server must say so explicitly rather
+# than defaulting to every mounted KB.
+(cd "$SANDBOX" && HOME="$SANDBOX" "$BIN" connect opencode --server-url "$SERVER_URL" --kb all --auto-trust) >"${DIR}/connect.log" 2>&1 || true
 
 OPENCODE_CFG="${SANDBOX}/.config/opencode/opencode.json"
 if [[ ! -f "$OPENCODE_CFG" ]]; then


### PR DESCRIPTION
Closes #244

## The window

A first `connect` against a multi-KB server had an over-exposure window that **no ordering of the existing commands could avoid**:

1. a fresh `.cartographer.yaml` carries no explicit binding, so `BoundKBs` resolves to "every known KB";
2. `doConnect` enumerated the mounted KBs, wrote the MCP entries, and materialized every artifact of that default projection;
3. `cartographer client bind` refuses a provider that is not connected yet — correctly, since a binding nobody reads would be meaningless.

So the operator could only narrow a provider *after* every skill, subagent, hook, instructions block and MCP descriptor of every known KB had already been delivered. On the machine that produced the audit, that is how a DANTE-specific skill reached a HomeLab-only client. D169/D170's binding fixes the steady state, not the first write.

The default was also **sticky**: "all known" includes KBs mounted later, so a projection chosen implicitly on day one silently widened as the server grew.

## What changed

- **`--kb`** (repeatable or comma-separated) is resolved and validated immediately after the KB enumeration and persisted into the bindings **before** the MCP entries and before materialization.
- **A new multi-KB connect fails rather than defaults**: with 2+ KBs, no `--kb`, and no provider already bound, `connect` errors naming the mounted KBs and the flag, and writes **nothing** — a test asserts the target directory is untouched.
- **An already-bound provider is not a first connect.** Its recorded choice stands, so re-runs and `reconnect` never re-open a narrowed catalogue — and nobody is migrated on upgrade.
- **`--kb all` is explicit**, recorded as a binding to the mounted names rather than as the implicit default. That difference is the whole point.
- **Interactively**, the choice is a step *after* the probe — the KB names do not exist until the server has been probed, and the probe runs after the connect form. Nothing is pre-selected, because a pre-ticked list is how "all of them" quietly becomes the answer again.
- **`--dry-run`** applies the binding in memory so the projection it reports is the one the selection would produce.

## A bug the tests caught

My first version passed the *selection* as `entriesForKBs`' `mounted` argument. With one KB chosen that hits the `len(mounted) <= 1` branch and emits the bare, unscoped `cartographer` entry — a client that reaches **every** KB on the server, the exact opposite of the intent. `mounted` stays the server's full list (it is what says the endpoint must be scoped with `?kb=` at all) and the binding does the selecting. There is now a comment at that line saying why.

## Breaking change

A scripted first `connect` against a server mounting two or more KBs now requires `--kb`. Two existing multi-KB tests were updated to pass `--kb all`, which is the correct migration and documents the change.

`make vet && make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)