### PR TITLE
feat(skill)!: one validator for the MCP channel and the git one (D191)

### DIFF
--- a/cmd/cartographer/serve.go
+++ b/cmd/cartographer/serve.go
@@ -356,8 +356,9 @@ func runServe(cfg *config.Config) {
 			log.Printf("KB %q provisioning artifact signing enabled (key ID %s)", name, artifactsig.KeyID(artifactSigner.Public().(ed25519.PublicKey)))
 		}
 		if _, scanErr := provisioning.BuildManifest(nil, map[string]string{name: k.Root}, provisioning.BuildOptions{
-			MCPAllowlists: map[string][]provisioning.MCPAllowlistEntry{name: m.Spec.MCPAllowlist},
-			MCPDiagnostic: func(message string) { log.Printf("warning: %s", message) },
+			MCPAllowlists:   map[string][]provisioning.MCPAllowlistEntry{name: m.Spec.MCPAllowlist},
+			MCPDiagnostic:   func(message string) { log.Printf("warning: %s", message) },
+			SkillDiagnostic: func(message string) { log.Printf("warning: %s", message) },
 		}); scanErr != nil {
 			log.Printf("warning: KB %q MCP descriptor scan: %v", name, scanErr)
 		}

--- a/docs/decisions/skills-services-secrets.md
+++ b/docs/decisions/skills-services-secrets.md
@@ -121,3 +121,67 @@ case-insensitive match is strictly additive: KBs that worked keep working, KBs t
 returned nothing start working. The regression test asserts the **absence** of the plaintext
 rather than only the presence of the placeholder, so a future change that reintroduces the
 leak fails the build.
+
+
+## D191 — One skill validator, for the MCP channel and the git one
+
+**Status: implemented.** Closes #245.
+
+**Context.** A skill written through MCP and the same skill arriving through git were validated by
+two different rules, and the git channel was the weaker one. A malformed artifact it accepted broke
+the sync of the **whole KB** later, far from its cause.
+
+Two gaps.
+
+**The shared validator was too thin.** `skill.Validate` checked only a non-empty name, a non-empty
+description, and a body over 500 lines as a warning. It did not check kebab-case, a maximum name
+length, or that the frontmatter `name` matched the directory. The clients do impose those rules —
+Kiro and OpenCode document lowercase kebab-case, 64 characters maximum, equal to the directory, and
+OpenCode additionally rejects consecutive `--`. A skill that passed our validation and was refused
+by the client was a silent no-op in the agent's catalogue, invisible from here.
+
+**The two channels did not run the same check.** `artifact_write` called `validateSkillArtifact`,
+which required `name` to equal the directory. `BuildManifest` — which serves the git channel and is
+declared equivalent — called `skill.LoadAllSkills` and **discarded the error slice**
+(`kbSkills, _ :=`), never invoking `Validate` at all. With directory `skills/foo/` and frontmatter
+`name: bar`, the manifest registered the artifact as `bar` but hashed the directory `foo`;
+`ReadArtifactFiles` then looked for `skills/bar`, the read failed, and it could take `sync_pull`
+down for the entire KB. A hand-edited or git-imported skill broke every client of that KB, while
+identical content would have been refused outright over MCP.
+
+**Decision.**
+
+- **One validator, called from both channels.** `skill.Validate` is the single authority.
+  `validateSkillArtifact` delegates to it and keeps only the MCP-specific part (the path shape of
+  the incoming write); `BuildManifest` calls it too.
+- **The rule set is the intersection of what the clients accept**, not the most permissive union:
+  lowercase `[a-z0-9]` segments separated by single `-`, no leading/trailing `-`, no `--`, at most
+  64 characters, and frontmatter `name` equal to the directory. Adopting the strictest client rule
+  is the point — the failure being fixed is a client silently ignoring a skill.
+- **Severity split.** A name/directory mismatch, an invalid or over-long name and an empty
+  description are **errors**: they break a channel or a client. Body length and description length
+  stay **warnings** — they degrade quality without breaking anything, and turning an existing KB's
+  long descriptions into hard failures would block syncs that work today.
+- **`BuildManifest` reports, it does not silently skip.** An invalid skill is excluded from the
+  manifest and the reason is surfaced with the KB, the skill and the violated rule named — through
+  a `SkillDiagnostic` callback (the same shape `MCPDiagnostic` already had, wired to the server's
+  startup log) and on `Manifest.Issues` for a programmatic caller. The errors `LoadAllSkills`
+  returns are surfaced the same way instead of being discarded.
+- **`Issue` carries the rule it violated**, so a caller attributes a refusal without parsing a
+  message.
+- **The `<namespace>--<skill-name>` convention is dropped.** It was unreachable from production
+  code and incompatible with the `--` rule above. The comment, the `TestNamespaceExtraction` test
+  exercising a local `strings.SplitN` with no production caller, and the E2E fixture
+  `kbinfra--query-rete` (now `query-rete`) are all retired. Namespacing, if it is ever needed again,
+  comes back as a separate decision rather than as a dormant string convention.
+
+**Invariants kept.** A KB with one invalid skill still syncs its valid artifacts — the failure is
+scoped to the offending skill, the opposite of the whole-KB `sync_pull` breakage it replaces.
+`LoadSkill` keeps its signature and parsing. `Manifest.Issues` is deliberately **not** part of the
+revision: excluding an artifact already changes it, and hashing the message list would make an
+edit to the wording look like a catalogue change.
+
+**Consequences.** Skills that pass today can be refused after this change — breaking for KBs whose
+skill names are non-conforming, and the release notes must name the rules. `docs/sync.md` and this
+page also stop contradicting each other on `signed`: the signature and the trust policy are now
+described as the two distinct things they are.

--- a/docs/skills-services-secrets.md
+++ b/docs/skills-services-secrets.md
@@ -10,6 +10,35 @@ the Agent Skills frontmatter (`name` and `description`) and exposes installed
 and binary-bundled skills through `skill_list`. `skill_install` copies a
 bundled skill into the KB.
 
+**Naming rules** (D191). One validator answers for both channels — a write over
+`artifact_write` and a skill that arrived through git are held to the same rules,
+because a skill only one of them accepts breaks the other later:
+
+| Rule | Severity |
+|---|---|
+| `name` is required | error |
+| `name` matches `[a-z0-9]` segments joined by single `-` — no uppercase, no `_`, no leading/trailing `-`, no `--` | error |
+| `name` is at most 64 characters | error |
+| `name` equals the directory name | error |
+| `description` is required | error |
+| `description` is at most 1024 characters | warning |
+| body is at most 500 lines | warning |
+
+The rule set is the **intersection of what the supported clients accept**, not
+the most permissive union: a skill Cartographer accepts and a client silently
+ignores is a no-op in the agent's catalogue, and that failure is invisible from
+here. The name/directory equality is the one with teeth — the manifest registers
+the artifact under the frontmatter name but hashes and reads the directory, so a
+mismatch sends the read to a path that does not exist.
+
+An error excludes that skill from the manifest and nothing else: the KB's other
+artifacts still sync, and the reason is reported with the KB, the skill and the
+rule named. Warnings never exclude anything.
+
+The historical `<namespace>--<skill-name>` directory convention is **retired**
+(D191): it was unreachable from production code and incompatible with the `--`
+rule above.
+
 Skills may include executable `scripts/` files and binary `assets/`; provisioning
 preserves each source file's executable bit and transports auxiliary files as raw bytes.
 
@@ -23,13 +52,17 @@ Editing that copy is **not** a supported channel: the next sync replaces it. The
 channels are `artifact_write` on the owning KB (or a git push to the KB repo) — the block
 states which, with the exact path.
 
-Skills and hooks can execute with the agent's privileges. The current `signed`
-manifest field is a trust-policy result, not a cryptographic signature:
+Skills and hooks can execute with the agent's privileges. Two distinct things
+decide whether one is materialized, and they are not the same:
 
-- bundled artifacts are trusted;
-- KB artifacts require the user's persisted trust choice or an explicit
-  one-shot override;
-- Cartographer does not verify signed commits or Sigstore attestations.
+- **Signature.** Artifacts from a KB with a configured signing key carry an
+  Ed25519 signature, verified client-side against the pinned public key
+  (`VerifiedManifest`, local key pins) — see [sync](sync.md) for the trust chain.
+  Cartographer does **not** verify signed git commits or Sigstore attestations;
+  the signature covers the artifact's identity and content hash.
+- **Trust policy**, which the `signed` manifest field feeds into: bundled
+  artifacts are trusted by construction, and KB artifacts require the user's
+  persisted trust choice or an explicit one-shot override.
 
 Keep executable content reviewable, pin external dependencies inside the skill
 where appropriate and never store plaintext credentials in skill files.

--- a/internal/mcpserver/tools_artifact.go
+++ b/internal/mcpserver/tools_artifact.go
@@ -40,7 +40,7 @@ const artifactMaxPathLen = 400
 
 // artifactSlugPattern matches lowercase-hyphenated artifact names (D71: "slug
 // minuscolo-trattinato"), including the "--" namespace separator used by
-// KB skills (e.g. "kbinfra--query-rete", see internal/skill doc comment).
+// KB skills (e.g. "query-rete", see internal/skill doc comment).
 var artifactSlugPattern = regexp.MustCompile(`^[a-z0-9]+(-{1,2}[a-z0-9]+)*$`)
 
 // artifactManifestKBKey is the placeholder KB name passed to
@@ -770,13 +770,13 @@ func validateSkillArtifact(slug string, data []byte) error {
 			}
 		}
 	}
-	if s.Name != slug {
-		return fmt.Errorf("SKILL.md frontmatter name %q must match the directory name %q", s.Name, slug)
-	}
-	for _, issue := range skill.Validate(s) {
-		if !issue.Warning {
-			return fmt.Errorf("%s", issue.Message)
-		}
+	// skill.Validate is the single authority (D191): the name rules, the
+	// name/directory equality and the description requirement all live there,
+	// so this channel and the git one cannot drift apart. What stays here is
+	// the MCP-specific part — the path shape of the incoming write, already
+	// checked by the caller, which is where `slug` comes from.
+	if err := skill.FirstError(skill.Validate(s)); err != nil {
+		return fmt.Errorf("%s", err.Message)
 	}
 	return nil
 }

--- a/internal/mcpserver/tools_artifact_test.go
+++ b/internal/mcpserver/tools_artifact_test.go
@@ -291,7 +291,7 @@ func TestClassifyArtifactPath(t *testing.T) {
 		wantNm  string
 	}{
 		{"skills/my-skill/SKILL.md", true, "skill", "my-skill"},
-		{"skills/kbinfra--query-rete/SKILL.md", true, "skill", "kbinfra--query-rete"},
+		{"skills/query-rete/SKILL.md", true, "skill", "query-rete"},
 		{"skills/my-skill/scripts/run.sh", true, "skill", "my-skill"},
 		{"agents/my-agent.md", true, "agent", "my-agent"},
 		{"hooks/my-hook/hook.json", true, "hook", "my-hook"},

--- a/internal/provisioning/provisioning.go
+++ b/internal/provisioning/provisioning.go
@@ -68,6 +68,11 @@ type BuildOptions struct {
 	// MCPDiagnostic receives non-fatal denied/stale allow-list diagnostics.
 	// It never contains descriptor headers or environment references.
 	MCPDiagnostic func(string)
+	// SkillDiagnostic receives one message per skill excluded from the
+	// manifest because it failed validation (D191). Excluding it is what keeps
+	// the rest of the KB syncing; saying so is what keeps the exclusion from
+	// being silent.
+	SkillDiagnostic func(string)
 }
 
 // ArtifactFile is a single file of an Artifact, with content in memory.
@@ -85,6 +90,12 @@ type Manifest struct {
 	Revision    string     `json:"revision"`
 	GeneratedAt string     `json:"generated_at,omitempty"`
 	Artifacts   []Artifact `json:"artifacts"`
+	// Issues carries the attributed reasons artifacts were left out of this
+	// manifest (D191) — named KB, named artifact, named rule. It is not part of
+	// the revision: excluding an artifact already changes that, and an issue
+	// list that fed the hash would make a message edit look like a catalogue
+	// change.
+	Issues []string `json:"issues,omitempty"`
 }
 
 // ManagedFile records a single file materialized by provisioning in the client's base-dir.
@@ -406,6 +417,7 @@ func contentHashDirOS(dirPath, kind string) (string, error) {
 // forged Ed25519 signature.
 func BuildManifest(bundleFS fs.FS, kbRoots map[string]string, opts BuildOptions) (Manifest, error) {
 	var artifacts []Artifact
+	var issues []string
 
 	// 1. Skill dal bundle.
 	if bundleFS != nil {
@@ -455,8 +467,31 @@ func BuildManifest(bundleFS fs.FS, kbRoots map[string]string, opts BuildOptions)
 		// 2. Skill (skills/<name>/SKILL.md, several files per artifact). A KB with
 		// no skills/ folder or an unreadable directory: kbSkills is empty,
 		// silent skip (no fatal error).
-		kbSkills, _ := skill.LoadAllSkills(kbRoot)
+		kbSkills, loadErrs := skill.LoadAllSkills(kbRoot)
+		for _, loadErr := range loadErrs {
+			// Previously discarded. An unreadable SKILL.md is not fatal — the
+			// rest of the KB must still sync — but it must not be invisible
+			// either (D191).
+			issue := fmt.Sprintf("KB %q: skill not loaded: %v", kbName, loadErr)
+			issues = append(issues, issue)
+			if opts.SkillDiagnostic != nil {
+				opts.SkillDiagnostic(issue)
+			}
+		}
 		for _, s := range kbSkills {
+			// One validator for both channels (D191). An error-severity issue
+			// excludes this skill from the manifest and nothing else: a KB with
+			// one malformed skill still syncs its valid artifacts, where before
+			// the mismatch reached ReadArtifactFiles and could take sync_pull
+			// down for the whole KB.
+			if bad := skill.FirstError(skill.Validate(&s)); bad != nil {
+				issue := fmt.Sprintf("KB %q: skill %q excluded (%s): %s", kbName, s.DirPath, bad.Rule, bad.Message)
+				issues = append(issues, issue)
+				if opts.SkillDiagnostic != nil {
+					opts.SkillDiagnostic(issue)
+				}
+				continue
+			}
 			skillDir := filepath.Join(kbRoot, s.DirPath)
 			hash, err := contentHashDirOS(skillDir, "skill")
 			if err != nil {
@@ -606,7 +641,9 @@ func BuildManifest(bundleFS fs.FS, kbRoots map[string]string, opts BuildOptions)
 		}
 		a.Signature = sig
 	}
-	return MergeArtifacts(artifacts), nil
+	m := MergeArtifacts(artifacts)
+	m.Issues = issues
+	return m, nil
 }
 
 // contentHashBytes computes a deterministic sha256 hex of raw data, with no

--- a/internal/provisioning/provisioning_test.go
+++ b/internal/provisioning/provisioning_test.go
@@ -1579,3 +1579,94 @@ func TestManagedFileRecordsSource(t *testing.T) {
 		}
 	}
 }
+
+// --- one validator for both channels (D191) ---
+
+// writeSkill materializes skills/<dir>/SKILL.md under kbRoot with the given
+// frontmatter name.
+func writeSkill(t *testing.T, kbRoot, dir, name string) {
+	t.Helper()
+	path := filepath.Join(kbRoot, "skills", dir)
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "---\nname: " + name + "\ndescription: A skill.\n---\nBody.\n"
+	if err := os.WriteFile(filepath.Join(path, "SKILL.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The concrete failure D191 fixes: skills/foo with `name: bar` used to reach
+// the manifest registered as "bar" but hashed from "foo", so ReadArtifactFiles
+// looked for skills/bar and could take sync_pull down for the entire KB. Now it
+// is excluded, named, and the KB's other skills still ship.
+func TestBuildManifest_InvalidSkillExcludedAndAttributed(t *testing.T) {
+	kbRoot := t.TempDir()
+	writeSkill(t, kbRoot, "foo", "bar")
+	writeSkill(t, kbRoot, "good-one", "good-one")
+	writeSkill(t, kbRoot, "good-two", "good-two")
+
+	var diagnostics []string
+	m, err := provisioning.BuildManifest(nil, map[string]string{"wiki": kbRoot}, provisioning.BuildOptions{
+		SkillDiagnostic: func(msg string) { diagnostics = append(diagnostics, msg) },
+	})
+	if err != nil {
+		t.Fatalf("one invalid skill must not fail the whole KB: %v", err)
+	}
+
+	var names []string
+	for _, a := range m.Artifacts {
+		if a.Kind == "skill" {
+			names = append(names, a.Name)
+		}
+	}
+	if strings.Join(names, ",") != "good-one,good-two" {
+		t.Errorf("skills = %v; want the two valid ones only", names)
+	}
+
+	if len(m.Issues) != 1 {
+		t.Fatalf("expected exactly one issue, got %v", m.Issues)
+	}
+	for _, want := range []string{"wiki", "foo", "name_directory_mismatch"} {
+		if !strings.Contains(m.Issues[0], want) {
+			t.Errorf("issue must name %q: %s", want, m.Issues[0])
+		}
+	}
+	if len(diagnostics) != 1 || diagnostics[0] != m.Issues[0] {
+		t.Errorf("the diagnostic and the recorded issue must be the same message: %v vs %v", diagnostics, m.Issues)
+	}
+}
+
+// The two channels share one authority, so they must agree over the same cases.
+func TestBuildManifest_AgreesWithTheMCPChannel(t *testing.T) {
+	for _, tc := range []struct {
+		dir, name string
+		valid     bool
+	}{
+		{"query-rete", "query-rete", true},
+		{"foo", "bar", false},
+		{"Bad-Name", "Bad-Name", false},
+		{"kbinfra--query-rete", "kbinfra--query-rete", false},
+	} {
+		t.Run(tc.dir, func(t *testing.T) {
+			kbRoot := t.TempDir()
+			writeSkill(t, kbRoot, tc.dir, tc.name)
+			m, err := provisioning.BuildManifest(nil, map[string]string{"wiki": kbRoot}, provisioning.BuildOptions{})
+			if err != nil {
+				t.Fatalf("BuildManifest: %v", err)
+			}
+			shipped := 0
+			for _, a := range m.Artifacts {
+				if a.Kind == "skill" {
+					shipped++
+				}
+			}
+			if tc.valid && shipped != 1 {
+				t.Errorf("%s should ship, issues: %v", tc.dir, m.Issues)
+			}
+			if !tc.valid && shipped != 0 {
+				t.Errorf("%s should be excluded, but reached the manifest", tc.dir)
+			}
+		})
+	}
+}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -1,5 +1,6 @@
 // Package skill implements loading and validation of SKILL.md files (agentskills.io format).
-// Skills live under skills/ in the KB root, one per directory named <namespace>--<skill-name>.
+// Skills live under skills/ in the KB root, one directory per skill, named
+// exactly as the skill's frontmatter `name` (D191).
 package skill
 
 import (
@@ -7,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/BeppeTemp/cartographer/internal/okf"
@@ -31,12 +33,32 @@ type CatalogEntry struct {
 	Path        string `json:"path"`
 }
 
-// Issue represents a validation issue for a skill.
+// Issue represents a validation issue for a skill. Rule names the check that
+// failed, so a caller can attribute a refusal without parsing the message.
 type Issue struct {
 	Path    string
+	Rule    string
 	Message string
 	Warning bool // true = warning, false = error
 }
+
+// skillNameRe is the intersection of what the supported clients accept:
+// lowercase [a-z0-9] segments separated by single "-", no leading or trailing
+// "-", and no "--" (OpenCode rejects it outright). Adopting the strictest
+// client rule rather than the most permissive is the point of D191 — a skill we
+// accept and a client silently ignores is a no-op in the agent's catalogue, and
+// that failure is invisible from here.
+var skillNameRe = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+// maxSkillNameLen and maxSkillDescriptionLen are the client-side limits a skill
+// must respect to be catalogued. The name limit is an error (the client refuses
+// the skill); the description limit is a warning, because a long description
+// degrades selection without breaking anything, and turning an existing KB's
+// descriptions into hard failures would block syncs that work today.
+const (
+	maxSkillNameLen        = 64
+	maxSkillDescriptionLen = 1024
+)
 
 // LoadSkill reads and parses a SKILL.md file from the given directory path.
 // dirPath is the full absolute path to the skill directory.
@@ -185,34 +207,73 @@ func Catalog(skills []Skill) []CatalogEntry {
 	return entries
 }
 
-// Validate checks a skill for common issues:
-// - name is required
-// - description is required
-// - body exceeds 500 lines is a warning
-// Returns a list of issues (empty = valid).
+// Validate is the single authority on whether a skill is well-formed (D191).
+// Both channels that can introduce one call it: artifact_write over MCP, and
+// BuildManifest for a skill that arrived through git. They used to disagree,
+// and the git side was the weaker one — a malformed artifact it accepted broke
+// the sync of the whole KB later, far from its cause.
+//
+// Errors (they break a channel or a client):
+//   - name required, matching skillNameRe, at most maxSkillNameLen
+//   - frontmatter name equal to the directory basename
+//   - description required
+//
+// Warnings (they degrade quality, they break nothing):
+//   - body over maxSkillBodyLines
+//   - description over maxSkillDescriptionLen
 func Validate(s *Skill) []Issue {
 	var issues []Issue
 
-	if strings.TrimSpace(s.Name) == "" {
+	name := strings.TrimSpace(s.Name)
+	switch {
+	case name == "":
 		issues = append(issues, Issue{
-			Path:    s.DirPath,
+			Path: s.DirPath, Rule: "name_required",
 			Message: "name is required",
-			Warning: false,
 		})
+	default:
+		if len(name) > maxSkillNameLen {
+			issues = append(issues, Issue{
+				Path: s.DirPath, Rule: "name_too_long",
+				Message: fmt.Sprintf("name is %d characters, over the %d-character limit the clients enforce", len(name), maxSkillNameLen),
+			})
+		}
+		if !skillNameRe.MatchString(name) {
+			issues = append(issues, Issue{
+				Path: s.DirPath, Rule: "name_invalid",
+				Message: fmt.Sprintf("name %q must be lowercase alphanumeric segments joined by single hyphens (no uppercase, underscore, leading/trailing hyphen or \"--\")", name),
+			})
+		}
+		// The manifest registers the artifact under the frontmatter name but
+		// hashes and reads the directory: when they disagree, ReadArtifactFiles
+		// looks for a path that does not exist and can take sync_pull down for
+		// the entire KB.
+		if base := filepath.Base(s.DirPath); base != "." && base != "/" && base != name {
+			issues = append(issues, Issue{
+				Path: s.DirPath, Rule: "name_directory_mismatch",
+				Message: fmt.Sprintf("frontmatter name %q must match the directory name %q", name, base),
+			})
+		}
 	}
 
-	if strings.TrimSpace(s.Description) == "" {
+	description := strings.TrimSpace(s.Description)
+	if description == "" {
 		issues = append(issues, Issue{
-			Path:    s.DirPath,
+			Path: s.DirPath, Rule: "description_required",
 			Message: "description is required",
-			Warning: false,
+		})
+	} else if len(description) > maxSkillDescriptionLen {
+		issues = append(issues, Issue{
+			Path: s.DirPath, Rule: "description_too_long",
+			Message: fmt.Sprintf("description is %d characters, over the %d-character guideline", len(description), maxSkillDescriptionLen),
+			Warning: true,
 		})
 	}
 
 	lineCount := len(strings.Split(s.Body, "\n"))
 	if lineCount > maxSkillBodyLines {
 		issues = append(issues, Issue{
-			Path: s.DirPath,
+			Path: s.DirPath, Rule: "body_too_long",
 			// Lines only: the check counts lines, and a token count depends on
 			// the tokenizer, so reporting the overage in one unit and the budget
 			// in another was not actionable (D161).
@@ -222,4 +283,15 @@ func Validate(s *Skill) []Issue {
 	}
 
 	return issues
+}
+
+// FirstError returns the first error-severity issue in issues, or nil when they
+// are all warnings — the shape both channels need to decide whether to refuse.
+func FirstError(issues []Issue) *Issue {
+	for i := range issues {
+		if !issues[i].Warning {
+			return &issues[i]
+		}
+	}
+	return nil
 }

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -101,7 +101,7 @@ func TestLoadAllSkills(t *testing.T) {
 	}
 
 	// Create two skill directories.
-	for _, name := range []string{"myns--skill-one", "myns--skill-two"} {
+	for _, name := range []string{"skill-one", "skill-two"} {
 		d := filepath.Join(skillsDir, name)
 		if err := os.MkdirAll(d, 0755); err != nil {
 			t.Fatal(err)
@@ -134,13 +134,13 @@ func TestLoadAllSkillsPartialError(t *testing.T) {
 	}
 
 	// One valid skill, one directory without SKILL.md.
-	good := filepath.Join(skillsDir, "ns--good")
+	good := filepath.Join(skillsDir, "good")
 	if err := os.MkdirAll(good, 0755); err != nil {
 		t.Fatal(err)
 	}
 	writeSkillMD(t, good, "---\nname: good\ndescription: Good skill\n---\nBody.\n")
 
-	bad := filepath.Join(skillsDir, "ns--bad")
+	bad := filepath.Join(skillsDir, "bad")
 	if err := os.MkdirAll(bad, 0755); err != nil {
 		t.Fatal(err)
 	}
@@ -157,8 +157,8 @@ func TestLoadAllSkillsPartialError(t *testing.T) {
 
 func TestCatalog(t *testing.T) {
 	skills := []Skill{
-		{Name: "alpha", Description: "First skill", Version: "1.0.0", DirPath: "skills/ns--alpha"},
-		{Name: "beta", Description: "Second skill", DirPath: "skills/ns--beta"},
+		{Name: "alpha", Description: "First skill", Version: "1.0.0", DirPath: "skills/alpha"},
+		{Name: "beta", Description: "Second skill", DirPath: "skills/beta"},
 	}
 
 	entries := Catalog(skills)
@@ -174,14 +174,14 @@ func TestCatalog(t *testing.T) {
 	if entries[1].Version != "" {
 		t.Errorf("entries[1].Version = %q; want empty", entries[1].Version)
 	}
-	if entries[0].Path != "skills/ns--alpha" {
-		t.Errorf("entries[0].Path = %q; want %q", entries[0].Path, "skills/ns--alpha")
+	if entries[0].Path != "skills/alpha" {
+		t.Errorf("entries[0].Path = %q; want %q", entries[0].Path, "skills/alpha")
 	}
 }
 
 func TestValidate(t *testing.T) {
 	t.Run("valid skill", func(t *testing.T) {
-		s := &Skill{Name: "ok", Description: "Good desc", DirPath: "skills/ns--ok"}
+		s := &Skill{Name: "ok", Description: "Good desc", DirPath: "skills/ok"}
 		issues := Validate(s)
 		if len(issues) != 0 {
 			t.Errorf("expected no issues, got %v", issues)
@@ -189,7 +189,7 @@ func TestValidate(t *testing.T) {
 	})
 
 	t.Run("missing name", func(t *testing.T) {
-		s := &Skill{Name: "", Description: "desc", DirPath: "skills/ns--x"}
+		s := &Skill{Name: "", Description: "desc", DirPath: "skills/x"}
 		issues := Validate(s)
 		if len(issues) != 1 {
 			t.Fatalf("expected 1 issue, got %d", len(issues))
@@ -200,7 +200,7 @@ func TestValidate(t *testing.T) {
 	})
 
 	t.Run("missing description", func(t *testing.T) {
-		s := &Skill{Name: "x", Description: "", DirPath: "skills/ns--x"}
+		s := &Skill{Name: "x", Description: "", DirPath: "skills/x"}
 		issues := Validate(s)
 		if len(issues) != 1 {
 			t.Fatalf("expected 1 issue, got %d", len(issues))
@@ -215,7 +215,7 @@ func TestValidate(t *testing.T) {
 		for i := range lines {
 			lines[i] = "line"
 		}
-		s := &Skill{Name: "x", Description: "desc", Body: strings.Join(lines, "\n"), DirPath: "skills/ns--x"}
+		s := &Skill{Name: "x", Description: "desc", Body: strings.Join(lines, "\n"), DirPath: "skills/x"}
 		issues := Validate(s)
 		if len(issues) != 1 {
 			t.Fatalf("expected 1 issue, got %d", len(issues))
@@ -226,7 +226,7 @@ func TestValidate(t *testing.T) {
 	})
 
 	t.Run("missing name and description", func(t *testing.T) {
-		s := &Skill{DirPath: "skills/ns--x"}
+		s := &Skill{DirPath: "skills/x"}
 		issues := Validate(s)
 		if len(issues) != 2 {
 			t.Fatalf("expected 2 issues, got %d", len(issues))
@@ -305,36 +305,71 @@ func TestLoadAllFromFSPartialError(t *testing.T) {
 	}
 }
 
-func TestNamespaceExtraction(t *testing.T) {
-	// Verify the <namespace>--<skill-name> convention parses correctly.
-	cases := []struct {
-		dirName   string
-		wantNS    string
-		wantSkill string
-	}{
-		{"myns--myskill", "myns", "myskill"},
-		{"foo--bar-baz", "foo", "bar-baz"},
-		{"noskill", "", ""},
-	}
+// --- one rule set, the intersection of what the clients accept (D191) ---
 
-	for _, tc := range cases {
-		parts := strings.SplitN(tc.dirName, "--", 2)
-		if tc.wantNS == "" {
-			// No separator expected.
-			if len(parts) == 2 {
-				t.Errorf("%q: unexpected split into %v", tc.dirName, parts)
+func TestValidate_NameRules(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		skill    string
+		wantRule string
+	}{
+		{"lowercase kebab is valid", "query-rete", ""},
+		{"digits are valid", "kb2-sync", ""},
+		{"single segment is valid", "runbooks", ""},
+		{"uppercase", "Query-Rete", "name_invalid"},
+		{"underscore", "query_rete", "name_invalid"},
+		{"leading dash", "-query", "name_invalid"},
+		{"trailing dash", "query-", "name_invalid"},
+		{"double dash is the retired namespace convention", "kbinfra--query-rete", "name_invalid"},
+		{"space", "query rete", "name_invalid"},
+		{"65 characters", strings.Repeat("a", 65), "name_too_long"},
+		{"64 characters is the limit, not over it", strings.Repeat("a", 64), ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Skill{Name: tc.skill, Description: "desc", DirPath: "skills/" + tc.skill}
+			bad := FirstError(Validate(s))
+			if tc.wantRule == "" {
+				if bad != nil {
+					t.Fatalf("%q should be valid, got %s: %s", tc.skill, bad.Rule, bad.Message)
+				}
+				return
 			}
-			continue
-		}
-		if len(parts) != 2 {
-			t.Errorf("%q: expected split, got %v", tc.dirName, parts)
-			continue
-		}
-		if parts[0] != tc.wantNS {
-			t.Errorf("%q: namespace = %q; want %q", tc.dirName, parts[0], tc.wantNS)
-		}
-		if parts[1] != tc.wantSkill {
-			t.Errorf("%q: skill = %q; want %q", tc.dirName, parts[1], tc.wantSkill)
-		}
+			if bad == nil {
+				t.Fatalf("%q should be refused with %s", tc.skill, tc.wantRule)
+			}
+			if bad.Rule != tc.wantRule {
+				t.Errorf("%q: rule = %q; want %q (%s)", tc.skill, bad.Rule, tc.wantRule, bad.Message)
+			}
+		})
+	}
+}
+
+// The failure this rule exists for: the manifest registers the artifact under
+// the frontmatter name but hashes and reads the directory, so a mismatch sends
+// ReadArtifactFiles to a path that does not exist.
+func TestValidate_NameMustMatchDirectory(t *testing.T) {
+	s := &Skill{Name: "bar", Description: "desc", DirPath: "skills/foo"}
+	bad := FirstError(Validate(s))
+	if bad == nil {
+		t.Fatal("skills/foo with name: bar must be refused")
+	}
+	if bad.Rule != "name_directory_mismatch" {
+		t.Errorf("rule = %q; want name_directory_mismatch", bad.Rule)
+	}
+	if !strings.Contains(bad.Message, "foo") || !strings.Contains(bad.Message, "bar") {
+		t.Errorf("message must name both: %s", bad.Message)
+	}
+}
+
+func TestValidate_SeveritySplit(t *testing.T) {
+	// Warnings degrade quality; they must never exclude a skill, or an
+	// existing KB's long descriptions would start blocking syncs that work.
+	long := &Skill{Name: "ok", Description: strings.Repeat("d", maxSkillDescriptionLen+1), DirPath: "skills/ok"}
+	issues := Validate(long)
+	if len(issues) != 1 || !issues[0].Warning {
+		t.Fatalf("a long description must be exactly one warning, got %+v", issues)
+	}
+	if FirstError(issues) != nil {
+		t.Error("a warning-only skill must not be excluded")
 	}
 }

--- a/test/e2e/fixtures/kb-homelab-lite/skills/query-rete/SKILL.md
+++ b/test/e2e/fixtures/kb-homelab-lite/skills/query-rete/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: kbinfra--query-rete
+name: query-rete
 description: Guide for querying the infra map (rete expanded concept) of the homelab KB.
 version: "1.0"
 ---

--- a/test/e2e/scenarios/04_skill_lifecycle.sh
+++ b/test/e2e/scenarios/04_skill_lifecycle.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # scenarios/04_skill_lifecycle.sh — OPERATOR scenario: skill lifecycle (materialization + prune).
 #
-# Uses the kb-homelab-lite fixture, which contains the domain skill kbinfra--query-rete.
+# Uses the kb-homelab-lite fixture, which contains the domain skill query-rete.
 # Verifies that:
 #   (a) `cartographer connect opencode --auto-trust` materializes the skill in
 #       .opencode/skills/<name>/SKILL.md (via sync_pull) and writes the v2 lockfile.
@@ -49,7 +49,7 @@ server_wait_health 20
 trap 'server_stop' EXIT
 
 SERVER_URL="http://127.0.0.1:${E2E_HTTP_PORT}/mcp"
-SKILL_NAME="kbinfra--query-rete"
+SKILL_NAME="query-rete"
 SKILL_SRC="${KB_DIR}/skills/${SKILL_NAME}"
 SKILL_DEST="${SANDBOX_DIR}/.opencode/skills/${SKILL_NAME}/SKILL.md"
 LOCK_FILE="${SANDBOX_DIR}/.cartographer-sync.lock.json"


### PR DESCRIPTION
Closes #245

## The bug

`BuildManifest` — which serves the git channel and is declared equivalent to `artifact_write` — called `skill.LoadAllSkills` and **discarded the error slice** (`kbSkills, _ :=`), never invoking `Validate` at all.

With directory `skills/foo/` and frontmatter `name: bar`:

1. the manifest registers the artifact as `bar` but hashes the directory `foo`;
2. `ReadArtifactFiles` then looks for `skills/bar`;
3. the read fails and can take `sync_pull` down **for the entire KB**.

So a hand-edited or git-imported skill broke every client of that KB, while identical content would have been refused outright over MCP.

`skill.Validate` was also too thin to catch what the clients actually enforce — no kebab-case, no length limit, no name/directory equality. A skill Cartographer accepted and Kiro or OpenCode silently ignored was a no-op in the agent's catalogue, invisible from our side.

## What changed

- **One authority.** `skill.Validate` is it; `validateSkillArtifact` delegates to it and keeps only the MCP-specific path check, `BuildManifest` calls it too. A table test runs the same cases through both and asserts they agree.
- **The rule set is the intersection of what the clients accept**, not the permissive union: lowercase `[a-z0-9]` segments joined by single `-`, no leading/trailing `-`, no `--`, at most 64 characters, frontmatter `name` equal to the directory. Adopting the strictest client rule is the point.
- **Errors exclude the offending skill and nothing else**, with the KB, the skill and the violated rule named — through a `SkillDiagnostic` callback (the shape `MCPDiagnostic` already had, wired to the server's startup log) and on `Manifest.Issues`. A KB with one bad skill still syncs its valid artifacts, which is the opposite of today's whole-KB breakage. `LoadAllSkills`' own errors are surfaced the same way instead of discarded.
- **Warnings never exclude.** Body length and description length degrade quality without breaking anything, and turning an existing KB's long descriptions into hard failures would block syncs that work today.
- **`<namespace>--<skill-name>` is retired**: unreachable from production code and incompatible with the `--` rule. The comment, `TestNamespaceExtraction` (which exercised a local `strings.SplitN` with no production caller) and the E2E fixture `kbinfra--query-rete` → `query-rete` all go.

`Manifest.Issues` is deliberately **not** part of the revision: excluding an artifact already changes it, and hashing the message list would make a wording edit look like a catalogue change.

## Also fixed

`docs/skills-services-secrets.md` claimed Cartographer "does not verify signed commits or Sigstore attestations" in a way that read as *no cryptographic verification at all*, contradicting `docs/sync.md`. The page now separates the Ed25519 signature and key pinning from the trust policy the `signed` field feeds.

## Breaking change

Skills whose name is non-conforming, or disagrees with their directory, are refused where the git channel previously accepted them. The release notes must name the rules — they are in the D191 entry and in a table in `docs/skills-services-secrets.md`.

`make vet && make test && make e2e` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)