### PR TITLE
docs(readme): steer the installing agent to the runbook it never reaches (D197)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,15 @@ flowchart LR
 
 ## Install
 
+### Prerequisites
+
+- **git** — a KB *is* a git repository; nothing works without it.
+- **A git remote for your first KB** — an empty repository you own (GitHub, Gitea,
+  any git host). That remote is what makes the KB durable and syncable; a
+  local-only KB (`--no-remote`) is neither (D134).
+- **`sops` in `PATH`** — only if the KB will hold encrypted values.
+- **Go 1.26+** — only for the `go install` path.
+
 ```bash
 # macOS (Homebrew)
 brew install beppetemp/tap/cartographer
@@ -202,9 +211,22 @@ curl -fsSL https://raw.githubusercontent.com/BeppeTemp/cartographer/main/install
 go install github.com/BeppeTemp/cartographer/cmd/cartographer@latest
 ```
 
-### Agent-driven install
+`install.sh` supports Darwin and Linux only.
 
-Give an agent this prompt to install Cartographer, mount its first KB, connect itself, and verify the setup:
+### Installing Cartographer with an agent
+
+**If you are an agent and the user has asked you to install Cartographer**: fetch
+<https://raw.githubusercontent.com/BeppeTemp/cartographer/main/docs/agent-install.md>
+and follow it command by command. Do **not** install from the Quick start below.
+The runbook exists because four commands are not enough on this path: it asks the
+user for the KB git remote before it is needed, branches on whether Homebrew is
+present, identifies which client is actually executing you, verifies the install
+(`version`, `/health`, `status`), carries a failure table for what realistically
+goes wrong, and ends by telling the user to restart their agent
+session — the step you cannot perform yourself and without which a correct
+install looks broken.
+
+For a human driving an agent, this is the prompt to paste:
 
 ```text
 Set up Cartographer on this machine by following
@@ -212,10 +234,49 @@ https://raw.githubusercontent.com/BeppeTemp/cartographer/main/docs/agent-install
 My first knowledge base is at: `<git remote URL>`
 ```
 
+### What gets installed
+
+- **The binary**, `cartographer` — in Homebrew's prefix (`brew`), in
+  `/usr/local/bin` or, when that is not writable, `~/.local/bin` (`install.sh`),
+  or in `$GOBIN`/`$GOPATH/bin` (`go install`).
+- **A native per-user service**, if you run `cartographer service install`:
+  `~/Library/LaunchAgents/com.cartographer.serve.plist` on macOS, or
+  `~/.config/systemd/user/cartographer.service` on Linux, listening on
+  `127.0.0.1:39273`. Its config is generated at
+  `~/.config/cartographer/server.yaml`. The service is **optional** — a
+  stdio-only setup (`serve --kb <path>`) is a legitimate topology and installs
+  none of this.
+- **A data directory**, `~/cartographer-data` by default, holding the cloned KBs.
+- **Writes into your agent clients' own configuration** under `$HOME`, and only
+  when you run `cartographer connect` — never before. Each destination path is
+  listed in the [One KB, every agent](#one-kb-every-agent) matrix above. A sync
+  timer (`com.cartographer.sync` / `cartographer-sync.timer`) is installed for
+  clients that have no session-start hook.
+
+### How to remove it
+
+`install.sh uninstall` removes the **binary only**. It refuses to run while the
+native units are still installed, and names the teardown that has to come first:
+
+```bash
+cartographer disconnect                      # removes what was materialized into your agents
+cartographer service sync-timer uninstall
+cartographer service uninstall
+curl -fsSL https://raw.githubusercontent.com/BeppeTemp/cartographer/main/install.sh | sh -s -- uninstall
+```
+
+Your KBs are git repositories in the data directory: nothing above deletes them,
+and removing `~/cartographer-data` is a deliberate, separate act.
+
 ## Quick start
 
 The primary path is four commands: install the binary, run it as a native service, create your
 first KB, and connect an agent client to it.
+
+> This assumes an **interactive operator** who will answer the prompts, supply the
+> KB remote and diagnose a failure as it happens. Agents installing on someone's
+> behalf follow [`docs/agent-install.md`](docs/agent-install.md) instead, for the
+> reasons given under [Installing Cartographer with an agent](#installing-cartographer-with-an-agent).
 
 ```bash
 brew install beppetemp/tap/cartographer   # or curl install.sh, or `go install` (see Install above)

--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -1,10 +1,15 @@
 # Agent-driven installation
 
-Use this runbook when the user supplies the Cartographer repository link and the git remote for
-their first Knowledge Base (KB). A KB is a git repository and its remote is what makes it durable
-and syncable, so the remote is required: if the user did not supply one, **ask for it before step
-3** — an empty repository they own (GitHub, Gitea, or any git host). Execute every command in
-order; report the expected result before continuing.
+Use this runbook whenever the user asks you to install Cartographer — a repository link and a
+conversation is the normal starting point, and it is enough. Execute every command in order; report
+the expected result before continuing.
+
+**Establish one input first: the git remote for the user's first Knowledge Base (KB).** A KB is a
+git repository and its remote is what makes it durable and syncable, so the remote is required, and
+on this path it is almost always the thing nobody supplied. Ask for it now — an empty repository
+they own (GitHub, Gitea, or any git host) — rather than discovering at step 3 that you need a URL
+you do not have. Only if the user explicitly accepts a throwaway, local-only KB do you proceed
+without one.
 
 ## 1. Install Cartographer
 
@@ -119,8 +124,7 @@ cartographer status
 ```
 
 Expected output: a version, then health JSON containing `"ready":true`, then in-sync status with
-exit code 0. Restart the connected agent session after this check so it loads the MCP tools and
-provisioned skills.
+exit code 0.
 
 Confirm the instructions actually reach the model, not just the disk. `cartographer status` and
 `cartographer doctor` now check the provider's own precedence chain (D189), but the provider's own
@@ -134,13 +138,26 @@ Expected output: a `cartographer:kb:*` section. If it is absent while `status` r
 instructions installed, report it: a provider precedence rule Cartographer does not model yet.
 
 `connect` provisioned the bundled skills, including `cartographer-ops`. Use that skill for ongoing
-operations, diagnosis, upgrades, and synchronization after installation.
+operations, diagnosis, upgrades, and synchronization after installation. From there the bundled
+`kb-create` and `kb-import` skills cover authoring the KB's own content and artifacts.
+
+## 6. Tell the user to restart their agent session
+
+This is a step you cannot perform: the session that must restart is the one you are running in.
+State it to the user explicitly, as the last thing you say:
+
+> Restart your agent session now. The MCP tools and the provisioned skills are loaded at session
+> start, so until you do, Cartographer is installed but invisible to me.
+
+Omitting this is the single most common way a correct installation is reported as broken.
 
 ## Failures
 
 | Observed symptom | Next action |
 |---|---|
 | `command -v brew` has no output | Run the `install.sh` command in step 1. |
+| The user's agent shows no Cartographer MCP tools after a successful `connect` | The session was not restarted. Repeat step 6 — this is not a failed install. |
+| `cartographer status` exits non-zero immediately after install | The service may still be starting: wait a few seconds and retry once before diagnosing. |
 | The service reports that port 39273 is busy | Stop or reconfigure the process using the port, then rerun `cartographer service install`. |
 | `kb clone` reports a git authentication failure | Configure ambient credentials (an SSH agent for SSH remotes or a git credential helper for HTTPS), then rerun the same `kb clone` command. |
 | `kb clone` reports a host key that is not in `known_hosts` | Connect once with `ssh <host>` to review and accept the key yourself, then rerun. The clone never accepts a host key on your behalf (D173). |

--- a/docs/decisions/deployment-release.md
+++ b/docs/decisions/deployment-release.md
@@ -716,3 +716,69 @@ frontmatter contract. `uninstall` on a machine with no units behaves exactly as 
 behaviour change, release-note it. Everything else is documentation, corrected hints and test
 coverage. The provider list in `docs/agent-install.md` (item 6) was already fixed by the
 Antigravity work (D194) and needed no change here.
+
+## D197 — The evaluate-then-install path: steer the agent that is actually reading
+
+**Status: implemented.** Closes #252.
+
+**Context.** People do not reach Cartographer by reading the repository. They paste the repository
+link into an agent they already have open — *"explain this project, I'm evaluating installing
+it"* — read the agent's answer, and then say *"install it"*. At that second prompt the agent has
+only what it read at the first: `README.md`. Nobody hands it `docs/agent-install.md`.
+
+The runbook is good — command by command, expected output after each, a failure table, and the
+right refusals (never accept a host key on the user's behalf, never clone into the service data dir
+by hand, never create a KB without a remote unless the user accepts a local-only one). It was
+simply unreachable from the path people take, and the README steered the agent the wrong way in
+five specific ways: its agent section was addressed to a *human* copying a prompt; §Quick start
+followed immediately, called itself "the primary path", and is four commands that omit the platform
+check, the `brew`-absent branch, asking for the KB remote, `cartographer agents`, the verification
+triple, the failure table and the session restart; the runbook's own opening framed a *supplied* KB
+remote as a precondition, which on this path is always false; its step 5 told the executing agent to
+restart the session it is running in; and the README had no prerequisites, no statement of what
+lands on the machine, and no uninstall, so the evaluation answer was either incomplete or inferred.
+
+**Decisions.**
+
+- **Steer, do not restructure.** The fix is one paragraph in §Install addressed to the agent in the
+  second person: if you are asked to install Cartographer, fetch the runbook's raw URL and follow
+  it, and do not improvise from Quick start. It states *why* in the same breath — the runbook asks
+  for the remote, identifies the executing client, verifies, and carries the failure table — so an
+  agent weighing two visible options has the basis to choose rather than an unexplained
+  prohibition. The section heading was renamed from "Agent-driven install", which described only
+  the human's recipe, to "Installing Cartographer with an agent", which covers both readers.
+- **Quick start stays and names its audience.** It is genuinely useful to a human skimming the
+  page; deleting it to protect agents would fix the wrong reader's experience. It gains one line
+  saying it assumes an interactive operator, and routes agents to the runbook.
+- **The footprint statement lives in the README, not in `deployment.md`.** The whole premise is
+  that the evaluating agent has only the README, so the facts it needs must be there: prerequisites
+  (git, an empty remote for the first KB, `sops` only for encrypted values, Go only for the source
+  path); what gets installed (the binary and where each method puts it, the optional per-user
+  service on `127.0.0.1:39273` with its two unit paths, `~/cartographer-data`, and the writes into
+  each client's configuration that happen **only** on `connect`); and removal. Every path was
+  derived from `install.sh`, `internal/service/paths.go`, `internal/defaults` and
+  `cmd/cartographer/service.go` rather than paraphrased. The destinations themselves are not
+  repeated: the "One KB, every agent" matrix already lists every one.
+- **Uninstall is described as it is.** D192 item 11 had already changed `install.sh uninstall` to
+  refuse while native units remain and to name the teardown; the README states that behaviour,
+  including that removing `~/cartographer-data` is a separate deliberate act, because the KBs are
+  the user's git repositories.
+- **The runbook's entry condition becomes the prompt, not the inputs.** "The user asked you to
+  install Cartographer" is what is actually true. The KB remote stays required and is promoted from
+  a parenthetical to the first thing the runbook establishes, since on this path it is always the
+  missing input.
+- **The session restart becomes its own closing step, addressed to the user.** The agent executing
+  the runbook *is* the session that must restart; it cannot do it. Step 6 now exists for no other
+  purpose, with the sentence to say and the reason. Two rows were added to the failure table for
+  the symptoms this path produces: no MCP tools after a successful `connect` (the session was not
+  restarted — not a failed install), and `status` exiting non-zero immediately after install (the
+  service is still starting; retry once).
+- **No new install mechanism and no new command.** This is text and one runbook's framing.
+
+**Invariants kept.** The runbook's refusals are untouched. The raw URL in the README's prompt block
+still resolves — it is what people paste. Every command in both files stays runnable as printed
+(the D192 standard). `getting-started.md` was reconciled on the two points where it could contradict
+the runbook, prerequisites and the restart, and now hands off to the bundled `kb-create`/`kb-import`
+skills where the runbook ends.
+
+**Consequences.** Documentation only; no behaviour change and no release impact.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,6 +4,12 @@ From zero to a working agentic wiki in about ten minutes, using the **Local
 Core** profile: one server, one KB, one agent (Claude Code in this walkthrough
 — OpenCode, Codex CLI, Kiro and Antigravity work the same way via `cartographer connect`).
 
+You need **git**, and an empty git repository you own to be the first KB's
+remote — a KB is a git repository, and that remote is what makes it durable and
+syncable (D134). `sops` is needed only if the KB will hold encrypted values, and
+Go 1.26+ only for the from-source install. What each installation method puts on
+the machine, and how to remove it, is in the README under §Install.
+
 ## 1. Install the client/server binary
 
 ```bash
@@ -21,8 +27,10 @@ go install github.com/BeppeTemp/cartographer/cmd/cartographer@latest
 multi-provider client (`connect` / `status` / `sync`), and a TUI dashboard
 (run it with no arguments in a terminal).
 
-If an agent is performing the installation from a repository link and a first KB remote, use the
-imperative [agent-driven installation runbook](agent-install.md) instead of this human walkthrough.
+If an **agent** is performing the installation on your behalf, it follows the
+imperative [agent-driven installation runbook](agent-install.md) instead of this
+human walkthrough — a repository link is all it needs to start, and it will ask
+you for the KB remote itself.
 
 ## 2. Run the server and create your first KB
 
@@ -71,8 +79,11 @@ arguments for an interactive form, `cartographer status` to check for drift,
 
 ## 4. First session
 
-Open a new Claude Code session and ask something that produces knowledge
-worth keeping, for example:
+**Restart Claude Code first.** The MCP tools and the provisioned skills are
+loaded at session start, so a session that was already open when you ran
+`connect` sees none of them — the same closing step the agent runbook makes
+explicit. In the new session, ask something that produces knowledge worth
+keeping, for example:
 
 > Explore this repository and write a concept page about its architecture
 > in the wiki. Close the session with a log entry.
@@ -103,3 +114,5 @@ agent made can be reviewed or reverted with ordinary git.
   [`data-plane.md`](data-plane.md)
 - Connecting other agents and keeping them in sync →
   [`configurator.md`](configurator.md) and [`sync.md`](sync.md)
+- Authoring the KB's own content, skills, subagents and secrets → the bundled
+  `kb-create` and `kb-import` skills, which `connect` just installed


### PR DESCRIPTION
Implements the plan in #252.

People reach Cartographer by pasting the repo link into an agent they already have open, reading its explanation, then saying *"install it"*. At that second prompt the agent has only `README.md` in context — `docs/agent-install.md` is a good runbook that path never reaches, and §Quick start is the path of least resistance while omitting the platform check, the KB remote, verification and the session restart.

**WP1 — the README speaks to the agent that is reading it.** §Install gains a paragraph addressed to the agent in the second person, naming the runbook's raw URL and stating *why* the runbook rather than Quick start. The heading "Agent-driven install" became "Installing Cartographer with an agent". Quick start gains one line naming its audience.

**WP2 — the README answers the evaluation question.** Prerequisites; what gets installed (binary per method, the optional per-user service on `127.0.0.1:39273` with both unit paths, `~/cartographer-data`, and the per-client writes that happen only on `connect`); and removal as it currently behaves after D192 item 11. Every path derived from `install.sh:49-60`, `internal/service/paths.go:64,84`, `internal/service/manager.go:21-22`, `internal/defaults/defaults.go:13` and `cmd/cartographer/service.go:343` — not paraphrased from the issue.

**WP3 — the runbook meets the flow it is entered from.** Entry condition is now "the user asked you to install Cartographer"; the KB remote is promoted from a parenthetical to the first thing established. The session restart becomes step 6 in its own right, addressed to the user, since the executing agent is the session that must restart. Two failure rows added: no MCP tools after a successful `connect`, and `status` exiting non-zero immediately after install.

**WP4 — docs.** `getting-started.md` reconciled on prerequisites and the restart, and now hands off to the bundled `kb-create`/`kb-import` skills where the runbook ends. `docs/index.md` §Maintenance rules still describes both files correctly and needed no change. `D197` added to `docs/decisions/deployment-release.md`.

Documentation only; no behaviour change. `make vet && make test` green.

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AY3RmkHqUB1SaugB2YSGpB