### PR TITLE
docs(skill): the onboarding skills cover artifacts and the encryption flow (D196)

### DIFF
--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -139,7 +139,9 @@ instructions installed, report it: a provider precedence rule Cartographer does 
 
 `connect` provisioned the bundled skills, including `cartographer-ops`. Use that skill for ongoing
 operations, diagnosis, upgrades, and synchronization after installation. From there the bundled
-`kb-create` and `kb-import` skills cover authoring the KB's own content and artifacts.
+`kb-create` and `kb-import` skills take over: `kb-create/references/artifacts.md` for authoring the
+KB's skills, subagents, hooks and MCP descriptors, and `kb-create/references/secrets.md` for the
+SOPS encryption flow.
 
 ## 6. Tell the user to restart their agent session
 

--- a/docs/decisions/skills-services-secrets.md
+++ b/docs/decisions/skills-services-secrets.md
@@ -185,3 +185,77 @@ edit to the wording look like a catalogue change.
 skill names are non-conforming, and the release notes must name the rules. `docs/sync.md` and this
 page also stop contradicting each other on `signed`: the signature and the trust policy are now
 described as the two distinct things they are.
+
+## D196 — The onboarding skills route to references for artifact authoring and the encryption flow
+
+**Status: implemented.** Closes #251.
+
+**Context.** `kb-create` and `kb-import` take an operator from "no KB" to "KB mounted and a client
+connected", and stop there. The two things a first onboarding actually struggles with are the two
+things neither skill contained.
+
+*Artifact authoring was absent.* Neither skill named `artifact_write`, `artifact_read`,
+`artifact_list` or `artifact_delete` even once. `kb-create` offered `skill_list`/`skill_install`,
+which copy a **bundled** skill into the KB — a different operation from authoring one. An operator
+finishing the skill had a KB with concepts and no idea how to put a skill, a subagent, a hook or an
+MCP descriptor into it: not the six accepted paths, not the shape of each, not the optimistic-write
+protocol (`if_match` required on update, forbidden on create — an agent that guesses wrong fails its
+first two attempts), not the client-side naming rules of D191, and not the manifest → trust →
+projection → materialization chain that is what actually makes an artifact appear in a client.
+
+*The encryption flow was one sentence* — "if the KB has SOPS secrets, add its age key as
+`<nome>.age`" — which is the deployment half. Every step the operator must perform and Cartographer
+never will was missing: the age key, the root `.sops.yaml` creation rules, the first encrypted file.
+`kb-import` was worse: its secrets check told the operator that findings are "moved to the SOPS
+flow" and never said what that flow was.
+
+These are bundled skills, so this is not a documentation nit: their text is what an agent acts on,
+and the operator experiences the gap in the product.
+
+**Decisions.**
+
+- **The skills become routers, not longer documents.** `kb-create` was already 128 lines; inlining
+  two procedures would triple it and bury the common path. Each SKILL.md gains a Reference Files
+  table mapping task → file, with the instruction to read only the matching one. This needed **no
+  code change**: `//go:embed all:bundled` already embeds every file in a skill directory,
+  `LoadSkill` reads frontmatter from `SKILL.md` only and is indifferent to siblings, and
+  provisioning already transports auxiliary files as raw bytes.
+- **The encryption reference is organized around the boundary, not the tool list.** Its spine is a
+  table of who does what — operator: age key, `.sops.yaml`, first encrypted file, recipients;
+  Cartographer: `secret_set` on an existing file, `secret_resolve`, `service_get`. The gap people
+  fall into *is* that boundary, so the document is shaped like it, and `docs/skills-services-secrets.md`
+  was corrected to state it as a boundary rather than as a remark inside the `secret_set` paragraph.
+- **It opens with "do you need this at all".** A KB with no service credentials needs none of it;
+  saying so first makes the section skippable instead of intimidating.
+- **Failure modes are indexed by the symptom, not by the cause.** `sops` missing, a key that cannot
+  decrypt, `rw` scope missing over HTTP, `secrets_on_non_service`, a pointer that does not exist,
+  `secret_set` on a file that does not exist, and a committed file that turned out to be plaintext
+  because the `path_regex` did not match — that last one carries the instruction to treat the value
+  as compromised, because git history is forever.
+- **The artifact reference states the client-side naming rules as author-side requirements.** From
+  the author's perspective that is what they are: D191 had landed, so the implemented rules are
+  quoted rather than cited as pending.
+- **Every command is runnable as printed** (the D192 standard), with placeholders written as
+  placeholders. These files are read by an agent that executes them literally.
+- **`kb-create` step 2 now leads with `cartographer kb create <name> --remote <url>`**, which
+  scaffolds, attaches the remote and pushes in one command, with the `serve --kb --init` + manual
+  remote sequence demoted to the fallback for a machine that cannot reach the remote. Flags were
+  checked against `cmd/cartographer/kbcmd.go`, not paraphrased.
+- **The three defects D192 item 5 owned were verified gone, not re-fixed**: the `.cartographer.yaml`
+  edit, the missing `cartographer client bind`, and the naming self-contradiction are all already
+  corrected on `main`.
+- **A test guards the routing in both directions.** `internal/skillbundle` now asserts that every
+  `references/` file is reachable from the embedded FS and non-empty, and that every one of them is
+  mentioned by its skill's `SKILL.md`. A reference added to the tree but not to the embed, or one no
+  skill routes to, can no longer ship silently.
+- **No new MCP tool and no new CLI flag.** This ships documentation inside the binary.
+
+**Invariants kept.** Bundled skills keep their frontmatter contract and are validated on load;
+only `version:` changed (`kb-create` 2.4 → 3.0, `kb-import` 1.0 → 1.1) plus the `kb-create`
+description, which had to say what the skill now covers or the router would never be loaded.
+`skill_install` copies what it always copied. No MCP tool behaviour, destination or config key
+changed. The GitOps/Kubernetes procedure stays `kb-create`'s primary topology.
+
+**Consequences.** Bundled-skill content only, no behaviour change. A KB that installed `kb-create`
+with `skill_install` keeps its old copy until reinstalled — a stale installed copy is exactly the
+confusion this closes, so it is worth a release note.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -114,5 +114,8 @@ agent made can be reviewed or reverted with ordinary git.
   [`data-plane.md`](data-plane.md)
 - Connecting other agents and keeping them in sync →
   [`configurator.md`](configurator.md) and [`sync.md`](sync.md)
-- Authoring the KB's own content, skills, subagents and secrets → the bundled
-  `kb-create` and `kb-import` skills, which `connect` just installed
+- Authoring the KB's own skills, subagents, hooks and MCP descriptors → the
+  bundled `kb-create` skill's `references/artifacts.md`
+- Keeping encrypted values the KB can resolve → the same skill's
+  `references/secrets.md`
+- Importing an existing wiki or docs folder → the bundled `kb-import` skill

--- a/docs/skills-services-secrets.md
+++ b/docs/skills-services-secrets.md
@@ -46,6 +46,11 @@ Client provisioning materializes KB skills into each provider's native
 directory. See [synchronization](sync.md) for the manifest, trust and pruning
 rules.
 
+Authoring a KB's artifacts — the six accepted `artifact_write` paths, the minimum
+shape of each kind, the `if_match` protocol, and the manifest → trust →
+projection → materialization chain — is written out in the bundled `kb-create`
+skill's `references/artifacts.md` (D196).
+
 A materialized `SKILL.md` carries a provenance block naming the KB it came
 from, its path there, and its content hash ([D138](decisions/sync-provisioning.md#d138)).
 Editing that copy is **not** a supported channel: the next sync replaces it. The supported
@@ -135,12 +140,31 @@ Use `secret_refs` for least privilege: each list item is
 declared `NAME` values. Existing descriptors without `secret_refs` retain the
 legacy `secrets_source` whole-file behavior.
 
+### The operator/Cartographer boundary
+
+The encryption flow is split, and the split is where onboarding actually fails
+(D196). Cartographer does **not** bootstrap encryption: it operates what an
+operator has already set up.
+
+| Step | Performed by |
+|---|---|
+| Generate the age key | operator (`age-keygen`) |
+| Write the root `.sops.yaml` creation rules | operator — Cartographer never writes this file |
+| Create the **first** encrypted file and choose its recipients | operator (`sops` CLI) |
+| Rotate or add a pointer in an **existing** encrypted file | Cartographer (`secret_set`) |
+| Declare which values a concept uses | Cartographer (`concept_write`, `secret_refs`) |
+| Resolve declared values | Cartographer (`secret_resolve`, `service_get`) |
+
 `secret_set(path, key, value)` rotates or adds a pointer in an existing
 encrypted `secrets/*.sops.yaml` file. It uses `sops set --value-stdin`, checks
 that the result remains encrypted, and commits through the normal KB write
-flow. Creating the encrypted file and choosing its recipients remain an
-operator action; Cartographer never writes the root `.sops.yaml` creation-rules
-file, but it does update existing encrypted `*.sops.yaml` secret files.
+flow. It **refuses** any path that is not a local `secrets/*.sops.yaml` and any
+file that does not yet exist — bootstrapping one is an operator action, not a
+tool call.
+
+The operator-side half is written out step by step in the bundled `kb-create`
+skill's `references/secrets.md`, which is where an agent is sent when it has to
+perform it.
 
 ## Operational guidance
 

--- a/internal/skillbundle/bundle_test.go
+++ b/internal/skillbundle/bundle_test.go
@@ -1,0 +1,71 @@
+package skillbundle
+
+import (
+	"io/fs"
+	"path"
+	"strings"
+	"testing"
+)
+
+// TestBundledReferencesAreEmbedded guards the routing model the onboarding
+// skills use (D196): a SKILL.md routes to references/*.md loaded on demand, and
+// those files ship inside the binary via //go:embed. A reference added to the
+// source tree but not reaching the embedded FS — or shipped empty — would leave
+// the skill pointing at a file the agent cannot read, which is exactly the
+// silent gap the routing was introduced to close.
+func TestBundledReferencesAreEmbedded(t *testing.T) {
+	seen := 0
+	err := fs.WalkDir(FS, "bundled", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || path.Base(path.Dir(p)) != "references" {
+			return nil
+		}
+		seen++
+		data, readErr := fs.ReadFile(FS, p)
+		if readErr != nil {
+			t.Errorf("%s: not readable from the embedded FS: %v", p, readErr)
+			return nil
+		}
+		if len(strings.TrimSpace(string(data))) == 0 {
+			t.Errorf("%s: embedded but empty", p)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk bundled: %v", err)
+	}
+	if seen == 0 {
+		t.Fatal("no references/ file found in the embedded bundle: the embed no longer carries them")
+	}
+}
+
+// TestBundledSkillReferencesAreRouted pairs with the test above from the other
+// side: a reference file that no SKILL.md mentions is dead weight the agent will
+// never load, and a SKILL.md routing to a file that is not there is worse.
+func TestBundledSkillReferencesAreRouted(t *testing.T) {
+	skills, err := fs.ReadDir(FS, "bundled")
+	if err != nil {
+		t.Fatalf("read bundled: %v", err)
+	}
+	for _, s := range skills {
+		if !s.IsDir() {
+			continue
+		}
+		refs, err := fs.ReadDir(FS, path.Join("bundled", s.Name(), "references"))
+		if err != nil {
+			continue // a skill with no references is fine
+		}
+		body, err := fs.ReadFile(FS, path.Join("bundled", s.Name(), "SKILL.md"))
+		if err != nil {
+			t.Fatalf("%s: read SKILL.md: %v", s.Name(), err)
+		}
+		for _, r := range refs {
+			want := "references/" + r.Name()
+			if !strings.Contains(string(body), want) {
+				t.Errorf("%s/SKILL.md does not route to %s", s.Name(), want)
+			}
+		}
+	}
+}

--- a/internal/skillbundle/bundled/kb-create/SKILL.md
+++ b/internal/skillbundle/bundled/kb-create/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-create
-description: Operator procedure to declare and provision a new Knowledge Base GitOps-style, so it survives pod restarts.
-version: "2.4"
+description: Operator procedure to declare and provision a new Knowledge Base GitOps-style, so it survives pod restarts; also covers authoring the KB's artifacts (skills, subagents, hooks, MCP descriptors) and the SOPS encryption flow.
+version: "3.0"
 ---
 # KB Create — Skill
 
@@ -24,6 +24,16 @@ exists as an ad-hoc runtime mount on an emptyDir is **not durable**.
 > D134). This skill remains the procedure for the GitOps/Kubernetes topology below, where the KB
 > also has to be declared in the server's ConfigMap.
 
+## Reference Files
+
+Two tasks have a full procedure of their own. Read **only** the file that matches
+what you are doing — not all of them upfront.
+
+| Task | File |
+|---|---|
+| Put a skill, subagent, hook, MCP descriptor or instructions block into the KB | `references/artifacts.md` |
+| Store an encrypted value the KB can resolve (age key, `.sops.yaml`, `Service` concept, `secret_refs`) | `references/secrets.md` |
+
 ## Steps
 
 ### 1. Create the Gitea repo and the per-KB service user
@@ -38,27 +48,37 @@ collaborator with **write** permission on the repo only, and generate an access 
 (scope `write:repository`). This token is the KB's git credential (one user per KB = per-repo
 isolation; Gitea tokens are per-user, not per-repo).
 
-### 2. Generate the KB skeleton locally (one-shot)
-On any machine with the `cartographer` binary and git access to the new repo:
+### 2. Generate the KB skeleton and push it
+On any machine with the `cartographer` binary and git access to the new repo, one command
+scaffolds the KB, attaches the remote and pushes the first commit:
+
+```
+cartographer kb create <name> --remote <gitea-repo-url>
+```
+
+`<name>` accepts letters, digits, `-` and `_` only. `--remote` must point at the **empty**
+repository from step 1 — it becomes the KB's `origin`, and the remote is mandatory (D134):
+`--no-remote` is the explicit opt-out for a throwaway local KB that is neither durable nor synced.
+The KB lands in the local service's data dir (`--data <dir>` overrides it); add `--restart` to
+restart the local service and wait for it to come back healthy.
+
+*Fallback* — a machine that cannot reach the remote, or where you want the skeleton somewhere of
+your own choosing:
 
 ```
 cartographer serve --kb <dir> --init   # creates the layout, then Ctrl-C
-```
-
-This creates the standard layout: `data/` (conceptual root), `services/`, `skills/`, `agents/`,
-`hooks/` — content directories only, no `AGENTS.md`/`.gitignore` (D62; the local `.cartographer/`
-index is excluded via `.git/info/exclude`, not a versioned `.gitignore`) — and initializes `<dir>`
-as a git repo with a first commit
-("init: KB inizializzata"). Optionally, add a curated `instructions.md` at the KB root (sibling of
-`data/`, `skills/`, `agents/`) with free-form orchestration directives (e.g. delegation routing,
-"large reads → explorer") — its body is folded into the generated `instructions` artifact after the
-auto-generated archives/agent sections (D61, `docs/sync.md` §Instructions). Then push it to the
-Gitea repo created in step 1:
-
-```
 git -C <dir> remote add origin <gitea-repo-url>
 git -C <dir> push -u origin <branch>
 ```
+
+Either way the standard layout is: `data/` (conceptual root), `services/`, `skills/`, `agents/`,
+`hooks/` — content directories only, no `AGENTS.md`/`.gitignore` (D62; the local `.cartographer/`
+index is excluded via `.git/info/exclude`, not a versioned `.gitignore`) — plus a first commit.
+Optionally, add a curated `instructions.md` at the KB root (sibling of `data/`, `skills/`,
+`agents/`) with free-form orchestration directives (e.g. delegation routing, "large reads →
+explorer") — its body is folded into the generated `instructions` artifact after the
+auto-generated archives/agent sections (D61, `docs/sync.md` §Instructions). See
+`references/artifacts.md` for that file's role among the KB's other artifacts.
 
 ### 3. Declare the KB in the server config (ConfigMap)
 Add an entry under `kbs:` in the server's YAML config (`CARTOGRAPHER_CONFIG`, see
@@ -85,6 +105,11 @@ the server picks up `<nome>.token` and `<nome>.age` by convention. SSH remotes
 - Add the Gitea token from step 1 to the k8s `Secret` backing `git.token_dir` (key
   `<nome>.token`); if the KB has SOPS secrets, add its age key as `<nome>.age` in the secret
   backing `sops.age_key_dir`. Never inline key material in the ConfigMap itself.
+- **The age key is the deployment half only.** Generating that key, writing the root `.sops.yaml`
+  creation rules and creating the first encrypted file are operator actions Cartographer never
+  performs — `secret_set` refuses a file that does not exist. Do them **before** this step, and do
+  not assume an encrypted file is already there: `references/secrets.md` is the full procedure. A
+  KB with no service credentials needs none of it.
 - Add a **scoped token** for the clients of this KB to `CARTOGRAPHER_TOKENS` (or `auth.tokens` in
   the YAML): format `token|kb:<nome>:rw` (read-write) or `token|kb:<nome>:r` (read-only), entries
   separated by comma/whitespace, scopes on one token separated by `;`. Do not reuse an admin
@@ -107,9 +132,11 @@ Apply the updated ConfigMap/Secret and roll out the Deployment so the server pic
 - To change which KBs an already-connected client receives, use `cartographer client bind` /
   `unbind` / `reset`, then `cartographer sync`. Bindings are enforced during sync (D170).
 
-## Optional: Maps and Journals
-Once the KB is live, use the standard MCP tools to shape its content — this part is unchanged from
-v1.x and can be driven by the agent, not just the operator:
+## Optional: shape the KB
+Once the KB is live there are two independent things to shape, both drivable by the agent rather
+than the operator.
+
+### Content: Maps and Journals
 - Ask the user to describe the **Maps** (thematic, mixed concept types) or **Journals**
   (chronological logs, e.g. incidents/notes) they need: name, description, `kind`
   (`map`/`journal`), `concept_types`, `ontology_mode`: `strict`/`emergent`/`off`, default
@@ -118,11 +145,21 @@ v1.x and can be driven by the agent, not just the operator:
 - A concept that outgrows a single file becomes an **expanded concept** via `concept_expand`
   (turns `<id>.md` into `<id>/index.md` plus satellite concepts) — there is no separate
   "dossier create" step.
-- Call `skill_list` / `skill_install` to offer relevant bundled skills.
+
+### Artifacts: skills, subagents, hooks, MCP descriptors
+A KB also configures the agents that read it. Authoring those artifacts — the six accepted
+`artifact_write` paths, the shape of each, the naming rules a client enforces, the `if_match`
+protocol, and the manifest → trust → projection → materialization chain that is what actually makes
+one appear in a client — is in `references/artifacts.md`.
+
+`skill_list` / `skill_install` are a **different** operation: they copy a skill bundled in the
+binary into the KB. That is installation, not authoring.
 
 ## Reference
 
-- Tools: `atlas_overview`, `map_create`, `concept_expand`, `concept_write`, `skill_list`, `skill_install`.
+- Tools: `atlas_overview`, `map_create`, `concept_expand`, `concept_write`, `skill_list`,
+  `skill_install`; `artifact_list`/`artifact_read`/`artifact_write`/`artifact_delete` for artifacts;
+  `service_get`, `secret_resolve`, `secret_set` for encrypted values.
 - Layout: `data/` is the conceptual root; concept IDs are relative to it.
 - Multi-KB HTTP: endpoint is `/mcp?kb=<name>` when more than one KB is mounted. `<name>` is the
   `name:` field of the KB's `kbs:` entry, which falls back to the repository basename only when it

--- a/internal/skillbundle/bundled/kb-create/references/artifacts.md
+++ b/internal/skillbundle/bundled/kb-create/references/artifacts.md
@@ -1,0 +1,178 @@
+# Authoring the KB's artifacts
+
+A KB is not only what an agent reads — it is also **how that agent is set up to
+work**. Skills, subagents, hooks, MCP descriptors and standing instructions are
+content of the KB, authored with the `artifact_*` tools and materialized into
+every connected client's native format.
+
+This is different from `skill_install`, which copies a **bundled** skill (one
+shipped inside the binary) into the KB. That is installation, not authoring.
+
+## 1. The six accepted paths
+
+`artifact_write` accepts exactly these, relative to the KB root — anything else
+is refused:
+
+| Path | Kind | Shape |
+|---|---|---|
+| `skills/<slug>/**` | skill | a directory; `SKILL.md` is required, `scripts/` and `assets/` optional |
+| `agents/<slug>.md` | subagent | one Markdown file, YAML frontmatter + prompt body |
+| `hooks/**` | hook | a directory; `hook.json` plus the script it runs |
+| `mcp/<slug>.json` | MCP server | one JSON descriptor |
+| `instructions.md` | instructions | one Markdown file at the KB root |
+| `templates/<slug>.md` | template | KB-only (D109): never materialized into a client |
+
+## 2. The minimum shape of each
+
+### `skills/<slug>/SKILL.md`
+
+```markdown
+---
+name: my-skill
+description: One sentence saying when an agent should load this skill.
+---
+# My Skill
+
+Procedure the agent follows.
+```
+
+Frontmatter `name` and `description` are both required, and `name` must equal the
+directory name. Auxiliary files travel as raw bytes with their executable bit
+preserved, so `skills/my-skill/scripts/run.sh` stays executable in the client.
+
+### `agents/<slug>.md`
+
+```markdown
+---
+name: my-agent
+description: When the main agent should delegate to this one.
+---
+You are …
+```
+
+Both frontmatter fields are **required** — `artifact_write` refuses the file
+without them. The body is the agent's prompt and travels verbatim. This one
+source file is translated per provider: Markdown for Claude Code and Antigravity,
+TOML for Codex, an OpenCode agent file for OpenCode. `tools` and `model` keys are
+dropped in the translations that cannot carry them, because those names are not
+portable between clients. An agent with **no** frontmatter description falls back
+to the artifact's own name, which makes it nearly unselectable — write a real one.
+
+### `hooks/<name>/hook.json`
+
+```json
+{
+  "event": "SessionStart",
+  "matcher": "Write|Edit",
+  "command": "./on-session-start.sh"
+}
+```
+
+`event` uses the Claude Code event names as the source vocabulary and is
+translated per provider; `matcher` is optional; `command` is resolved relative to
+the hook's own materialized directory unless it is absolute — so ship the script
+beside the `hook.json` and reference it relatively. An event with no equivalent on
+a given provider leaves the hook materialized and produces a **warning, not a
+failure**: expect that on a heterogeneous machine.
+
+### `mcp/<slug>.json`
+
+```json
+{
+  "type": "http",
+  "url": "https://example.com/mcp",
+  "headers": {"Authorization": "Bearer ${EXAMPLE_TOKEN}"}
+}
+```
+
+`type` is `http` (needs an absolute `url`, rejects `command`/`args`) or `stdio`
+(needs `command`, rejects `url`/`headers`). Every `headers`/`env` value **must**
+contain at least one `${VAR}` reference: a value with none is rejected as a
+probable hardcoded secret. The client resolves the reference against its own
+environment at apply time, so no credential ever lives in the KB. Unknown JSON
+fields are rejected.
+
+### `instructions.md`
+
+Free-form orchestration directives at the KB root. Its body is folded into the
+generated instructions artifact after the auto-generated archives and agent
+sections (D61) — it augments them, it does not replace them.
+
+## 3. Naming rules
+
+These apply to a skill's `name` and directory, and they are the **intersection of
+what the supported clients accept**, not the most permissive union (D191). A skill
+Cartographer accepts and a client silently ignores is a no-op in the agent's
+catalogue, and that failure is invisible from the KB:
+
+| Rule | Severity |
+|---|---|
+| `name` is required | error |
+| `name` is `[a-z0-9]` segments joined by single `-` — no uppercase, no `_`, no leading/trailing `-`, no `--` | error |
+| `name` is at most 64 characters | error |
+| `name` equals the directory name | error |
+| `description` is required | error |
+| `description` is at most 1024 characters | warning |
+| body is at most 500 lines | warning |
+
+An error excludes **that skill** from the manifest and nothing else: the KB's
+other artifacts still sync, and the reason names the KB, the skill and the rule.
+Warnings exclude nothing.
+
+The historical `<namespace>--<skill-name>` directory convention is retired — it
+is incompatible with the `--` rule above.
+
+## 4. The write protocol
+
+`artifact_write` is optimistic-concurrency, and the rule is inverted between
+create and update. Getting it wrong is the first thing that happens to everyone:
+
+- **Creating a new file** — *omit* `if_match`. Passing it on a file that does not
+  exist fails with `stale_write: <path> not found`; and if the file *does* already
+  exist, omitting it fails with `already_exists: <path> already exists (sha256 …)`.
+- **Updating an existing file** — `if_match` is **required**, and its value is the
+  sha256 of the current content, taken from `artifact_read` or `artifact_list`.
+  A missing or mismatched hash fails with `stale_write`.
+
+So the loop is: `artifact_list` (or `artifact_read`) → take the sha256 → write
+with `if_match`. On `already_exists`, read the file and retry as an update. On
+`stale_write` for a file you believe exists, someone changed it since your read:
+read it again, reconcile, retry.
+
+`artifact_delete` always requires `if_match`, and removes the artifact's own
+now-empty directory for skills and hooks.
+
+## 5. What happens after the write
+
+`artifact_write` alone changes **nothing** on any client's disk. The artifact
+reaches an agent through a chain, and each link can stop it:
+
+1. **Manifest** — the server scans `skills/`, `agents/`, `hooks/`, `mcp/` and
+   `instructions.md` and builds the list of artifacts the KB offers. A skill that
+   fails a naming *error* is excluded here.
+2. **Binding** — the client must be bound to this KB. On a server with two or
+   more KBs, `connect` requires the choice explicitly (D190).
+3. **Trust** — a KB artifact needs the user's persisted trust decision. Skills
+   and hooks execute with the agent's privileges; bundled artifacts are trusted by
+   construction, KB ones are not.
+4. **Materialization** — `cartographer sync` writes the translated artifact into
+   the client's native directory.
+
+So after authoring: run `cartographer sync`, then **restart the agent session** —
+skills and MCP tools are loaded at session start.
+
+A materialized `SKILL.md` carries a provenance block naming the source KB, its
+path there, and its content hash. **Editing the materialized copy is not a
+channel**: the next sync replaces it. The supported channels are `artifact_write`
+on the owning KB, or a git push to the KB repository — the block states which,
+with the exact path.
+
+## 6. The rest of the loop
+
+- `artifact_list` — inventory, with the sha256 of every file. Start here.
+- `artifact_read` — one file's content plus its sha256.
+- `artifact_write` — create or update, per §4.
+- `artifact_delete` — remove, `if_match` required.
+
+Full reference: `docs/skills-services-secrets.md` (skills, services, secrets) and
+`docs/sync.md` (manifest, trust, pruning).

--- a/internal/skillbundle/bundled/kb-create/references/secrets.md
+++ b/internal/skillbundle/bundled/kb-create/references/secrets.md
@@ -1,0 +1,176 @@
+# Encrypted values: the SOPS flow, end to end
+
+## 0. Do you need this at all?
+
+A KB that holds no service credentials needs **none** of this. Skip the whole
+reference and come back when a concept needs to reference a real secret.
+
+You need it when the KB describes a service whose credentials an agent should be
+able to resolve — a client secret, an API token, a database password — and you
+want that value versioned with the KB rather than pasted into a chat.
+
+## 1. The boundary: what you do, what Cartographer does
+
+This is the part that traps people, so it comes before the procedure.
+
+| Step | Who |
+|---|---|
+| Generate the age key | **you**, with `age-keygen` |
+| Write the root `.sops.yaml` creation rules | **you** — Cartographer never writes this file |
+| Create the **first** encrypted file and choose its recipients | **you**, with the `sops` CLI |
+| Rotate or add a pointer in an **existing** encrypted file | Cartographer (`secret_set`) |
+| Declare which values a concept uses | Cartographer (`concept_write`, `secret_refs`) |
+| Resolve declared values | Cartographer (`secret_resolve`, `service_get`) |
+
+`secret_set` **refuses** any path that is not a local `secrets/*.sops.yaml`, and
+refuses a file that does not exist: *"bootstrapping an encrypted file and its
+recipients is an operator action"*. Do not try to create the first file with it.
+
+## 2. Operator-only steps
+
+### 2.1 Generate an age key
+
+```bash
+age-keygen -o ~/.config/cartographer/kb-<kb-name>.age
+```
+
+Keep it **outside the KB**. It is passed to the `sops` child process as
+`SOPS_AGE_KEY_FILE` and must never be committed. The server selects it in this
+order, first match wins:
+
+1. `kbs[].sops_age_key_file` in the server config;
+2. global `sops.age_key_file`;
+3. the `CARTOGRAPHER_SOPS_AGE_KEY_FILE` environment variable.
+
+On a GitOps deployment with `sops.age_key_dir` set, the convention is
+`<age_key_dir>/<kb-name>.age` and no per-KB config key is needed.
+
+### 2.2 Write the root `.sops.yaml`
+
+At the **root of the KB repository**, not inside `secrets/`:
+
+```yaml
+creation_rules:
+  - path_regex: secrets/.*\.sops\.yaml$
+    age: age1qqqq...   # the public key printed by age-keygen
+```
+
+Test the regex before relying on it — a rule that does not match means `sops`
+writes the file in **plaintext** and you will not be told:
+
+```bash
+sops --verbose encrypt --in-place secrets/probe.sops.yaml
+```
+
+### 2.3 Create the first encrypted file
+
+```bash
+mkdir -p secrets
+sops secrets/keycloak.sops.yaml    # opens $EDITOR on a new encrypted file
+```
+
+Write plain YAML in the editor; `sops` encrypts the values on save. Confirm the
+result really is encrypted before committing:
+
+```bash
+grep -q 'ENC\[' secrets/keycloak.sops.yaml && echo encrypted
+```
+
+Commit and push it like any other KB file.
+
+## 3. Cartographer-side steps
+
+### 3.1 The Service concept
+
+Service descriptors are ordinary concepts under `services/` with `type: Service`.
+**`Service` is a reserved type**, matched case-insensitively (D158), so
+`type: service` works too. Keep the frontmatter **flat** — Cartographer's
+scalar/list subset is what `service_get` reads:
+
+```yaml
+---
+type: Service
+title: Keycloak
+kind: idp
+base_url: https://keycloak.example.internal
+secret_refs:
+  - CLIENT_SECRET=secrets/keycloak.sops.yaml#/dante_client/DEV/client_secret
+  - ADMIN_PASSWORD=secrets/keycloak.sops.yaml#/admin/0/password
+---
+```
+
+Each `secret_refs` entry is exactly `NAME=secrets/file.sops.yaml#/json-pointer`.
+Resolution returns only the declared `NAME` values — that is the least-privilege
+form, and it is the one to use. The older `secrets_source: secrets/file.sops.yaml`
+declares the *whole file* and is kept only for descriptors that already use it.
+
+### 3.2 Resolve
+
+```
+service_get(service_id: "services/keycloak", resolve_secrets: true)
+secret_resolve(concept_id: "services/keycloak")
+secret_resolve(concept_id: "services/keycloak", names: ["CLIENT_SECRET"], reveal: true)
+```
+
+`secret_resolve` works on **any** concept, not only a Service: a task or dossier
+page can own its own `secret_refs`.
+
+`secret_resolve` **redacts by default**: you get the sorted key names with
+`<redacted>` values, which is what verifying that resolution works actually
+needs. `reveal: true` returns the values and is **recorded in the audit trail** —
+printing a credential is a decision, and the transcript keeps it. `names` filters
+the keys and composes with redaction, so you can confirm *which* of several keys
+resolve without printing any of them.
+
+A decrypted value must never be written back into a concept body.
+
+### 3.3 Rotate
+
+```
+secret_set(path: "secrets/keycloak.sops.yaml", key: "/dante_client/DEV/client_secret", value: "<new>")
+```
+
+It runs `sops set --value-stdin`, verifies the result is still encrypted, and
+commits through the normal KB write flow. Requires `rw` scope over HTTP and a
+`sops_age_key_file` configured for the KB.
+
+## 4. JSON Pointer rules
+
+Cartographer flattens the decrypted YAML's scalar leaves into RFC 6901 JSON
+Pointers. Given:
+
+```yaml
+dante_client:
+  DEV:
+    client_secret: s3cr3t
+admin:
+  - client_secret: other
+```
+
+the pointers are `/dante_client/DEV/client_secret` and `/admin/0/client_secret` —
+a list index is a path segment. In a mapping key, `~` is escaped as `~0` and `/`
+as `~1`. A null leaf is the empty string.
+
+## 5. Failure modes, by the symptom you will actually see
+
+| Symptom | Cause and fix |
+|---|---|
+| `sops` not found | The `sops` CLI is not in the server's `PATH`. Resolution shells out to it; install it on the machine or image running the server. |
+| resolution fails to decrypt | The configured age key is not a recipient of that file. Re-encrypt with `sops updatekeys`, or point at the right key (§2.1 order). |
+| resolution refused over HTTP | `service_get(resolve_secrets)` and `secret_set` need **`rw`** scope. A `kb:<name>:r` token cannot resolve. |
+| `lint` reports `secrets_on_non_service` | `secret_refs` or `secrets_source` was declared on a concept whose `type` is not `Service`. This is the most common mistake; fix the type or move the refs. |
+| a `NAME` resolves to nothing | The JSON Pointer does not exist in the decrypted file. Check it with `sops decrypt secrets/<file>.sops.yaml` and re-read §4. |
+| `secret_set: file does not exist` | You are trying to create the first encrypted file with it. Go back to §2.3. |
+| the committed file is readable plaintext | The `.sops.yaml` `path_regex` did not match. Fix the rule (§2.2), re-encrypt, and treat the plaintext value as **compromised** — git history is forever: rotate it upstream. |
+
+## 6. Hygiene
+
+- **Multiple recipients** whenever losing one key must not make recovery
+  impossible.
+- **On offboarding**, update recipients *and* rotate the real upstream
+  credentials: encrypted historical values remain in git forever.
+- Keep at least one **tested** offline recovery key. Untested is unrecovered.
+- SOPS is **encrypted storage, not a dynamic secret manager**: it issues no
+  short-lived credentials and rotates no service on its own.
+
+Full reference: `docs/skills-services-secrets.md`.

--- a/internal/skillbundle/bundled/kb-import/SKILL.md
+++ b/internal/skillbundle/bundled/kb-import/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-import
 description: Agent-guided procedure to import an existing non-OKF wiki or knowledge base (Obsidian vault, markdown folder, wiki export) into a Cartographer KB, incrementally and without big-bang LLM rewriting.
-version: "1.0"
+version: "1.1"
 ---
 # KB Import — Skill
 
@@ -26,8 +26,20 @@ style (`[[wiki]]` vs `[text](path.md)`), presence/shape of existing frontmatter,
 non-content (assets, templates, daily notes, trash). Produce a short summary for the operator.
 
 > **Secrets check.** Grep the source for credentials/PII (`password`, `token`, `BEGIN.*KEY`,
-> etc.) **before** anything is written to a KB that will be pushed. Anything found is excluded
-> or moved to the SOPS flow — git history is forever.
+> etc.) **before** anything is written to a KB that will be pushed — git history is forever, so
+> this check comes before any write and stays first. For each finding, decide explicitly between
+> two outcomes and record the choice with the operator:
+>
+> 1. **Exclude** the file (or strip the value) from the import — the default for anything that is
+>    not a credential the KB needs to resolve;
+> 2. **Move the value into an encrypted file** and leave the concept referencing it via
+>    `secret_refs`. The full procedure — age key, root `.sops.yaml` creation rules, the first
+>    encrypted file, the `Service` concept — is the `kb-create` skill's
+>    `references/secrets.md`. Cartographer performs none of the operator-side steps.
+>
+> If the corpus carries a `.sops.yaml` or `*.sops.yaml` of its own, do **not** merge it blindly
+> into the target KB's rules: the recipients must be reconciled deliberately, because a wrong
+> merge silently produces files nobody on the team can decrypt.
 
 ### 2. Mapping plan — human checkpoint
 Propose, and get the operator's explicit approval on:
@@ -79,10 +91,18 @@ backlog resumable by any future session — resist finishing it in one go.
 When `lint` reports no `imported_draft` in the imported scope, the import is complete: final
 full `lint`, `log_append` with the closing summary.
 
+An imported corpus usually needs **artifacts** of its own — the skills, subagents and hooks that
+configure the agents reading it, which no import scaffold can synthesize. Once the curation queue is
+drained, `references/artifacts.md` in the `kb-create` skill is the procedure. For the operational
+aftermath — connecting clients, syncing, diagnosing drift, upgrades — use the `cartographer-ops`
+skill.
+
 ## Reference
 
 - Tools: `atlas_overview`, `map_create`, `concept_expand`, `concept_read`, `concept_write`,
   `concept_patch`, `concept_move`, `concept_list`, `supersede`, `lint`, `search`, `log_append`.
-- CLI: `cartographer import` (see D74 WP2), `kb-create` skill for a brand-new target KB.
+- CLI: `cartographer import` (see D74 WP2), `kb-create` skill for a brand-new target KB,
+  for authoring artifacts (`references/artifacts.md`) and for the SOPS flow
+  (`references/secrets.md`); `cartographer-ops` for operations after the import.
 - Rationale and scope: `docs/decisions/data-plane.md` D74 (import), D28 (why no server-side ingest), D72
   (wiki-links, `concept_move` batch).


### PR DESCRIPTION
Implements the plan in #251.

**WP1 — `references/secrets.md`.** The SOPS flow end to end, organized around the operator/Cartographer boundary rather than around the tool list, because that boundary is where onboarding fails. Opens with "do you need this at all" so it is skippable; then the operator-only steps (`age-keygen`, the root `.sops.yaml` and testing its `path_regex`, the first encrypted file with the `sops` CLI), then the Cartographer-side ones (the `Service` concept, `secret_refs`, `service_get(resolve_secrets)`, `secret_resolve` redacting by default with `reveal: true` audited, `secret_set` for rotation), the JSON Pointer rules with both worked examples, failure modes indexed **by the symptom the operator sees**, and hygiene.

**WP2 — `references/artifacts.md`.** The six accepted `artifact_write` paths and the minimum shape of each; the D191 naming rules stated as author-side requirements (they landed, so they are quoted, not cited as pending); the `if_match` protocol with both error codes and why the rule is inverted between create and update; and the manifest → binding → trust → materialization chain, i.e. why `artifact_write` alone changes nothing until a `sync` and a session restart. Also the distinction from `skill_install`, which installs a *bundled* skill rather than authoring one.

**WP3 — `kb-import`.** §1's secrets check now states a real decision procedure (exclude, or encrypt and reference) pointing at WP1, keeps the git-history-is-forever warning first, and covers a corpus carrying its own `.sops.yaml`. §6 hands off to WP2's reference and to `cartographer-ops`.

**WP4 — `kb-create` aligned with the CLI.** Step 2 leads with `cartographer kb create <name> --remote <url>`, with `serve --kb --init` + manual remote demoted to the fallback; flags checked against `cmd/cartographer/kbcmd.go:99-117`. `version:` 2.4 → 3.0 and 1.0 → 1.1. The three D192 item-5 defects were verified already fixed on `main` and not re-touched.

**WP5 — docs.** `docs/skills-services-secrets.md` states the boundary as a boundary and points at both references; `docs/agent-install.md` and `docs/getting-started.md` name them as the next step; `D196` added to `docs/decisions/skills-services-secrets.md`.

**Test.** `internal/skillbundle/bundle_test.go` asserts every `references/` file is reachable from the embedded FS and non-empty, **and** that every one is routed to by its skill's `SKILL.md` — both directions, so neither a missing embed nor a dead file ships silently. `skill_install` already copies recursively (`tools_skill.go:439-457`), so an installed copy carries the references.

No code change beyond the test. `make vet && make test` green.

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AY3RmkHqUB1SaugB2YSGpB