### PR TITLE
feat(transport): one tool surface for a multi-KB server (D187)

### DIFF
--- a/cmd/cartographer/clientsync_test.go
+++ b/cmd/cartographer/clientsync_test.go
@@ -1169,7 +1169,7 @@ func TestDryRunPlanCoversRemovalsAndKnownKBs(t *testing.T) {
 	if _, _, err := removeMCPEntries(cfg.ServerName, cfg.KnownKBs, []string{"claude"}, dir, false, "", false); err != nil {
 		t.Fatal(err)
 	}
-	entries, err := entriesByProviderForKBs(cfg, []string{"claude"}, cfg.ServerName, cfg.ServerURL, []string{"one", "gone"})
+	entries, err := entriesByProviderForKBs(cfg, []string{"claude"}, cfg.ServerName, cfg.ServerURL, []string{"one", "gone"}, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/cartographer/connect.go
+++ b/cmd/cartographer/connect.go
@@ -697,7 +697,20 @@ func doConnect(opts connectOptions) (connectResult, error) {
 	if healthErr != nil || !facts.Listed {
 		entryKBs = nil
 	}
-	entriesByProvider, err := entriesByProviderForKBs(existing, opts.Providers, opts.Name, opts.ServerURL, entryKBs)
+	// D187: a routed server collapses the entry set to one, whatever the
+	// binding says — the KB travels in each tool call now, not in the URL. A
+	// server that is unreachable keeps the historical shape: routing is only
+	// ever asserted from evidence.
+	routedPath := ""
+	if healthErr == nil {
+		routedPath = facts.RoutedPath
+	}
+	existing.ServerRoutedPath = routedPath
+	existing.ServerMountMode = ""
+	if routedPath != "" {
+		existing.ServerMountMode = "routed"
+	}
+	entriesByProvider, err := entriesByProviderForKBs(existing, opts.Providers, opts.Name, opts.ServerURL, entryKBs, routedPath)
 	if err != nil {
 		return connectResult{}, err
 	}
@@ -708,8 +721,13 @@ func doConnect(opts connectOptions) (connectResult, error) {
 	if err != nil {
 		return connectResult{}, err
 	}
-	if w := kiroFlatNamespaceWarning(opts.Providers, entriesByProvider, effectiveToolPrefixes(facts, healthErr), healthErr); w != "" {
-		configWarnings = append(configWarnings, w)
+	// A routed server writes one entry per provider, and one entry cannot
+	// collide with itself: the flat-namespace warning (D102) has nothing to
+	// warn about and firing it would be noise.
+	if routedPath == "" {
+		if w := kiroFlatNamespaceWarning(opts.Providers, entriesByProvider, effectiveToolPrefixes(facts, healthErr), healthErr); w != "" {
+			configWarnings = append(configWarnings, w)
+		}
 	}
 
 	// 1b. Ensure the bootstrap hook (D60): purely local, independent of the

--- a/cmd/cartographer/doctor.go
+++ b/cmd/cartographer/doctor.go
@@ -383,7 +383,7 @@ func checkManagedFiles(dir string, providers []string, lockFile provisioning.Loc
 // match the KBs recorded in .cartographer.yaml. An entry for a KB no longer
 // mounted keeps pointing an agent at something that is gone.
 func checkMCPEntries(dir string, cfg *clientconfig.Config, providers []string) []doctorFinding {
-	entriesByProvider, err := entriesByProviderForKBs(cfg, providers, cfg.ServerName, cfg.ServerURL, cfg.KnownKBs)
+	entriesByProvider, err := entriesByProviderForKBs(cfg, providers, cfg.ServerName, cfg.ServerURL, cfg.KnownKBs, cfg.ServerRoutedPath)
 	if err != nil {
 		return []doctorFinding{{
 			Check: "mcp-entries", Severity: doctorError, Path: filepath.Join(dir, clientconfig.FileName),

--- a/cmd/cartographer/multikb.go
+++ b/cmd/cartographer/multikb.go
@@ -130,6 +130,10 @@ type serverFacts struct {
 	// tool prefix and capability map (D151): reading a value /health already
 	// serves beats re-deriving it client-side.
 	KBs []client.HealthKB
+	// RoutedPath is the routed mount's path when the server serves one (D187),
+	// empty otherwise. A client that sees it writes ONE MCP entry pointing at
+	// that endpoint instead of one per KB.
+	RoutedPath string
 }
 
 // enumerateKBs obtains the mounted KB names and the server version from
@@ -144,6 +148,9 @@ func enumerateKBs(serverURL string, auth bool, tokenEnv string) (serverFacts, er
 		return serverFacts{}, err
 	}
 	facts := serverFacts{Version: health.Version}
+	if health.Routed() {
+		facts.RoutedPath = health.RoutedPath
+	}
 	if health.KBs == nil {
 		return facts, nil
 	}
@@ -288,7 +295,20 @@ func quoteAll(names []string) []string {
 // though that client's list has a single name.
 //
 // url.URL is used rather than concatenation so an existing query survives.
-func entriesForKBs(baseName, serverURL string, mounted, bound []string) ([]mcpEntry, error) {
+func entriesForKBs(baseName, serverURL string, mounted, bound []string, routedPath string) ([]mcpEntry, error) {
+	if routedPath != "" {
+		// D187: a routed server exposes one endpoint for every KB, so one entry
+		// is the whole configuration. The binding still decides which KBs this
+		// provider may use — routing changes the transport, not the
+		// authorization — but it no longer shapes the entry set, because the
+		// KB now travels in each tool call rather than in the URL.
+		u, err := url.Parse(serverURL)
+		if err != nil {
+			return nil, fmt.Errorf("parse server URL %q: %w", serverURL, err)
+		}
+		u.Path = routedPath
+		return []mcpEntry{{Name: baseName, URL: u.String()}}, nil
+	}
 	if len(mounted) <= 1 {
 		// Nothing to select against: the server routes the bare endpoint, and
 		// no binding can name a KB the server does not identify.
@@ -329,7 +349,7 @@ func managedEntryNames(baseName string, kbs []string) []string {
 // entriesByProviderForKBs builds each provider's own entry set from its binding
 // (D170). A provider explicitly bound to NO KBs gets no entry at all — that is
 // the one case where an empty list is a declaration rather than an absence.
-func entriesByProviderForKBs(cfg *clientconfig.Config, providers []string, baseName, serverURL string, mounted []string) (map[string][]mcpEntry, error) {
+func entriesByProviderForKBs(cfg *clientconfig.Config, providers []string, baseName, serverURL string, mounted []string, routedPath string) (map[string][]mcpEntry, error) {
 	out := make(map[string][]mcpEntry, len(providers))
 	for _, p := range providers {
 		bound, explicit := cfg.BoundKBs(p)
@@ -344,7 +364,7 @@ func entriesByProviderForKBs(cfg *clientconfig.Config, providers []string, baseN
 			out[p] = nil
 			continue
 		}
-		entries, err := entriesForKBs(baseName, serverURL, mounted, bound)
+		entries, err := entriesForKBs(baseName, serverURL, mounted, bound, routedPath)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/cartographer/multikb_test.go
+++ b/cmd/cartographer/multikb_test.go
@@ -185,7 +185,7 @@ func TestDoConnect_Kiro_MultiKB_WarnsFlatNamespace(t *testing.T) {
 }
 
 func TestEntriesForKBs_SingleStaysBare(t *testing.T) {
-	entries, err := entriesForKBs("wiki", "https://example.test/mcp", []string{"only"}, []string{"only"})
+	entries, err := entriesForKBs("wiki", "https://example.test/mcp", []string{"only"}, []string{"only"}, "")
 	if err != nil || len(entries) != 1 || entries[0].Name != "wiki" || entries[0].URL != "https://example.test/mcp" {
 		t.Fatalf("entriesForKBs = %+v, %v; want one bare entry", entries, err)
 	}
@@ -217,7 +217,7 @@ func TestDoConnect_SingleKB_BareEntry_AllProviders(t *testing.T) {
 
 func TestRemoveMCPEntries_RemovesEveryManagedEntry(t *testing.T) {
 	dir := t.TempDir()
-	entries, err := entriesForKBs("wiki", "https://example.test/mcp", []string{"a", "b"}, []string{"a", "b"})
+	entries, err := entriesForKBs("wiki", "https://example.test/mcp", []string{"a", "b"}, []string{"a", "b"}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -250,7 +250,7 @@ func TestCmdSync_ReconcilesOneToManyAndBack(t *testing.T) {
 	if err := clientconfig.Save(dir, cfg); err != nil {
 		t.Fatal(err)
 	}
-	bare, _ := entriesForKBs("wiki", cfg.ServerURL, cfg.KnownKBs, cfg.KnownKBs)
+	bare, _ := entriesForKBs("wiki", cfg.ServerURL, cfg.KnownKBs, cfg.KnownKBs, "")
 	if _, _, err := applyMCPEntries(sameEntriesFor(cfg.Agents, bare), cfg.Agents, dir, false, "", false); err != nil {
 		t.Fatal(err)
 	}
@@ -290,7 +290,7 @@ func TestDoDisconnect_RemovesPersistedPerKBEntries(t *testing.T) {
 	if err := clientconfig.Save(dir, cfg); err != nil {
 		t.Fatal(err)
 	}
-	entries, _ := entriesForKBs("wiki", cfg.ServerURL, cfg.KnownKBs, cfg.KnownKBs)
+	entries, _ := entriesForKBs("wiki", cfg.ServerURL, cfg.KnownKBs, cfg.KnownKBs, "")
 	if _, _, err := applyMCPEntries(sameEntriesFor(cfg.Agents, entries), cfg.Agents, dir, false, "", false); err != nil {
 		t.Fatal(err)
 	}
@@ -313,7 +313,7 @@ func TestCmdSync_ServerDownKeepsMCPEntriesAndKBs(t *testing.T) {
 	if err := clientconfig.Save(dir, cfg); err != nil {
 		t.Fatal(err)
 	}
-	entries, _ := entriesForKBs("wiki", cfg.ServerURL, cfg.KnownKBs, cfg.KnownKBs)
+	entries, _ := entriesForKBs("wiki", cfg.ServerURL, cfg.KnownKBs, cfg.KnownKBs, "")
 	if _, _, err := applyMCPEntries(sameEntriesFor(cfg.Agents, entries), cfg.Agents, dir, false, "", false); err != nil {
 		t.Fatal(err)
 	}
@@ -538,7 +538,7 @@ func TestEntriesForKBs_ShapeFromServerSetFromBinding(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			entries, err := entriesForKBs("wiki", "https://example.test/mcp", tc.mounted, tc.bound)
+			entries, err := entriesForKBs("wiki", "https://example.test/mcp", tc.mounted, tc.bound, "")
 			if err != nil {
 				t.Fatalf("entriesForKBs: %v", err)
 			}
@@ -565,7 +565,7 @@ func TestEntriesByProviderForKBs_EmptyBindingGetsNoEntry(t *testing.T) {
 			"codex":  {KBs: []string{"a"}},
 		},
 	}
-	byProvider, err := entriesByProviderForKBs(cfg, cfg.Agents, "wiki", "https://example.test/mcp", cfg.KnownKBs)
+	byProvider, err := entriesByProviderForKBs(cfg, cfg.Agents, "wiki", "https://example.test/mcp", cfg.KnownKBs, "")
 	if err != nil {
 		t.Fatalf("entriesByProviderForKBs: %v", err)
 	}
@@ -781,5 +781,60 @@ func TestDoConnect_UnknownKB_FailsBeforeAnyWrite(t *testing.T) {
 	}
 	if len(entries) != 0 {
 		t.Errorf("a rejected selection must write nothing, found %d entries", len(entries))
+	}
+}
+
+// TestEntriesForKBs_Routed_OneEntry is D187's client-side acceptance: a server
+// with three KBs produces ONE MCP entry, pointing at the routed endpoint, with
+// no ?kb= in the URL — the KB now travels in each tool call.
+func TestEntriesForKBs_Routed_OneEntry(t *testing.T) {
+	entries, err := entriesForKBs("wiki", "https://example.test/mcp", []string{"a", "b", "c"}, []string{"a", "b", "c"}, "/mcp/routed")
+	if err != nil {
+		t.Fatalf("entriesForKBs: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("routed server produced %d entries, want 1: %+v", len(entries), entries)
+	}
+	if entries[0].Name != "wiki" {
+		t.Errorf("entry name = %q, want the bare server name", entries[0].Name)
+	}
+	if !strings.HasSuffix(entries[0].URL, "/mcp/routed") {
+		t.Errorf("entry URL = %q, want the routed path", entries[0].URL)
+	}
+	if strings.Contains(entries[0].URL, "kb=") {
+		t.Errorf("entry URL carries a kb selector: %q", entries[0].URL)
+	}
+}
+
+// TestEntriesForKBs_Routed_NarrowBindingStillOneEntry: routing changes the
+// transport, not the authorization. A provider bound to one of three KBs still
+// gets the single routed entry — what it may *use* is the binding's business,
+// enforced during sync, not the entry set's.
+func TestEntriesForKBs_Routed_NarrowBindingStillOneEntry(t *testing.T) {
+	entries, err := entriesForKBs("wiki", "https://example.test/mcp", []string{"a", "b", "c"}, []string{"b"}, "/mcp/routed")
+	if err != nil {
+		t.Fatalf("entriesForKBs: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name != "wiki" {
+		t.Fatalf("entries = %+v, want the single routed entry", entries)
+	}
+}
+
+// TestManagedEntryNames_CoversModeSwitch: switching a deployment between the
+// two topologies must not leave orphan entries behind. The removal set has to
+// name both shapes, because a reconnect removes what the client owned before
+// it writes what it owns now.
+func TestManagedEntryNames_CoversModeSwitch(t *testing.T) {
+	names := managedEntryNames("wiki", []string{"a", "b"})
+	want := map[string]bool{"wiki": false, "wiki-a": false, "wiki-b": false}
+	for _, n := range names {
+		if _, ok := want[n]; ok {
+			want[n] = true
+		}
+	}
+	for n, seen := range want {
+		if !seen {
+			t.Errorf("managedEntryNames does not cover %q: a %s entry would survive a mode switch", n, n)
+		}
 	}
 }

--- a/cmd/cartographer/serve.go
+++ b/cmd/cartographer/serve.go
@@ -52,6 +52,7 @@ func cmdServe(args []string) int {
 	gitSyncFlag := fs.Bool("git-sync", true, "Fetch+pull before and push after each write when a remote is configured (default true; or CARTOGRAPHER_GIT_SYNC=false to disable)")
 	configFlag := fs.String("config", "", "Path to a YAML config file (or CARTOGRAPHER_CONFIG)")
 	toolsProfileFlag := fs.String("tools-profile", "", "Tools advertised by tools/list: 'agent' (default, core set) or 'full' (or CARTOGRAPHER_TOOLS_PROFILE)")
+	mountModeFlag := fs.String("mount-mode", "", "Multi-KB HTTP mount topology: 'per-kb' (default, one endpoint per KB) or 'routed' (one endpoint, kb as a tool argument) (or CARTOGRAPHER_MCP_MOUNT_MODE)")
 	fs.Parse(args)
 
 	cfg, err := loadServeConfig(fs, config.FlagOverrides{
@@ -63,6 +64,7 @@ func cmdServe(args []string) int {
 		GitAutocommit: gitAutoCommitFlag,
 		GitSync:       gitSyncFlag,
 		ToolsProfile:  toolsProfileFlag,
+		MountMode:     mountModeFlag,
 	}, *configFlag)
 	if err != nil {
 		log.Fatal(err)
@@ -111,6 +113,8 @@ func loadServeConfig(fs *flag.FlagSet, overrides config.FlagOverrides, configFla
 			explicit.GitSync = overrides.GitSync
 		case "tools-profile":
 			explicit.ToolsProfile = overrides.ToolsProfile
+		case "mount-mode":
+			explicit.MountMode = overrides.MountMode
 		}
 	})
 	config.ApplyFlags(cfg, explicit)
@@ -326,6 +330,16 @@ func runServe(cfg *config.Config) {
 		if len(mounts) == 1 {
 			prefixMode = "off"
 		}
+		// A routed mount (D187) exposes one copy of the tools on one endpoint,
+		// so there is no flat namespace left to disambiguate and a *derived*
+		// prefix would only re-inflate the names routing exists to shrink. The
+		// D153 default is therefore not applied here — the operator never asked
+		// for it. An explicit kbs[].tool_prefix survives this override and is
+		// refused by EnableRoutedMount, because that one the operator did ask
+		// for and the two requests contradict each other.
+		if cfg.MCP.MountMode == config.MountModeRouted {
+			prefixMode = "off"
+		}
 		toolPrefix, err := config.ResolveToolPrefix(m.Spec, prefixMode, name)
 		if err != nil {
 			log.Fatal(err)
@@ -411,7 +425,7 @@ func runServe(cfg *config.Config) {
 	}
 
 	if cfg.HTTP != "" {
-		serveHTTP(cfg.HTTP, kbs, kbNames, kbToolPrefixes, kbArtifactSigners, kbMCPAllowlists, cfg.Auth, cfg.MCP.AllowedOrigins, cfg.ToolsProfile, sqlIdxs, auditLog)
+		serveHTTP(cfg.HTTP, kbs, kbNames, kbToolPrefixes, kbArtifactSigners, kbMCPAllowlists, cfg.Auth, cfg.MCP.AllowedOrigins, cfg.ToolsProfile, cfg.MCP.MountMode, sqlIdxs, auditLog)
 	} else {
 		serveStdio(kbs[0], kbArtifactSigners[0], kbMCPAllowlists[0], cfg.ToolsProfile, sqlIdxs, auditLog)
 	}
@@ -442,7 +456,7 @@ func serveStdio(k *kb.KB, artifactSigner ed25519.PrivateKey, allowlist []provisi
 	}
 }
 
-func serveHTTP(addr string, kbs []*kb.KB, names []string, toolPrefixes []string, artifactSigners []ed25519.PrivateKey, allowlists [][]provisioning.MCPAllowlistEntry, authCfg config.AuthConfig, allowedOrigins []string, toolsProfile string, sqlIdxs map[string]*sqlindex.Index, auditLog *audit.Log) {
+func serveHTTP(addr string, kbs []*kb.KB, names []string, toolPrefixes []string, artifactSigners []ed25519.PrivateKey, allowlists [][]provisioning.MCPAllowlistEntry, authCfg config.AuthConfig, allowedOrigins []string, toolsProfile, mountMode string, sqlIdxs map[string]*sqlindex.Index, auditLog *audit.Log) {
 	if auditLog != nil {
 		log.Printf("audit log active")
 	}
@@ -483,7 +497,7 @@ func serveHTTP(addr string, kbs []*kb.KB, names []string, toolPrefixes []string,
 				s.SetDisplayName("cartographer:" + name)
 			}
 			sqlIdx := sqlIdxs[filepath.Clean(k.Root)]
-			mcpserver.RegisterKBTools(s, k, mcpserver.Deps{SQLIndex: sqlIdx, BundleFS: skillbundle.FS, ArtifactSigner: artifactSigners[i], MCPAllowlist: allowlists[i]})
+			mcpserver.RegisterKBTools(s, k, mcpserver.Deps{SQLIndex: sqlIdx, BundleFS: skillbundle.FS, ArtifactSigner: artifactSigners[i], MCPAllowlist: allowlists[i], RoutedMount: mountMode == config.MountModeRouted})
 			s.SetToolsProfile(toolsProfile)
 			s.SetAuditLog(auditLog)
 			s.SetKBName(name)
@@ -500,6 +514,22 @@ func serveHTTP(addr string, kbs []*kb.KB, names []string, toolPrefixes []string,
 			prefixLog = fmt.Sprintf(", tool prefix: %s__", prefix)
 		}
 		log.Printf("mounted KB %q at %s (tools profile: %s%s)", name, k.Root, toolsProfile, prefixLog)
+	}
+
+	// D187: the routed mount is additive — the per-KB endpoints above keep
+	// their exact behaviour, tools/list output included. It is enabled after
+	// every KB is mounted because it registers the union of what they
+	// registered.
+	if mountMode == config.MountModeRouted {
+		err := multi.EnableRoutedMount(version, func(s *mcpserver.Server) {
+			s.SetToolsProfile(toolsProfile)
+			s.SetTransport("http")
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("routed mount enabled at %s (%d KB(s), one copy of the tools, kb as a tool argument)",
+			mcpserver.RoutedMountPath, len(names))
 	}
 
 	if w := flatNamespaceMountWarning(names, toolPrefixes); w != "" {

--- a/cmd/cartographer/status.go
+++ b/cmd/cartographer/status.go
@@ -89,6 +89,13 @@ func renderStatus(output string, s statusSnapshot, code int) int {
 		fmt.Printf("configured against server %s — now %s: run `cartographer reconnect` to rebuild the client configuration\n",
 			strings.Join(changed, ", "), s.Server)
 	}
+	// D187: a mount-mode switch changes the *shape* of every MCP entry, not
+	// their content, so an incremental sync cannot see it. Report it; do not
+	// heal it.
+	if s.Reachable && s.MountMode != s.ConfiguredMountMode {
+		fmt.Printf("mount mode changed: configured %s, server now serves %s — run `cartographer reconnect` to rewrite the MCP entries\n",
+			mountModeLabel(s.ConfiguredMountMode), mountModeLabel(s.MountMode))
+	}
 	for _, p := range s.Providers {
 		if !p.Connected {
 			continue
@@ -213,4 +220,13 @@ func printShadowedInstructionsLine(p providerStatus) {
 	}
 	fmt.Printf("  instructions not active: %s takes precedence and is not merged — run `cartographer doctor` for the two ways out\n",
 		p.ShadowedInstructions)
+}
+
+// mountModeLabel names a mount mode for a human, including the historical one
+// that is recorded as an empty string.
+func mountModeLabel(mode string) string {
+	if mode == "" {
+		return "one endpoint per KB"
+	}
+	return mode
 }

--- a/cmd/cartographer/status_snapshot.go
+++ b/cmd/cartographer/status_snapshot.go
@@ -118,6 +118,14 @@ type statusSnapshot struct {
 	State     string           `json:"state"`
 	Error     *statusError     `json:"error,omitempty"`
 	Service   *serviceSnapshot `json:"service,omitempty"`
+	// MountMode is the topology the server is serving right now, and
+	// ConfiguredMountMode the one this client's MCP entries were written
+	// against (D187). When they differ the entries are for the wrong endpoint
+	// shape: status reports it, and does not heal it — the fix is an explicit
+	// `cartographer reconnect`, the same answer D142 gives to a server-version
+	// change.
+	MountMode           string `json:"mount_mode,omitempty"`
+	ConfiguredMountMode string `json:"configured_mount_mode,omitempty"`
 }
 
 func classifyNetworkError(endpoint string, err error) statusError {
@@ -181,6 +189,10 @@ func snapshotForConfig(dir string, cfg *clientconfig.Config, includeService bool
 		return s
 	}
 	s.Reachable, s.Server, s.Ready = true, health.Version, health.Ready
+	if health.Routed() {
+		s.MountMode = "routed"
+	}
+	s.ConfiguredMountMode = cfg.ServerMountMode
 	if health.KBs != nil {
 		for _, kb := range *health.KBs {
 			s.KBs = append(s.KBs, kb.Name)

--- a/cmd/cartographer/sync.go
+++ b/cmd/cartographer/sync.go
@@ -129,8 +129,16 @@ func runSync(dir string, cfg *clientconfig.Config, opts syncOptions) (syncResult
 		if !facts.Listed {
 			entryKBs = nil
 		}
+		// D187: the live topology wins over the persisted one, and is persisted
+		// with the rest of the server-owned cache below.
+		routedPath := facts.RoutedPath
+		cfg.ServerRoutedPath = routedPath
+		cfg.ServerMountMode = ""
+		if routedPath != "" {
+			cfg.ServerMountMode = "routed"
+		}
 		var err error
-		entriesByProvider, err = entriesByProviderForKBs(cfg, targets, cfg.ServerName, cfg.ServerURL, entryKBs)
+		entriesByProvider, err = entriesByProviderForKBs(cfg, targets, cfg.ServerName, cfg.ServerURL, entryKBs, routedPath)
 		if err != nil {
 			return syncResult{}, err
 		}

--- a/cmd/cartographer/tui.go
+++ b/cmd/cartographer/tui.go
@@ -305,7 +305,7 @@ func hasConnectedAgent(rows []dashboardAgent) bool {
 // bound is the provider's own KB binding (D170): the expected entry set is its
 // own, not the machine's. mounted decides the entry shape.
 func mcpConfigStatus(dir string, provider configurator.Provider, serverName string, mounted, bound []string) mcpConfigState {
-	entries, err := entriesForKBs(serverName, "http://placeholder", mounted, bound)
+	entries, err := entriesForKBs(serverName, "http://placeholder", mounted, bound, "")
 	if err != nil || len(entries) == 0 {
 		return mcpConfigMissing
 	}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -50,6 +50,25 @@ kbs:
                                    # mcp.tool_prefix_mode below. See docs/deployment.md
                                    # §MCP tool-name prefix.
 mcp:
+  # mount_mode: "per-kb"           # (D187) per-kb (default) | routed — how a multi-KB HTTP
+                                   # server exposes its tools. per-kb mounts one MCP server
+                                   # per KB, each advertising its own full copy of the tool
+                                   # schemas: a client using N KBs writes N server entries
+                                   # and pays N copies of the schemas in its fixed context,
+                                   # on every model round-trip (measured: 82,341 bytes for
+                                   # three KBs, two thirds of it duplicate).
+                                   # routed additionally serves /mcp/routed: one endpoint
+                                   # advertising the union of the tools exactly once, with
+                                   # the target KB travelling as a `kb` tool argument —
+                                   # required whenever 2+ KBs are routed, and never
+                                   # inferred. The per-KB endpoints (?kb= and /mcp/<name>)
+                                   # keep working unchanged in both modes: routing is an
+                                   # addition, not a replacement, so nothing changes for an
+                                   # existing deployment until this key is set.
+                                   # A KB that sets tool_prefix cannot be routed — the two
+                                   # are alternative answers to the same problem, and the
+                                   # combination is a fatal config error at startup.
+                                   # See docs/transport-auth.md §Mount modes.
   # tool_prefix_mode: "kb-name"    # (D102, default flipped in D153) kb-name (default) | off
                                    # global default applied to every KB above that doesn't
                                    # set its own tool_prefix; kb-name derives the prefix

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -66,12 +66,27 @@ rename on one-to-many transitions. If the server cannot be reached, it leaves
 the MCP entries and `known_kbs` untouched and warns; run `sync` again once it is
 up.
 
+**Routed servers (D187).** When `/health` reports `mount_mode: routed`, the KB is no longer part of
+the URL: the client writes **one** entry, `<server_name>`, pointed at the path the server names in
+`routed_path` (`/mcp/routed`), whatever the provider is bound to. The binding still decides which
+KBs that provider may use — routing changes the transport, not the authorization — and the
+generated instructions block names the `kb` value each KB's tools must be called with. Both facts
+are persisted in `.cartographer.yaml` (`server_mount_mode`, `server_routed_path`) so `doctor` and
+`status` can derive the expected entries offline.
+
+Switching an existing deployment between the two modes is a **reconnect**, not a silent rewrite: it
+changes the *shape* of every entry, which an incremental sync cannot see. `cartographer status`
+reports `mount mode changed: …` and names `cartographer reconnect`, the same answer D142 gives to a
+server-version change. The removal set covers both shapes, so a reconnect leaves no orphan entry
+from the previous mode.
+
 **Kiro and flat tool namespaces (D102).** Kiro's MCP tool namespace is flat across servers, unlike
 Claude Code/Codex/OpenCode which namespace per server: writing 2+ MCP entries for `kiro` (i.e.
 connecting to a 2+-KB server) leaves only one KB's tools reachable in a Kiro session unless the
 *server* mounts the others with a `tool_prefix` (`docs/deployment.md` §MCP tool-name prefix, D102).
 `connect`/`sync` warn on stderr in that case; the operator is expected to add
-`tool_prefix`/`tool_prefix_mode` server-side. Since D120 `/health` advertises each KB's effective
+`tool_prefix`/`tool_prefix_mode` server-side. The warning stays **silent against a routed server**:
+one entry cannot collide with itself, and routing is the other answer to the same problem. Since D120 `/health` advertises each KB's effective
 `tool_prefix`, so the client can see which KBs are already namespaced instead of reasoning from the
 precondition alone.
 

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -36,6 +36,16 @@ Tools marked **[A]** (advanced, `advancedToolNames` in `internal/mcpserver/visib
 
 **Agent governance vs. operator maintenance (D123).** `validate`, `lint`, `gate_check`, and `kb_status` are read-only governance diagnostics, not operator maintenance: the documented agent loop (`loop.md`, `use-cases.md`) runs them every session, and a descriptor-bound MCP host (one that can only invoke tools `tools/list` advertises, e.g. Codex) cannot call them by name the way a stdio/TUI agent can. They are therefore part of the default `agent` profile's core set, unlike `commit_gate`, `conflict_resolve`, `contradiction_report`, and the rest of `advancedToolNames`, which stay operator-only and advanced.
 
+**The `kb` argument on a routed mount (D187).** On the `/mcp/routed` endpoint of a server with
+`mcp.mount_mode: routed`, every tool below carries one extra property: `kb`, the Knowledge Base the
+call is for. It is **required** whenever the routed mount serves two or more KBs — the KB is never
+inferred — and optional when it serves exactly one, where there is nothing to disambiguate. A call
+without it is refused with an error naming the mounted KBs. The advertised set is the **union** of
+what the mounted KBs register, so a tool one KB gates off is still listed and is refused at dispatch
+for that KB, with an error naming the tool, the KB and the setting. On the per-KB endpoints
+(`/mcp?kb=` and `/mcp/<name>`) no `kb` argument exists and nothing below changes. See
+[`transport-auth.md`](transport-auth.md) §Mount modes.
+
 ### Reading and navigation
 
 | Tool | Purpose |

--- a/docs/decisions/transport-auth.md
+++ b/docs/decisions/transport-auth.md
@@ -749,3 +749,107 @@ off — now fails to start with a message naming the offending token and problem
 That is the intent, and it is the migration note the release needs. Valid
 configurations, including legacy unrestricted tokens and the auth-disabled local
 mode, are unchanged.
+
+---
+
+<a id="d187"></a>
+## D187 — One tool surface for a multi-KB server: a routed mount with the KB as an argument
+
+**Status: implemented.** Closes #242.
+
+**Context.** A client that uses N Knowledge Bases paid N copies of the same tool schemas in its
+fixed context, on **every** model round-trip. Measured against the running server (`tools/list` over
+HTTP, one call per mount) with three KBs configured for the `kiro` provider:
+
+```
+dante-kb       33 tools   27,392 bytes
+personal-kb    33 tools   27,491 bytes
+ai-team-kb     33 tools   27,458 bytes
+                          ------------
+                          82,341 bytes  ≈ 20,600 tokens
+```
+
+The three payloads are the same 33 tools, differing only by the [D102](#d102) prefix. On the session
+analysed, 204 round-trips carried all three: the two KBs never called accounted for ~2.8 million
+input tokens on their own, against 35,946 bytes for the entire rest of the fixed context (host
+prompt plus steering).
+
+Neither existing mitigation addresses it, because neither is about duplication. D65/D123's `agent`
+profile shrinks the tool set **per mount**; D102's prefix makes multi-KB *work* on a flat-namespace
+client. Multiply either by the number of mounts and the cost returns. The duplication is the
+**topology**: `MultiKBServer` mounts one independent `Server` per KB, each registering the full tool
+set, and the client writes one MCP entry per KB.
+
+**Decisions.**
+
+- **Opt-in, additive, default off.** `mcp.mount_mode: routed`
+  (`CARTOGRAPHER_MCP_MOUNT_MODE`, `--mount-mode`) adds `/mcp/routed` alongside the per-KB endpoints.
+  `?kb=` and `/mcp/<name>` keep byte-identical `tools/list` output and identical dispatch — pinned by
+  a test that compares the per-KB payload with and without routing enabled. Nothing changes for an
+  existing deployment until the key is set.
+- **The KB is an explicit tool argument, never inferred.** Every tool's `InputSchema` on the routed
+  mount carries a `kb` property, required whenever 2+ KBs are routed; a missing `kb` is an error
+  naming them. With exactly one KB routed it is optional — there is no ambiguity to resolve. A
+  default KB would land a write in the wrong archive on a model slip, which is precisely the failure
+  D102's flat-namespace warning exists to prevent; it must not return as a convenience.
+- **The exposed set is the union, refused per KB at dispatch.** An intersection would silently hide
+  `artifact_write` from a KB that allows it because a sibling does not. The union registers it once;
+  a call naming a KB that gates it off gets an error carrying the tool, the KB and the config key,
+  reusing `unknownToolMessage`'s existing setting lookup.
+- **Everything per-KB is resolved after `kb`, by dispatching into the per-KB server's own
+  `callTool`.** That is the whole of what a per-KB endpoint does with a call — the read/write
+  classification, the D118 authorization policy, the audit pair naming the real KB, the git lock and
+  commit wrapper — so the routed path cannot drift from the per-KB one. The routed `Server` carries
+  no audit log and an authorizer that defers every tool decision, so exactly one authorization and
+  one audit record happen, at the target.
+- **Metadata is authorized as "can reach at least one routed KB".** The fail-closed metadata gate
+  still has to answer for `initialize`/`tools/list`, and on a routed mount the honest generalization
+  is that a principal scoped to one KB legitimately lists the union and is refused per call on the
+  others.
+- **The `kb` property is injected at one point.** The routed mount decodes each tool's schema and
+  adds the property when it assembles its descriptor list — not by editing fifty schema literals,
+  which would drift the moment a tool is added.
+- **No tool-name prefix on a routed KB, and no KB named `routed`.** Prefixes disambiguate N mounts
+  on a flat namespace; with one mount there is nothing to disambiguate and a prefix would only
+  re-inflate the names this mount exists to shrink. The two requests are distinguished by who made
+  them: the **derived** prefix of D153's `kb-name` default is simply **not applied** under routing —
+  the operator never asked for it, and failing startup over a default nobody set would make the mode
+  unusable out of the box (found by the E2E scenario, which is what it is for). An **explicit**
+  `kbs[].tool_prefix` is a **fatal config error** naming the KB and the key: that one was asked for,
+  and it contradicts the request to route. A KB named `routed` would collide with the endpoint's own
+  path and is refused for the same reason. With routing off, `/mcp/routed` falls through to
+  `/mcp/<name>`, so such a KB keeps its endpoint.
+- **One channel for the choice.** A `?kb=` on `/mcp/routed` is `400`, the same rule `/mcp/<name>`
+  already applies to a conflicting `?kb=`: two channels for one choice are how they get to disagree.
+- **The client detects routing from `/health`, never assumes it.** The server emits
+  `mount_mode: "routed"` and `routed_path`, and omits both otherwise — which is exactly what a
+  pre-D187 server and a `per-kb` server look like to any client. `connect`/`sync` write **one** MCP
+  entry against a routed server, persist the fact in `.cartographer.yaml`
+  (`server_mount_mode`, `server_routed_path`), and `doctor` derives the expected entries from it
+  offline. The per-provider KB binding (D169/D170) is untouched: routing changes the transport, not
+  the authorization.
+- **The generated instructions name the tools as the agent will see them.** This is the part the
+  model actually reads, so a wrong name there would be worse than the duplication being removed. On
+  a routed server the block names the bare tools — a routed mount refuses a prefix — and states the
+  `kb` value to pass for that KB. The fact reaches `BuildManifest` through `Deps.RoutedMount`, the
+  same way D144 plumbed the prefix.
+- **A mode switch is a reconnect, reported and not healed.** It changes the *shape* of every entry,
+  which an incremental sync cannot see. `status` prints `mount mode changed: …` and names
+  `cartographer reconnect`, consistent with how D142 handles a server-version change. The removal
+  set already covers both shapes, so no orphan survives.
+- **The flat-namespace warning is silent against a routed server.** One entry cannot collide with
+  itself.
+
+**Invariants kept.** The per-KB endpoints' `tools/list` is byte-identical with routing on or off;
+`TestServer_ToolsProfile` keeps pinning the agent-visible set for a single-KB mount; audit records
+name the KB actually operated on, not the mount; `SetDisplayName`'s `cartographer:<kb>` handling for
+2+ per-KB mounts is unchanged.
+
+**Consequences.** Measured by the E2E scenario against a real three-KB server, `tools/list` goes
+from 81,633 bytes across three mounts to 31,969 on the routed one (115,932 → 46,196 on the Go test
+fixture, whose KBs register more tools) — the `kb` property makes each schema marginally
+larger, which is why the assertion is "well under two copies" rather than "exactly a third". New
+opt-in mount mode, no default change; minor bump.
+
+Details: `docs/transport-auth.md` §Mount modes, `docs/deployment.md` §HTTP routing,
+`docs/control-plane.md` §MCP API, `docs/configurator.md` §Routed servers.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -89,6 +89,11 @@ kbs:                          # (kbs[]) explicit KBs, local path or remote git (
                                                       # `team__<tool>` instead of `<tool>`. Wins over
                                                       # `mcp.tool_prefix_mode` below. See §MCP tool-name prefix.
 mcp:
+  mount_mode: "per-kb"          # (mcp.mount_mode) per-kb (default) | routed: how a multi-KB HTTP server
+                                # exposes its tools. routed adds /mcp/routed, one endpoint advertising
+                                # the union once with the KB as a `kb` tool argument. The per-KB
+                                # endpoints keep working unchanged. See docs/transport-auth.md
+                                # §Mount modes.
   tool_prefix_mode: "off"       # (mcp.tool_prefix_mode) off (default) | kb-name: global default for
                                 # every mounted KB that doesn't set its own kbs[].tool_prefix — kb-name
                                 # derives the prefix from the KB's own name. See §MCP tool-name prefix.
@@ -294,6 +299,7 @@ Every startup option has a corresponding environment variable (the CLI flag take
 | `CARTOGRAPHER_AUDIT_LOG` | — | Path to the audit log's JSONL file (e.g. `/data/audit.log`). If empty, audit is disabled. |
 | `CARTOGRAPHER_AUDIT_KEY` | — | Ed25519 seed (hex, 64 chars) for signing entries. Requires `CARTOGRAPHER_AUDIT_LOG`. |
 | `CARTOGRAPHER_SERVER_URL` | — | **Client** (not server): default server URL for `cartographer connect` on the client machine when no `.cartographer.yaml` exists yet. Precedence: existing yaml > env > `http://localhost:39273/mcp` (D64, `internal/clientconfig.Default`). |
+| `CARTOGRAPHER_MCP_MOUNT_MODE` | `--mount-mode` | Multi-KB HTTP mount topology: `per-kb` (default) \| `routed`. `routed` adds `/mcp/routed`, one endpoint advertising the union of the tools once with the KB as a `kb` tool argument; the per-KB endpoints are unchanged. A KB with `tool_prefix` cannot be routed (fatal at startup). D187, see `transport-auth.md` §Mount modes. |
 | `CARTOGRAPHER_MCP_TOOL_PREFIX_MODE` | — | Global default for `mcp.tool_prefix_mode`: `off` (default) \| `kb-name`. Overridden per KB by `kbs[].tool_prefix` (D102, see §MCP tool-name prefix). |
 | `CARTOGRAPHER_MCP_ALLOWED_ORIGINS` | — | Comma-separated browser origins allowed to reach `/mcp`, scheme and port included. Empty (default) accepts only an `Origin` matching the request's own `Host`; `*` accepts any; a request without an `Origin` header is unaffected (D128, → `transport-auth.md` §Origin). |
 
@@ -428,11 +434,20 @@ If both `/mcp/<name>` and `?kb=` are present and disagree, the request is reject
 conflicting kb selection` rather than silently picking one; an unknown `<name>` (either form) is
 `404 unknown kb`.
 
-For a client connected to a multi-KB server, `cartographer connect` and `cartographer sync` use
-the query form deliberately: they create one provider MCP entry per mounted KB,
-`<server_name>-<kb> → /mcp?kb=<kb>`. This makes the selected KB explicit to every current client
-without requiring a client to understand path routing. A one-KB server remains a single bare
-`<server_name> → /mcp` entry for backwards compatibility.
+A fourth route exists when `mcp.mount_mode: routed` is set (D187): `/mcp/routed` serves every
+mounted KB through one endpoint, advertising the union of the tools exactly once, with the KB
+carried as a `kb` tool argument. It is **additive** — the three routes above keep their exact
+behaviour, `tools/list` output included. A `?kb=` on `/mcp/routed` is `400 conflicting kb
+selection`: there the KB travels in the tool arguments. See `docs/transport-auth.md` §Mount modes.
+
+For a client connected to a multi-KB server in the default `per-kb` mode, `cartographer connect`
+and `cartographer sync` use the query form deliberately: they create one provider MCP entry per
+mounted KB, `<server_name>-<kb> → /mcp?kb=<kb>`. This makes the selected KB explicit to every
+current client without requiring a client to understand path routing. A one-KB server remains a
+single bare `<server_name> → /mcp` entry for backwards compatibility. Against a **routed** server
+they write one entry instead, `<server_name> → /mcp/routed`, discovered from `/health`'s
+`mount_mode`/`routed_path` — the per-provider KB binding still decides which KBs that client may
+use, because routing changes the transport, not the authorization.
 
 ### Runtime secrets
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -112,6 +112,21 @@ both mounted unprefixed and asserts the D144 startup warning names them, while
 `tools/list` stays unchanged on both endpoints: the warning is a diagnostic,
 never an implicit prefix.
 
+**The routed mount is asserted on the wire, not only in Go.** `17_routed_multikb`
+starts a real three-KB server with `mcp.mount_mode: routed` and drives it with
+`curl`: `/health` must advertise `mount_mode` and `routed_path`, `/mcp/routed`
+must list each tool exactly once with a `kb` argument and in far fewer bytes than
+the per-KB mounts summed, a call must reach the KB it names, a call without `kb`
+must be refused **naming the mounted KBs**, and `?kb=` on that URL must be `400`.
+It then asserts the additive promise from the other side — the per-KB endpoints
+still answer and their `tools/list` has gained no `kb` argument — and that
+`connect` writes exactly **one** MCP entry, pointed at `/mcp/routed`.
+
+The scenario earns its keep: it is what caught that D153's derived `kb-name`
+prefix, which nobody configures explicitly, was making the routed mode fail at
+startup out of the box. No Go test could see it, because the defect lived in the
+wiring between the config default and the mount, not in either.
+
 ### Packaging (`install.sh` and the generated Cask)
 
 `make test-install` runs the network-free suite under `test/install/` plus

--- a/docs/transport-auth.md
+++ b/docs/transport-auth.md
@@ -5,7 +5,7 @@
 | Transport | Interface | Authorization |
 |---|---|---|
 | stdio | Newline-delimited JSON-RPC 2.0, one session per process | Process/user boundary; no bearer token |
-| HTTP | `POST /mcp`, `/mcp?kb=<name>` or `/mcp/<name>` | Optional static bearer token |
+| HTTP | `POST /mcp`, `/mcp?kb=<name>`, `/mcp/<name>` or `/mcp/routed` | Optional static bearer token |
 
 HTTP requests return complete JSON-RPC responses. Cartographer does not expose
 the legacy two-endpoint SSE transport or an HTTP streaming session, and issues
@@ -34,6 +34,65 @@ request itself), since it validates its own static bearer tokens rather than
 delegating to a separate authorization server. Cartographer does **not**
 implement an OAuth authorization server, dynamic client registration or JWT
 validation; configured tokens are opaque static bearer values.
+
+### Mount modes
+
+A multi-KB HTTP server can expose its tools two ways. `mcp.mount_mode`
+(`CARTOGRAPHER_MCP_MOUNT_MODE`, `--mount-mode`) selects which, and the two
+**coexist**: enabling routing adds an endpoint, it never removes or alters the
+per-KB ones.
+
+| Mode | Endpoints | `tools/list` | Selecting the KB |
+|---|---|---|---|
+| `per-kb` (default) | `/mcp?kb=<name>`, `/mcp/<name>` | one full copy per KB | in the URL |
+| `routed` | the above, **plus** `/mcp/routed` | one copy of the union, on the routed endpoint | a `kb` tool argument |
+
+**Why routing exists.** A client using N KBs writes N MCP server entries and
+carries N copies of the same tool schemas in its fixed context, on every model
+round-trip. Measured against a running server with three KBs, `tools/list`
+returned 82,341 bytes across the three mounts — more than twice the whole rest
+of that session's fixed context — and the two KBs never called still paid for
+themselves on all 204 round-trips. The tool-name prefix
+([D102](decisions/transport-auth.md#d102)) makes multi-KB *work* on a
+flat-namespace client and the `agent` profile (D65/D123) shrinks the set *per
+mount*; neither removes the duplication, because the duplication is the
+topology.
+
+**The KB is an argument, never inferred.** On the routed endpoint every tool's
+input schema carries a `kb` property, **required** whenever two or more KBs are
+routed; a call without it is refused with an error naming the mounted KBs.
+With exactly one KB routed there is nothing to disambiguate, so `kb` is
+optional. A default KB would land a write in the wrong archive on a model slip,
+which is precisely what D102's flat-namespace warning exists to prevent.
+
+**The advertised set is the union.** A tool one KB gates off — `artifact_write`
+under `kbs[].allow_artifact_write` — is still registered once, and refused at
+dispatch for the KB that gates it, with an error naming the tool, the KB and the
+setting. The alternative, an intersection, would silently hide a tool from a KB
+that allows it because a sibling does not.
+
+**Everything per-KB is resolved after `kb`**: the read/write classification, the
+per-KB authorization policy, the git lock and commit wrapper, and the audit
+record's KB. The routed endpoint dispatches into the target KB's own server, so
+it cannot drift from the per-KB path.
+
+**Prefixes and routing do not combine.** A routed mount has no flat namespace
+left to disambiguate, so the `kb-name` *derived* default (D153) is **not applied**
+when routing: the operator never asked for it, and it would only re-inflate the
+names routing exists to shrink. An **explicit** `kbs[].tool_prefix` is a different
+matter — that one was asked for, and it contradicts the request to route, so it is
+refused at startup naming the KB and the key. A KB named `routed` is refused too:
+it would A `?kb=` on the routed URL is refused with
+400: the KB travels in the tool arguments there, and two channels for one choice
+are how they get to disagree.
+
+`GET /health` reports `mount_mode: "routed"` and `routed_path` when routing is
+on, and omits both otherwise — which is what an older client and a `per-kb`
+server both see. `cartographer connect`/`sync` read it and write **one** MCP
+entry for a routed server. Switching an existing deployment between modes
+changes the *shape* of every entry, which an incremental sync cannot see:
+`cartographer status` reports the mismatch and tells you to run
+`cartographer reconnect`. It does not heal it.
 
 ### Protocol versions: two eras at once
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -107,7 +107,18 @@ type Health struct {
 	Version string      `json:"version"`
 	Ready   *bool       `json:"ready"`
 	KBs     *[]HealthKB `json:"kbs"`
+	// MountMode is "routed" when the server serves every KB through a single
+	// endpoint with the KB as a tool argument (D187). Empty — which is what a
+	// per-KB server and every pre-D187 server decode to — means the historical
+	// one-endpoint-per-KB topology. Additive and byte-compatible.
+	MountMode string `json:"mount_mode,omitempty"`
+	// RoutedPath is that endpoint's path, named by the server rather than
+	// assumed by the client, so the two cannot drift.
+	RoutedPath string `json:"routed_path,omitempty"`
 }
+
+// Routed reports whether this server serves a routed mount (D187).
+func (h *Health) Routed() bool { return h != nil && h.MountMode == "routed" && h.RoutedPath != "" }
 
 // HealthKB is the additive per-KB item returned by a MultiKB server's
 // /health endpoint. A single-KB (and older) server omits the kbs field

--- a/internal/clientconfig/clientconfig.go
+++ b/internal/clientconfig/clientconfig.go
@@ -36,6 +36,17 @@ type Config struct {
 	// longer written by Save.
 	KnownKBs []string `yaml:"known_kbs,omitempty"`
 
+	// ServerMountMode records the mount topology the server advertised at the
+	// last successful connect/sync (D187): "routed" when it serves every KB
+	// through one endpoint with the KB as a tool argument, empty for the
+	// historical one-endpoint-per-KB topology. SERVER-owned, like KnownKBs.
+	// ServerRoutedPath is that endpoint's path as the *server* named it, so the
+	// client never assumes it. Both are what lets `doctor` and `status` derive
+	// the expected MCP entries without reaching the network, and what lets
+	// `status` report a mode change rather than silently healing it.
+	ServerMountMode  string `yaml:"server_mount_mode,omitempty"`
+	ServerRoutedPath string `yaml:"server_routed_path,omitempty"`
+
 	// Clients is the per-provider KB binding (D169): which KBs each connected
 	// provider may receive. USER-owned — never written by connect/sync.
 	// Always resolve it through BoundKBs, never by reading the map directly:
@@ -107,20 +118,22 @@ type ClientBinding struct {
 // pre-D169 client. KBs itself is read-only — Save never emits it again, so the
 // first write after the upgrade completes the migration.
 type yamlConfig struct {
-	ServerURL    string                            `yaml:"server_url"`
-	ServerName   string                            `yaml:"server_name"`
-	Auth         bool                              `yaml:"auth"`
-	TokenEnv     string                            `yaml:"token_env"`
-	Agents       []string                          `yaml:"agents"`
-	KBs          []string                          `yaml:"kbs,omitempty"`
-	KnownKBs     *[]string                         `yaml:"known_kbs,omitempty"`
-	Clients      map[string]ClientBinding          `yaml:"clients,omitempty"`
-	Trust        *bool                             `yaml:"trust,omitempty"`
-	SearchRoots  []string                          `yaml:"search_roots,omitempty"`
-	SearchDepth  int                               `yaml:"search_depth,omitempty"`
-	Paths        map[string]string                 `yaml:"paths,omitempty"`
-	SigningKeys  map[string][]string               `yaml:"signing_keys,omitempty"`
-	MCPApprovals map[string]map[string]MCPApproval `yaml:"mcp_approvals,omitempty"`
+	ServerURL        string                            `yaml:"server_url"`
+	ServerName       string                            `yaml:"server_name"`
+	Auth             bool                              `yaml:"auth"`
+	TokenEnv         string                            `yaml:"token_env"`
+	Agents           []string                          `yaml:"agents"`
+	KBs              []string                          `yaml:"kbs,omitempty"`
+	KnownKBs         *[]string                         `yaml:"known_kbs,omitempty"`
+	ServerMountMode  string                            `yaml:"server_mount_mode,omitempty"`
+	ServerRoutedPath string                            `yaml:"server_routed_path,omitempty"`
+	Clients          map[string]ClientBinding          `yaml:"clients,omitempty"`
+	Trust            *bool                             `yaml:"trust,omitempty"`
+	SearchRoots      []string                          `yaml:"search_roots,omitempty"`
+	SearchDepth      int                               `yaml:"search_depth,omitempty"`
+	Paths            map[string]string                 `yaml:"paths,omitempty"`
+	SigningKeys      map[string][]string               `yaml:"signing_keys,omitempty"`
+	MCPApprovals     map[string]map[string]MCPApproval `yaml:"mcp_approvals,omitempty"`
 }
 
 // Default returns a Config with the same defaults as configurator.DefaultConfig.
@@ -177,20 +190,22 @@ func Load(dir string) (*Config, error) {
 		delete(extra, key)
 	}
 	cfg := Config{
-		ServerURL:    y.ServerURL,
-		ServerName:   y.ServerName,
-		Auth:         y.Auth,
-		TokenEnv:     y.TokenEnv,
-		Agents:       y.Agents,
-		KnownKBs:     y.KBs, // legacy alias; overridden below when known_kbs is present
-		Clients:      y.Clients,
-		Trust:        true, // absent `trust` key defaults to true, see yamlConfig doc
-		SearchRoots:  y.SearchRoots,
-		SearchDepth:  y.SearchDepth,
-		Paths:        y.Paths,
-		SigningKeys:  y.SigningKeys,
-		MCPApprovals: y.MCPApprovals,
-		Extra:        extra,
+		ServerURL:        y.ServerURL,
+		ServerName:       y.ServerName,
+		Auth:             y.Auth,
+		TokenEnv:         y.TokenEnv,
+		Agents:           y.Agents,
+		KnownKBs:         y.KBs, // legacy alias; overridden below when known_kbs is present
+		ServerMountMode:  y.ServerMountMode,
+		ServerRoutedPath: y.ServerRoutedPath,
+		Clients:          y.Clients,
+		Trust:            true, // absent `trust` key defaults to true, see yamlConfig doc
+		SearchRoots:      y.SearchRoots,
+		SearchDepth:      y.SearchDepth,
+		Paths:            y.Paths,
+		SigningKeys:      y.SigningKeys,
+		MCPApprovals:     y.MCPApprovals,
+		Extra:            extra,
 	}
 	if y.KnownKBs != nil {
 		// Present — including present and empty — always wins over the legacy
@@ -214,19 +229,21 @@ func Save(dir string, cfg *Config) error {
 		return fmt.Errorf("clientconfig: mkdir %s: %w", dir, err)
 	}
 	y := yamlConfig{
-		ServerURL:    cfg.ServerURL,
-		ServerName:   cfg.ServerName,
-		Auth:         cfg.Auth,
-		TokenEnv:     cfg.TokenEnv,
-		Agents:       cfg.Agents,
-		KnownKBs:     &cfg.KnownKBs, // always emitted; the legacy `kbs` key is not written again (D169)
-		Clients:      cfg.Clients,
-		Trust:        &cfg.Trust,
-		SearchRoots:  cfg.SearchRoots,
-		SearchDepth:  cfg.SearchDepth,
-		Paths:        cfg.Paths,
-		SigningKeys:  cfg.SigningKeys,
-		MCPApprovals: cfg.MCPApprovals,
+		ServerURL:        cfg.ServerURL,
+		ServerName:       cfg.ServerName,
+		Auth:             cfg.Auth,
+		TokenEnv:         cfg.TokenEnv,
+		Agents:           cfg.Agents,
+		KnownKBs:         &cfg.KnownKBs, // always emitted; the legacy `kbs` key is not written again (D169)
+		ServerMountMode:  cfg.ServerMountMode,
+		ServerRoutedPath: cfg.ServerRoutedPath,
+		Clients:          cfg.Clients,
+		Trust:            &cfg.Trust,
+		SearchRoots:      cfg.SearchRoots,
+		SearchDepth:      cfg.SearchDepth,
+		Paths:            cfg.Paths,
+		SigningKeys:      cfg.SigningKeys,
+		MCPApprovals:     cfg.MCPApprovals,
 	}
 	data, err := yaml.Marshal(&y)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,14 @@ type Config struct {
 
 // MCPConfig controls MCP-protocol-level server behaviour.
 type MCPConfig struct {
+	// MountMode selects how a multi-KB HTTP server exposes its tools:
+	// "per-kb" (default) mounts one MCP server per KB, each advertising its
+	// own full copy of the tool schemas — byte-identical to pre-D187
+	// behaviour; "routed" additionally serves /mcp/routed, one endpoint
+	// advertising the union of the tools exactly once with the KB travelling
+	// as a required `kb` tool argument. The per-KB endpoints keep working in
+	// both modes: routing is an addition, never a replacement.
+	MountMode string
 	// ToolPrefixMode is the default per-KB tool-name prefix policy for KBs
 	// that don't set an explicit KBSpec.ToolPrefix: "off" (default) leaves
 	// tool names unprefixed, byte-identical to pre-D102 behaviour; "kb-name"
@@ -270,7 +278,7 @@ func Default() *Config {
 		// no error at call time — silent wrong answers from a plausible source,
 		// as the default configuration's behaviour. "off" is retained as an
 		// explicit, documented opt-out.
-		MCP: MCPConfig{ToolPrefixMode: "kb-name"},
+		MCP: MCPConfig{ToolPrefixMode: "kb-name", MountMode: MountModePerKB},
 	}
 }
 
@@ -295,6 +303,7 @@ type rawTools struct {
 }
 
 type rawMCP struct {
+	MountMode      string   `yaml:"mount_mode"`
 	ToolPrefixMode string   `yaml:"tool_prefix_mode"`
 	AllowedOrigins []string `yaml:"allowed_origins"`
 }
@@ -399,6 +408,9 @@ func Load(path string) (*Config, error) {
 		cfg.ToolsProfile = normalizeToolsProfile(raw.Tools.Profile)
 	}
 
+	if raw.MCP.MountMode != "" {
+		cfg.MCP.MountMode = normalizeMountMode(raw.MCP.MountMode)
+	}
 	if raw.MCP.ToolPrefixMode != "" {
 		cfg.MCP.ToolPrefixMode = normalizeToolPrefixMode(raw.MCP.ToolPrefixMode)
 	}
@@ -468,6 +480,9 @@ func FromEnv(cfg *Config) {
 	if v := os.Getenv("CARTOGRAPHER_TOOLS_PROFILE"); v != "" {
 		cfg.ToolsProfile = normalizeToolsProfile(v)
 	}
+	if v := os.Getenv("CARTOGRAPHER_MCP_MOUNT_MODE"); v != "" {
+		cfg.MCP.MountMode = normalizeMountMode(v)
+	}
 	if v := os.Getenv("CARTOGRAPHER_MCP_TOOL_PREFIX_MODE"); v != "" {
 		cfg.MCP.ToolPrefixMode = normalizeToolPrefixMode(v)
 	}
@@ -488,6 +503,7 @@ type FlagOverrides struct {
 	GitAutocommit *bool
 	GitSync       *bool
 	ToolsProfile  *string // "agent" | "full"
+	MountMode     *string // "per-kb" | "routed"
 }
 
 // ApplyFlags layers the explicitly-passed serve flags on top of cfg.
@@ -523,6 +539,9 @@ func ApplyFlags(cfg *Config, o FlagOverrides) {
 	if o.ToolsProfile != nil {
 		cfg.ToolsProfile = normalizeToolsProfile(*o.ToolsProfile)
 	}
+	if o.MountMode != nil {
+		cfg.MCP.MountMode = normalizeMountMode(*o.MountMode)
+	}
 }
 
 // normalizeGitProfile canonicalizes the profile spelling. It intentionally
@@ -540,6 +559,26 @@ func normalizeToolsProfile(v string) string {
 		return "full"
 	}
 	return "agent"
+}
+
+// Mount modes for a multi-KB HTTP server (D187).
+const (
+	// MountModePerKB is the historical behaviour: one MCP server per KB, each
+	// advertising its own copy of every tool schema.
+	MountModePerKB = "per-kb"
+	// MountModeRouted additionally serves one endpoint advertising the union
+	// of the tools once, with the KB as a required tool argument.
+	MountModeRouted = "routed"
+)
+
+// normalizeMountMode maps a mount_mode spelling onto the canonical
+// "per-kb"/"routed". Anything unrecognized falls back to "per-kb"
+// (fail-closed: no behavioural change for existing deployments/clients).
+func normalizeMountMode(v string) string {
+	if strings.ToLower(strings.TrimSpace(v)) == MountModeRouted {
+		return MountModeRouted
+	}
+	return MountModePerKB
 }
 
 // normalizeToolPrefixMode maps a tool_prefix_mode spelling onto the

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -147,7 +147,7 @@ func TestLoadFullYAML(t *testing.T) {
 		Sops:         SopsConfig{AgeKeyFile: "/etc/cartographer/age.key", AgeKeyDir: "/etc/kb-sops-keys"},
 		ToolsProfile: "full",
 		// The YAML sets no mcp.tool_prefix_mode, so the default applies (kb-name since D153).
-		MCP: MCPConfig{ToolPrefixMode: "kb-name"},
+		MCP: MCPConfig{ToolPrefixMode: "kb-name", MountMode: MountModePerKB},
 	}
 
 	if !reflect.DeepEqual(cfg, want) {
@@ -403,5 +403,53 @@ func TestParseTokenSpecsKeepsTokenlessEntry(t *testing.T) {
 func TestParseTokenSpecsIgnoresPureSeparators(t *testing.T) {
 	if specs := parseTokenSpecs("a,,b"); len(specs) != 2 {
 		t.Errorf("parseTokenSpecs = %+v, want two tokens", specs)
+	}
+}
+
+// TestMountModeDefaultIsPerKB pins D187's opt-in guarantee: an existing
+// configuration keeps the per-KB mount topology, byte-identical to before.
+func TestMountModeDefaultIsPerKB(t *testing.T) {
+	cfg := Default()
+	if cfg.MCP.MountMode != MountModePerKB {
+		t.Errorf("default MountMode = %q, want %q", cfg.MCP.MountMode, MountModePerKB)
+	}
+}
+
+// TestMountModePrecedence walks flag > env > YAML > default for mcp.mount_mode.
+func TestMountModePrecedence(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("mcp:\n  mount_mode: routed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.MCP.MountMode != MountModeRouted {
+		t.Fatalf("YAML MountMode = %q, want %q", cfg.MCP.MountMode, MountModeRouted)
+	}
+
+	// env beats YAML
+	t.Setenv("CARTOGRAPHER_MCP_MOUNT_MODE", "per-kb")
+	FromEnv(cfg)
+	if cfg.MCP.MountMode != MountModePerKB {
+		t.Fatalf("env MountMode = %q, want %q", cfg.MCP.MountMode, MountModePerKB)
+	}
+
+	// flag beats env
+	routed := MountModeRouted
+	ApplyFlags(cfg, FlagOverrides{MountMode: &routed})
+	if cfg.MCP.MountMode != MountModeRouted {
+		t.Fatalf("flag MountMode = %q, want %q", cfg.MCP.MountMode, MountModeRouted)
+	}
+
+	// an unrecognized spelling falls back to the historical topology rather
+	// than enabling a mode nobody asked for
+	bogus := "sideways"
+	ApplyFlags(cfg, FlagOverrides{MountMode: &bogus})
+	if cfg.MCP.MountMode != MountModePerKB {
+		t.Errorf("unrecognized MountMode = %q, want %q", cfg.MCP.MountMode, MountModePerKB)
 	}
 }

--- a/internal/mcpserver/httpserver.go
+++ b/internal/mcpserver/httpserver.go
@@ -159,6 +159,15 @@ type MultiKBServer struct {
 	servers map[string]*Server // one MCP server per KB
 	kbs     []KBInfo
 	version string
+	// routed is the optional single endpoint advertising the union of the
+	// mounted KBs' tools once, with the KB as a tool argument (D187). Nil —
+	// the default — means only the per-KB endpoints are served. See
+	// routedmount.go.
+	routed *Server
+	// routedNames are the KB names the routed mount serves, in deterministic
+	// order, used to decide whether `kb` may be omitted and to name them in
+	// the error when it may not.
+	routedNames []string
 }
 
 // readiness folds every mounted KB's audit state into one verdict, and returns
@@ -315,6 +324,14 @@ func (m *MultiKBServer) Handler() http.Handler {
 				"kbs":     kbs,
 				"ready":   ready,
 			}
+			// D187: the client needs to know the mount topology before it
+			// writes a single MCP entry, and /health is the probe it already
+			// performs first. Emitted only when routing is on, so an older
+			// client and a per-KB server stay byte-identical.
+			if m.routed != nil {
+				result["mount_mode"] = "routed"
+				result["routed_path"] = RoutedMountPath
+			}
 			json.NewEncoder(w).Encode(result)
 			return
 
@@ -374,6 +391,21 @@ func (m *MultiKBServer) Handler() http.Handler {
 				result["overflow"] = overflow
 			}
 			json.NewEncoder(w).Encode(result)
+			return
+
+		// D187: the routed mount. The KB travels in the tool arguments here, so
+		// a ?kb= on this URL is a second channel for the same choice — refused
+		// rather than silently preferred, the same rule /mcp/<name> already
+		// applies to a conflicting ?kb=. The guard is on m.routed, not on the
+		// path alone: with no routed mount enabled the path falls through to
+		// /mcp/<name>, so a KB that happens to be named "routed" keeps its own
+		// endpoint instead of being shadowed by a mode nobody turned on.
+		case r.URL.Path == RoutedMountPath && m.routed != nil:
+			if r.URL.Query().Get("kb") != "" {
+				http.Error(w, "conflicting kb selection: the routed mount takes the KB as a tool argument, not as a query parameter", http.StatusBadRequest)
+				return
+			}
+			m.routed.handleMCP(w, r)
 			return
 
 		case r.URL.Path == "/mcp":

--- a/internal/mcpserver/routedmount.go
+++ b/internal/mcpserver/routedmount.go
@@ -1,0 +1,298 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+)
+
+// routedmount.go (D187) — one endpoint for a multi-KB server.
+//
+// A client that uses N Knowledge Bases pays N copies of the same tool schemas
+// in its fixed context, on every model round-trip: measured against a running
+// server with three KBs, tools/list returned 82,341 bytes of which two thirds
+// were duplicates. D102's tool-name prefix makes multi-KB *work* on a
+// flat-namespace client; the D65/D123 agent profile shrinks the set *per
+// mount*. Neither removes the duplication, because the duplication is the
+// mount topology.
+//
+// The routed mount registers the union of the mounted KBs' tool descriptors
+// exactly once and carries the KB as an explicit `kb` tool argument. It is
+// additive: MountKB/MountKBWithPrefix and the ?kb=/ /mcp/<name> endpoints keep
+// their exact behaviour, tools/list output included, so nobody's working setup
+// changes on upgrade.
+//
+// Everything that is per-KB is resolved *after* `kb`: the read/write
+// classification, the auth policy (D118), the git lock and commit wrapper, the
+// audit record's KB, and whether a gated tool exists at all. That is achieved
+// by dispatching into the target KB's own Server.callTool, which is the whole
+// of what a per-KB endpoint does with a call — so the routed path cannot drift
+// from the per-KB one.
+
+// RoutedMountPath is the URL path the routed mount is served on. It is
+// deliberately not /mcp: a bare /mcp already auto-routes a single-KB server and
+// requires ?kb= otherwise, and overloading it would make the same URL mean two
+// different things depending on configuration.
+const RoutedMountPath = "/mcp/routed"
+
+// routedKBArgument is the tool argument naming the KB a call is for.
+const routedKBArgument = "kb"
+
+// EnableRoutedMount builds the routed mount over the KBs already mounted on m.
+// Call it after every MountKB/MountKBWithPrefix. It returns an error when the
+// configuration is inconsistent; on success the routed endpoint is served
+// alongside the per-KB ones.
+//
+// A KB carrying a tool-name prefix (D102) cannot be routed: prefixes exist to
+// disambiguate N mounts sharing one flat namespace, and with a single mount
+// there is nothing to disambiguate — a prefix would only re-inflate the names
+// this mount exists to shrink. Routing and prefixing are alternative answers to
+// the same problem, so asking for both is a config error, not a silently
+// ignored setting.
+func (m *MultiKBServer) EnableRoutedMount(version string, setup func(s *Server)) error {
+	if len(m.servers) == 0 {
+		return errors.New("routed mount: no KB is mounted")
+	}
+	names := m.mountedNames()
+	for _, name := range names {
+		if name == strings.TrimPrefix(RoutedMountPath, "/mcp/") {
+			return fmt.Errorf("KB %q collides with the routed mount's own path %s: rename the KB, or serve it per-KB",
+				name, RoutedMountPath)
+		}
+	}
+	for _, info := range m.kbs {
+		if info.ToolPrefix != "" {
+			return fmt.Errorf("KB %q: tool_prefix %q cannot be combined with mcp.mount_mode: routed — "+
+				"a routed mount exposes one copy of each tool, so there is no flat namespace to disambiguate; "+
+				"drop the prefix for this KB or serve it per-KB", info.Name, info.ToolPrefix)
+		}
+	}
+
+	routed := New(version)
+	routed.SetDisplayName("cartographer")
+	if setup != nil {
+		setup(routed)
+	}
+	// The real authorization decision belongs to the target KB and is taken
+	// inside its own callTool, after `kb` has been resolved. What this
+	// authorizer still has to answer is the metadata gate (initialize, ping,
+	// tools/list): a caller with no resolvable principal must be denied rather
+	// than implicitly treated as having full access. On a routed mount the
+	// honest rule is "can reach at least one of the routed KBs" — a principal
+	// scoped to one KB legitimately lists the union and is refused per call on
+	// the others.
+	routed.SetAuthorizer(func(ctx context.Context, tool string, args json.RawMessage) error {
+		if tool != "" {
+			return nil
+		}
+		var lastErr error = errors.New("forbidden")
+		for _, name := range names {
+			if err := m.servers[name].authorize(ctx, "", args); err == nil {
+				return nil
+			} else {
+				lastErr = err
+			}
+		}
+		return lastErr
+	})
+
+	for _, t := range m.unionTools() {
+		routed.RegisterTool(t)
+	}
+
+	m.routed = routed
+	m.routedNames = names
+	return nil
+}
+
+// mountedNames returns the mounted KB names in deterministic order.
+func (m *MultiKBServer) mountedNames() []string {
+	names := make([]string, 0, len(m.servers))
+	for name := range m.servers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// unionTools assembles the routed mount's tool list: every tool registered by
+// any mounted KB, once, in the registration order of the first KB that has it,
+// with the `kb` argument injected into each schema at this single point rather
+// than in fifty schema literals.
+//
+// The exposed set is the **union**, not the intersection. An intersection would
+// silently hide artifact_write from a KB that allows it because a sibling KB
+// does not; the union registers it once and refuses it per KB at dispatch, with
+// an error naming the KB and the setting that would enable it — which is the
+// answer a caller can act on.
+func (m *MultiKBServer) unionTools() []Tool {
+	seen := map[string]bool{}
+	var out []Tool
+	for _, name := range m.mountedNames() {
+		srv := m.servers[name]
+		srv.mu.Lock()
+		ord := append([]string(nil), srv.toolsOrd...)
+		srv.mu.Unlock()
+		for _, toolName := range ord {
+			if seen[toolName] {
+				continue
+			}
+			seen[toolName] = true
+			srv.mu.Lock()
+			t := srv.tools[toolName]
+			srv.mu.Unlock()
+			if t == nil {
+				continue
+			}
+			routedTool := *t
+			routedTool.InputSchema = withKBProperty(t.InputSchema, len(m.servers) > 1)
+			routedTool.Handler = m.routedHandler(toolName)
+			out = append(out, routedTool)
+		}
+	}
+	return out
+}
+
+// routedHandler resolves `kb`, strips it from the arguments and hands the call
+// to that KB's own Server.callTool — the same entry point the per-KB endpoint
+// uses, so authorization, audit, the read/write classification and the git
+// wrapper are the per-KB ones, unchanged, applied to the KB actually named.
+func (m *MultiKBServer) routedHandler(toolName string) func(context.Context, json.RawMessage) (ToolResult, error) {
+	return func(ctx context.Context, args json.RawMessage) (ToolResult, error) {
+		kbName, rest, err := splitKBArgument(args)
+		if err != nil {
+			return errorResult(err.Error()), nil
+		}
+		if kbName == "" {
+			if len(m.routedNames) == 1 {
+				// Exactly one KB routed: there is no ambiguity to resolve, so
+				// requiring the argument would be ceremony.
+				kbName = m.routedNames[0]
+			} else {
+				return errorResult(fmt.Sprintf(
+					"%q is required on this endpoint: it serves %d Knowledge Bases (%s) and the KB is never inferred",
+					routedKBArgument, len(m.routedNames), strings.Join(m.routedNames, ", "))), nil
+			}
+		}
+		srv, ok := m.servers[kbName]
+		if !ok {
+			return errorResult(fmt.Sprintf("unknown kb %q — this endpoint serves: %s",
+				kbName, strings.Join(m.describeRoutedKBs(), ", "))), nil
+		}
+		srv.mu.Lock()
+		_, registered := srv.tools[toolName]
+		srv.mu.Unlock()
+		if !registered {
+			// The union exposed it because a sibling KB has it. Attribute the
+			// refusal: the caller must learn which KB refused and why, not that
+			// a tool it can see does not exist.
+			return errorResult(fmt.Sprintf("kb %q: %s", kbName, unknownToolMessage(toolName))), nil
+		}
+		return srv.callTool(ctx, toolName, rest), nil
+	}
+}
+
+// describeRoutedKBs names the mounted KBs with their state, so an error about
+// an unknown kb carries the same information readiness() already assembles
+// rather than a bare list.
+func (m *MultiKBServer) describeRoutedKBs() []string {
+	_, kbs, degraded := m.readiness()
+	bad := map[string]bool{}
+	for _, d := range degraded {
+		bad[d] = true
+	}
+	out := make([]string, 0, len(kbs))
+	for _, info := range kbs {
+		state := info.Status
+		if bad[info.Name] {
+			state = "degraded"
+		}
+		out = append(out, fmt.Sprintf("%s (%s)", info.Name, state))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// splitKBArgument extracts the `kb` argument and returns the remaining
+// arguments with it removed, so the per-KB handler receives exactly the
+// arguments it would have received on its own endpoint.
+func splitKBArgument(args json.RawMessage) (string, json.RawMessage, error) {
+	if len(args) == 0 {
+		return "", json.RawMessage(`{}`), nil
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(args, &raw); err != nil {
+		return "", nil, fmt.Errorf("invalid params: %v", err)
+	}
+	v, ok := raw[routedKBArgument]
+	if !ok {
+		return "", args, nil
+	}
+	var name string
+	if err := json.Unmarshal(v, &name); err != nil {
+		return "", nil, fmt.Errorf("invalid params: %q must be a string", routedKBArgument)
+	}
+	delete(raw, routedKBArgument)
+	rest, err := json.Marshal(raw)
+	if err != nil {
+		return "", nil, fmt.Errorf("invalid params: %v", err)
+	}
+	return strings.TrimSpace(name), rest, nil
+}
+
+// withKBProperty injects the `kb` property into one tool's input schema, and
+// marks it required when more than one KB is routed. It edits the decoded
+// schema object rather than the JSON text: a tool whose schema is absent or
+// not an object is given the minimal one, so no tool can reach the routed
+// mount without the argument it is dispatched by.
+func withKBProperty(schema json.RawMessage, required bool) json.RawMessage {
+	obj := map[string]any{}
+	if len(schema) > 0 {
+		if err := json.Unmarshal(schema, &obj); err != nil {
+			obj = map[string]any{}
+		}
+	}
+	obj["type"] = "object"
+
+	props, _ := obj["properties"].(map[string]any)
+	if props == nil {
+		props = map[string]any{}
+	}
+	desc := "Knowledge Base this call is for; optional while this endpoint serves a single KB."
+	if required {
+		desc = "Knowledge Base this call is for. Required: this endpoint serves several KBs and never infers one."
+	}
+	props[routedKBArgument] = map[string]any{"type": "string", "description": desc}
+	obj["properties"] = props
+
+	if required {
+		var req []any
+		if existing, ok := obj["required"].([]any); ok {
+			req = existing
+		}
+		found := false
+		for _, r := range req {
+			if s, ok := r.(string); ok && s == routedKBArgument {
+				found = true
+				break
+			}
+		}
+		if !found {
+			req = append([]any{routedKBArgument}, req...)
+		}
+		obj["required"] = req
+	}
+
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return schema
+	}
+	return out
+}
+
+// RoutedMounted reports whether a routed mount is configured on this server.
+func (m *MultiKBServer) RoutedMounted() bool { return m.routed != nil }

--- a/internal/mcpserver/routedmount_test.go
+++ b/internal/mcpserver/routedmount_test.go
@@ -1,0 +1,407 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BeppeTemp/cartographer/internal/auth"
+	"github.com/BeppeTemp/cartographer/internal/kb"
+)
+
+// routedTestToken is the bearer token the fixtures below grant rw on every
+// mounted KB: metadata and every tool are fail-closed without a principal
+// (installPolicy), so a routed-mount test that skips auth would be asserting
+// the denial path rather than the routing.
+const routedTestToken = "routed-tok"
+
+func routedTokenStore(names ...string) *auth.TokenStore {
+	scopes := make([]auth.KBScope, 0, len(names))
+	for _, name := range names {
+		scopes = append(scopes, auth.KBScope{KB: name, Write: true})
+	}
+	return auth.NewScopedTokenStore([]auth.ScopedToken{{Token: routedTestToken, Scopes: scopes}})
+}
+
+// setupNamedTestKB is setupTestKB with a concept whose body names the KB, so a
+// routed call can be shown to have reached the KB it named rather than a
+// plausible sibling — the failure D187's "never infer the KB" rule exists to
+// prevent.
+func setupNamedTestKB(t *testing.T, kbName string) *kb.KB {
+	t.Helper()
+	k := setupTestKB(t)
+	body := "---\ntype: Runbook\ntitle: Marker " + kbName + "\n---\n# Marker\nbelongs-to-" + kbName + "\n"
+	if err := os.WriteFile(filepath.Join(k.DataRoot(), "manutenzione", "marker.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+	return k
+}
+
+// newRoutedTestHandler mounts the named KBs, enables the routed mount and
+// wraps the result in the token middleware.
+func newRoutedTestHandler(t *testing.T, names ...string) http.Handler {
+	t.Helper()
+	multi := NewMultiKBServer("test")
+	for _, name := range names {
+		k := setupNamedTestKB(t, name)
+		k.AllowArtifactWrite = true
+		multi.MountKB(name, func(s *Server) { RegisterKBTools(s, k, Deps{}) })
+	}
+	if err := multi.EnableRoutedMount("test", nil); err != nil {
+		t.Fatalf("EnableRoutedMount: %v", err)
+	}
+	return routedTokenStore(names...).Middleware(multi.Handler())
+}
+
+func routedPost(t *testing.T, handler http.Handler, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Authorization", "Bearer "+routedTestToken)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	return rr
+}
+
+type listedTool struct {
+	Name        string          `json:"name"`
+	InputSchema json.RawMessage `json:"inputSchema"`
+}
+
+func decodeToolList(t *testing.T, rr *httptest.ResponseRecorder) []listedTool {
+	t.Helper()
+	if rr.Code != http.StatusOK {
+		t.Fatalf("tools/list: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Result struct {
+			Tools []listedTool `json:"tools"`
+		} `json:"result"`
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode tools/list: %v; body=%s", err, rr.Body.String())
+	}
+	if resp.Error != nil {
+		t.Fatalf("tools/list error: %s", resp.Error.Message)
+	}
+	return resp.Result.Tools
+}
+
+// TestRoutedMount_ToolsList_OneCopyWithRequiredKB is the whole point of D187:
+// three KBs, one copy of each tool, and the KB carried as a required argument.
+func TestRoutedMount_ToolsList_OneCopyWithRequiredKB(t *testing.T) {
+	handler := newRoutedTestHandler(t, "kb-one", "kb-two", "kb-three")
+
+	tools := decodeToolList(t, routedPost(t, handler, RoutedMountPath, toolsListBody))
+	if len(tools) == 0 {
+		t.Fatal("routed tools/list returned no tools")
+	}
+	seen := map[string]int{}
+	for _, tool := range tools {
+		seen[tool.Name]++
+		var schema struct {
+			Properties map[string]json.RawMessage `json:"properties"`
+			Required   []string                   `json:"required"`
+		}
+		if err := json.Unmarshal(tool.InputSchema, &schema); err != nil {
+			t.Fatalf("%s: decode schema: %v", tool.Name, err)
+		}
+		if _, ok := schema.Properties["kb"]; !ok {
+			t.Errorf("%s: schema has no kb property", tool.Name)
+		}
+		required := false
+		for _, r := range schema.Required {
+			if r == "kb" {
+				required = true
+			}
+		}
+		if !required {
+			t.Errorf("%s: kb is not required with 3 KBs routed", tool.Name)
+		}
+	}
+	for name, n := range seen {
+		if n != 1 {
+			t.Errorf("tool %q advertised %d times, want exactly 1", name, n)
+		}
+	}
+
+	// The per-KB endpoint advertises the same tools without the kb argument:
+	// the routed payload is one copy where three mounts would be three.
+	perKBBody := routedPost(t, handler, "/mcp/kb-one", toolsListBody).Body.Len()
+	perKB := decodeToolList(t, routedPost(t, handler, "/mcp/kb-one", toolsListBody))
+	if len(perKB) != len(tools) {
+		t.Errorf("per-KB advertises %d tools, routed %d: the union should match a homogeneous mount", len(perKB), len(tools))
+	}
+
+	// D187's acceptance criterion: the payload a three-KB client carries drops
+	// from three copies to roughly one. The kb property makes each schema
+	// slightly larger, so the bar is "well under two copies", not "exactly a
+	// third" — a regression that reintroduces duplication fails it either way.
+	routedBody := routedPost(t, handler, RoutedMountPath, toolsListBody).Body.Len()
+	if routedBody >= 2*perKBBody {
+		t.Errorf("routed tools/list is %d bytes against %d per KB (x3 = %d): the duplication is not gone",
+			routedBody, perKBBody, 3*perKBBody)
+	}
+	t.Logf("tools/list: routed %d bytes vs %d for three per-KB mounts", routedBody, 3*perKBBody)
+}
+
+// TestRoutedMount_PerKBEndpointsUnchanged pins the invariant that makes this
+// opt-in safe: enabling the routed mount must not alter a single byte of what
+// the per-KB endpoints advertise.
+func TestRoutedMount_PerKBEndpointsUnchanged(t *testing.T) {
+	plain := NewMultiKBServer("test")
+	routed := NewMultiKBServer("test")
+	for _, name := range []string{"kb-one", "kb-two"} {
+		kPlain := setupNamedTestKB(t, name)
+		plain.MountKB(name, func(s *Server) { RegisterKBTools(s, kPlain, Deps{}) })
+		kRouted := setupNamedTestKB(t, name)
+		routed.MountKB(name, func(s *Server) { RegisterKBTools(s, kRouted, Deps{}) })
+	}
+	if err := routed.EnableRoutedMount("test", nil); err != nil {
+		t.Fatalf("EnableRoutedMount: %v", err)
+	}
+
+	for _, name := range []string{"kb-one", "kb-two"} {
+		store := routedTokenStore("kb-one", "kb-two")
+		want := routedPost(t, store.Middleware(plain.Handler()), "/mcp/"+name, toolsListBody).Body.String()
+		got := routedPost(t, store.Middleware(routed.Handler()), "/mcp/"+name, toolsListBody).Body.String()
+		if got != want {
+			t.Errorf("/mcp/%s tools/list changed when the routed mount was enabled:\n got: %s\nwant: %s", name, got, want)
+		}
+	}
+}
+
+func routedCall(t *testing.T, handler http.Handler, tool string, args map[string]any) ToolResult {
+	t.Helper()
+	body, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{"name": tool, "arguments": args},
+	})
+	rr := routedPost(t, handler, RoutedMountPath, string(body))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("%s: status=%d body=%s", tool, rr.Code, rr.Body.String())
+	}
+	var resp Response
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("%s: decode: %v; body=%s", tool, err, rr.Body.String())
+	}
+	if resp.Error != nil {
+		t.Fatalf("%s: rpc error: %s", tool, resp.Error.Message)
+	}
+	return decodeToolResult(t, resp)
+}
+
+// TestRoutedMount_DispatchesToTheNamedKB: each of three KBs is reachable, and
+// the content that comes back is that KB's.
+func TestRoutedMount_DispatchesToTheNamedKB(t *testing.T) {
+	handler := newRoutedTestHandler(t, "kb-one", "kb-two", "kb-three")
+
+	for _, name := range []string{"kb-one", "kb-two", "kb-three"} {
+		res := routedCall(t, handler, "concept_read", map[string]any{"kb": name, "id": "manutenzione/marker"})
+		if res.IsError {
+			t.Fatalf("%s: concept_read failed: %+v", name, res)
+		}
+		text := res.Content[0].Text
+		if !strings.Contains(text, "belongs-to-"+name) {
+			t.Errorf("kb=%s returned another KB's content: %s", name, text)
+		}
+	}
+}
+
+// TestRoutedMount_MissingKB_NamesThem: with more than one KB routed the
+// argument is required, and the refusal has to say which KBs exist — an error
+// the caller can act on without a second round-trip.
+func TestRoutedMount_MissingKB_NamesThem(t *testing.T) {
+	handler := newRoutedTestHandler(t, "kb-one", "kb-two", "kb-three")
+	res := routedCall(t, handler, "atlas_overview", map[string]any{})
+	if !res.IsError {
+		t.Fatal("a call with no kb succeeded; the KB must never be inferred")
+	}
+	text := res.Content[0].Text
+	for _, name := range []string{"kb-one", "kb-two", "kb-three"} {
+		if !strings.Contains(text, name) {
+			t.Errorf("missing-kb error does not name %q: %s", name, text)
+		}
+	}
+}
+
+// TestRoutedMount_SingleKB_KBOptional: with exactly one KB routed there is no
+// ambiguity to resolve, so requiring the argument would be ceremony.
+func TestRoutedMount_SingleKB_KBOptional(t *testing.T) {
+	handler := newRoutedTestHandler(t, "only")
+
+	res := routedCall(t, handler, "concept_read", map[string]any{"id": "manutenzione/marker"})
+	if res.IsError {
+		t.Fatalf("single-KB routed call without kb failed: %+v", res)
+	}
+
+	for _, tool := range decodeToolList(t, routedPost(t, handler, RoutedMountPath, toolsListBody)) {
+		var schema struct {
+			Required []string `json:"required"`
+		}
+		json.Unmarshal(tool.InputSchema, &schema)
+		for _, r := range schema.Required {
+			if r == "kb" {
+				t.Fatalf("%s: kb is required with a single KB routed", tool.Name)
+			}
+		}
+	}
+}
+
+func TestRoutedMount_UnknownKB(t *testing.T) {
+	handler := newRoutedTestHandler(t, "kb-one", "kb-two")
+	res := routedCall(t, handler, "atlas_overview", map[string]any{"kb": "nope"})
+	if !res.IsError || !strings.Contains(res.Content[0].Text, `unknown kb "nope"`) {
+		t.Fatalf("want unknown-kb error, got %+v", res)
+	}
+	if !strings.Contains(res.Content[0].Text, "kb-one") {
+		t.Errorf("unknown-kb error does not list the mounted KBs: %s", res.Content[0].Text)
+	}
+}
+
+// TestRoutedMount_GatedTool_UnionThenAttributedRefusal: the exposed set is the
+// union, so artifact_write is advertised because one KB allows it; the KB that
+// does not gets an error naming itself and the setting, rather than the tool
+// silently vanishing for everyone.
+func TestRoutedMount_GatedTool_UnionThenAttributedRefusal(t *testing.T) {
+	multi := NewMultiKBServer("test")
+	allowed := setupNamedTestKB(t, "open-kb")
+	allowed.AllowArtifactWrite = true
+	multi.MountKB("open-kb", func(s *Server) { RegisterKBTools(s, allowed, Deps{}) })
+	denied := setupNamedTestKB(t, "closed-kb") // AllowArtifactWrite stays false
+	multi.MountKB("closed-kb", func(s *Server) { RegisterKBTools(s, denied, Deps{}) })
+	if err := multi.EnableRoutedMount("test", nil); err != nil {
+		t.Fatalf("EnableRoutedMount: %v", err)
+	}
+	handler := routedTokenStore("open-kb", "closed-kb").Middleware(multi.Handler())
+
+	found := false
+	for _, tool := range decodeToolList(t, routedPost(t, handler, RoutedMountPath, toolsListBody)) {
+		if tool.Name == "artifact_write" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("artifact_write is absent from the routed union although one KB allows it")
+	}
+
+	res := routedCall(t, handler, "artifact_write", map[string]any{
+		"kb": "closed-kb", "path": "skills/x/SKILL.md", "content": "x",
+	})
+	if !res.IsError {
+		t.Fatal("artifact_write on a KB with the gate closed succeeded")
+	}
+	text := res.Content[0].Text
+	if !strings.Contains(text, "closed-kb") || !strings.Contains(text, "allow_artifact_write") {
+		t.Errorf("refusal names neither the KB nor the setting: %s", text)
+	}
+
+	res = routedCall(t, handler, "artifact_write", map[string]any{
+		"kb": "open-kb", "path": "skills/demo/SKILL.md",
+		"content": "---\nname: demo\ndescription: A demo skill for the routed mount test.\n---\nBody.\n",
+	})
+	if res.IsError {
+		t.Fatalf("artifact_write on the KB that allows it failed: %+v", res)
+	}
+}
+
+// TestRoutedMount_RejectsQueryKBSelector: two channels for the same choice is
+// how they get to disagree.
+func TestRoutedMount_RejectsQueryKBSelector(t *testing.T) {
+	handler := newRoutedTestHandler(t, "kb-one", "kb-two")
+	rr := routedPost(t, handler, RoutedMountPath+"?kb=kb-one", toolsListBody)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestRoutedMount_NotEnabled_PathFallsThrough: with no routed mount, the path
+// is an ordinary KB name, so a KB called "routed" keeps its own endpoint.
+func TestRoutedMount_NotEnabled_PathFallsThrough(t *testing.T) {
+	multi := newMultiKBTestHandler(t, "routed", "other")
+	rr := routedPost(t, routedTokenStore("routed", "other").Middleware(multi.Handler()), RoutedMountPath, toolsListBody)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("/mcp/routed for a KB named \"routed\": status=%d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestRoutedMount_RefusesToolPrefix: routing and prefixing are alternative
+// answers to the same problem, so asking for both is a config error rather
+// than a silently ignored setting.
+func TestRoutedMount_RefusesToolPrefix(t *testing.T) {
+	multi := NewMultiKBServer("test")
+	k := setupNamedTestKB(t, "kb-one")
+	if err := multi.MountKBWithPrefix("kb-one", "one", func(s *Server) { RegisterKBTools(s, k, Deps{}) }); err != nil {
+		t.Fatalf("MountKBWithPrefix: %v", err)
+	}
+	err := multi.EnableRoutedMount("test", nil)
+	if err == nil {
+		t.Fatal("routed mount accepted a prefixed KB")
+	}
+	if !strings.Contains(err.Error(), "kb-one") || !strings.Contains(err.Error(), "tool_prefix") {
+		t.Errorf("error names neither the KB nor the key: %v", err)
+	}
+}
+
+// TestRoutedMount_RefusesKBNamedRouted: the routed mount's own path cannot be
+// claimed by a KB, and the collision is refused at startup rather than
+// shadowing one of the two at request time.
+func TestRoutedMount_RefusesKBNamedRouted(t *testing.T) {
+	multi := NewMultiKBServer("test")
+	k := setupNamedTestKB(t, "routed")
+	multi.MountKB("routed", func(s *Server) { RegisterKBTools(s, k, Deps{}) })
+	if err := multi.EnableRoutedMount("test", nil); err == nil {
+		t.Fatal("routed mount accepted a KB named \"routed\"")
+	}
+}
+
+// TestWithKBProperty_PreservesExistingSchema: the injection edits the decoded
+// schema, so a tool's own required list and properties survive.
+func TestWithKBProperty_PreservesExistingSchema(t *testing.T) {
+	in := json.RawMessage(`{"type":"object","required":["id"],"properties":{"id":{"type":"string"}}}`)
+	out := withKBProperty(in, true)
+	var schema struct {
+		Properties map[string]json.RawMessage `json:"properties"`
+		Required   []string                   `json:"required"`
+	}
+	if err := json.Unmarshal(out, &schema); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := schema.Properties["id"]; !ok {
+		t.Error("existing property dropped")
+	}
+	if _, ok := schema.Properties["kb"]; !ok {
+		t.Error("kb property not injected")
+	}
+	if len(schema.Required) != 2 {
+		t.Errorf("required = %v, want both id and kb", schema.Required)
+	}
+}
+
+// TestSplitKBArgument_StripsKB: the per-KB handler must receive exactly the
+// arguments it would have received on its own endpoint.
+func TestSplitKBArgument_StripsKB(t *testing.T) {
+	name, rest, err := splitKBArgument(json.RawMessage(`{"kb":"kb-one","id":"a/b"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "kb-one" {
+		t.Errorf("name = %q", name)
+	}
+	var got map[string]any
+	json.Unmarshal(rest, &got)
+	if _, ok := got["kb"]; ok {
+		t.Error("kb was not stripped from the arguments")
+	}
+	if got["id"] != "a/b" {
+		t.Errorf("rest = %v", got)
+	}
+}

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -20,6 +20,12 @@ type Deps struct {
 	BundleFS       fs.FS              // nil → no bundled skills
 	ArtifactSigner ed25519.PrivateKey // nil → KB artifacts remain unsigned
 	MCPAllowlist   []provisioning.MCPAllowlistEntry
+	// RoutedMount says this server's KBs are reachable through the single
+	// routed endpoint (D187). It reaches the generated instructions block, the
+	// part the model actually reads, so the imprinting names the bare tools and
+	// the `kb` value to pass — a wrong name there is worse than the duplication
+	// routing removes.
+	RoutedMount bool
 }
 
 // RegisterKBTools registers all KB tools on the server, including search,
@@ -138,9 +144,9 @@ func RegisterKBTools(s *Server, k *kb.KB, deps Deps) {
 		register(toolSkillListWithBundle(k, deps.BundleFS))
 		register(gitWrap(k, toolSkillInstall(k, deps.BundleFS)))
 		toolPrefix := s.ToolNamePrefix()
-		register(toolSyncCheck(k, deps.BundleFS, toolPrefix, deps.ArtifactSigner, deps.MCPAllowlist))
-		register(toolSyncApply(k, deps.BundleFS, toolPrefix, deps.ArtifactSigner, deps.MCPAllowlist))
-		register(toolSyncPull(k, deps.BundleFS, toolPrefix, deps.ArtifactSigner, deps.MCPAllowlist))
+		register(toolSyncCheck(k, deps.BundleFS, toolPrefix, deps.RoutedMount, deps.ArtifactSigner, deps.MCPAllowlist))
+		register(toolSyncApply(k, deps.BundleFS, toolPrefix, deps.RoutedMount, deps.ArtifactSigner, deps.MCPAllowlist))
+		register(toolSyncPull(k, deps.BundleFS, toolPrefix, deps.RoutedMount, deps.ArtifactSigner, deps.MCPAllowlist))
 	} else {
 		register(toolSkillList(k))
 	}

--- a/internal/mcpserver/tools_sync.go
+++ b/internal/mcpserver/tools_sync.go
@@ -52,7 +52,7 @@ func flushPendingPush(k *kb.KB, toolName string) {
 // toolSyncCheck returns the current revision of the provisioning manifest (bundle + KB).
 // Read-only: writes nothing, safe on a remote server too.
 // The client may pass its own lockfile revision; the response includes in_sync=true/false.
-func toolSyncCheck(k *kb.KB, bundleFS fs.FS, toolPrefix string, signer ed25519.PrivateKey, allowlist []provisioning.MCPAllowlistEntry) Tool {
+func toolSyncCheck(k *kb.KB, bundleFS fs.FS, toolPrefix string, routedMount bool, signer ed25519.PrivateKey, allowlist []provisioning.MCPAllowlistEntry) Tool {
 	return Tool{
 		Name:     "sync_check",
 		ReadOnly: true,
@@ -77,7 +77,7 @@ func toolSyncCheck(k *kb.KB, bundleFS fs.FS, toolPrefix string, signer ed25519.P
 
 			// Use the basename of k.Root as the KB name in the manifest.
 			kbName := filepath.Base(k.Root)
-			m, err := provisioning.BuildManifest(bundleFS, map[string]string{kbName: k.Root}, buildOptions(kbName, toolPrefix, signer, allowlist))
+			m, err := provisioning.BuildManifest(bundleFS, map[string]string{kbName: k.Root}, buildOptions(kbName, toolPrefix, routedMount, signer, allowlist))
 			if err != nil {
 				return errorResult(fmt.Sprintf("sync_check: build manifest: %v", err)), nil
 			}
@@ -128,7 +128,7 @@ func toolSyncCheck(k *kb.KB, bundleFS fs.FS, toolPrefix string, signer ed25519.P
 // toolSyncApply materializes the provisioning artifacts into the client's base_dir.
 // Intended for local deployment (stdio): server and client share the filesystem.
 // For remote deployment use `cartographer sync`/`cartographer connect` (via sync_pull) from the client machine.
-func toolSyncApply(k *kb.KB, bundleFS fs.FS, toolPrefix string, signer ed25519.PrivateKey, allowlist []provisioning.MCPAllowlistEntry) Tool {
+func toolSyncApply(k *kb.KB, bundleFS fs.FS, toolPrefix string, routedMount bool, signer ed25519.PrivateKey, allowlist []provisioning.MCPAllowlistEntry) Tool {
 	return Tool{
 		Name: "sync_apply",
 		Description: "Materializes the provisioning skills into the given base_dir, updates the lockfile and prunes " +
@@ -170,7 +170,7 @@ func toolSyncApply(k *kb.KB, bundleFS fs.FS, toolPrefix string, signer ed25519.P
 			kbName := filepath.Base(k.Root)
 			kbRoots := map[string]string{kbName: k.Root}
 
-			m, err := provisioning.BuildManifest(bundleFS, kbRoots, buildOptions(kbName, toolPrefix, signer, allowlist))
+			m, err := provisioning.BuildManifest(bundleFS, kbRoots, buildOptions(kbName, toolPrefix, routedMount, signer, allowlist))
 			if err != nil {
 				return errorResult(fmt.Sprintf("sync_apply: build manifest: %v", err)), nil
 			}
@@ -271,7 +271,7 @@ type pulledArtifactJSON struct {
 // artifact's file contents embedded (base64). Meant for a remote HTTP client
 // that does not share the filesystem with the server: the client materializes
 // locally without reading bundle/KB directly. Read-only, no arguments required.
-func toolSyncPull(k *kb.KB, bundleFS fs.FS, toolPrefix string, signer ed25519.PrivateKey, allowlist []provisioning.MCPAllowlistEntry) Tool {
+func toolSyncPull(k *kb.KB, bundleFS fs.FS, toolPrefix string, routedMount bool, signer ed25519.PrivateKey, allowlist []provisioning.MCPAllowlistEntry) Tool {
 	return Tool{
 		Name:     "sync_pull",
 		ReadOnly: true,
@@ -284,7 +284,7 @@ func toolSyncPull(k *kb.KB, bundleFS fs.FS, toolPrefix string, signer ed25519.Pr
 			kbName := filepath.Base(k.Root)
 			kbRoots := map[string]string{kbName: k.Root}
 
-			m, err := provisioning.BuildManifest(bundleFS, kbRoots, buildOptions(kbName, toolPrefix, signer, allowlist))
+			m, err := provisioning.BuildManifest(bundleFS, kbRoots, buildOptions(kbName, toolPrefix, routedMount, signer, allowlist))
 			if err != nil {
 				return errorResult(fmt.Sprintf("sync_pull: build manifest: %v", err)), nil
 			}
@@ -324,12 +324,15 @@ func toolSyncPull(k *kb.KB, bundleFS fs.FS, toolPrefix string, signer ed25519.Pr
 
 // buildOptions assembles the manifest build options for the single KB this
 // server instance serves. toolPrefix is this endpoint's effective MCP
-// tool-name prefix (D102): it reaches the generated instructions block so the
-// imprinting names the tools the agent can actually call (D144).
-func buildOptions(kbName, toolPrefix string, signer ed25519.PrivateKey, allowlist []provisioning.MCPAllowlistEntry) provisioning.BuildOptions {
+// tool-name prefix (D102) and routedMount whether the server routes its KBs
+// through one endpoint (D187): both reach the generated instructions block so
+// the imprinting names the tools the agent can actually call, with the
+// arguments it must pass (D144).
+func buildOptions(kbName, toolPrefix string, routedMount bool, signer ed25519.PrivateKey, allowlist []provisioning.MCPAllowlistEntry) provisioning.BuildOptions {
 	opts := provisioning.BuildOptions{
 		MCPAllowlists: map[string][]provisioning.MCPAllowlistEntry{kbName: allowlist},
 		ToolPrefixes:  map[string]string{kbName: toolPrefix},
+		RoutedMount:   routedMount,
 	}
 	if len(signer) != 0 {
 		opts.Signers = map[string]ed25519.PrivateKey{kbName: signer}

--- a/internal/provisioning/provisioning.go
+++ b/internal/provisioning/provisioning.go
@@ -65,6 +65,13 @@ type BuildOptions struct {
 	// with (D144), so a prefixed KB does not imprint tools the agent cannot
 	// call.
 	ToolPrefixes map[string]string
+	// RoutedMount reports that this server serves its KBs through a single
+	// routed endpoint (D187): the tools are advertised once, unprefixed, and
+	// every call carries the KB as a `kb` argument. The generated instructions
+	// block is the part the model actually reads, so it must name the tools as
+	// the agent will see them and say which `kb` value to pass — a wrong name
+	// there is worse than the duplication routing removes.
+	RoutedMount bool
 	// MCPDiagnostic receives non-fatal denied/stale allow-list diagnostics.
 	// It never contains descriptor headers or environment references.
 	MCPDiagnostic func(string)
@@ -615,7 +622,7 @@ func BuildManifest(bundleFS fs.FS, kbRoots map[string]string, opts BuildOptions)
 		// timestamp) and placed directly in Artifact.Files, so ReadArtifactFiles
 		// doesn't need to read anything from the KB for this kind (see its
 		// "len(a.Files) > 0" check at the top of the function).
-		instrContent := []byte(generateKBInstructions(kbName, kbRoot, opts.ToolPrefixes[kbName]))
+		instrContent := []byte(generateKBInstructions(kbName, kbRoot, opts.ToolPrefixes[kbName], opts.RoutedMount))
 		artifacts = append(artifacts, Artifact{
 			Kind:        "instructions",
 			Name:        kbName,
@@ -732,11 +739,17 @@ func countMarkdownFiles(dir string) int {
 // on the result of this function, see BuildManifest) changes only when the
 // set of archives/agents or instructions.md changes, not on every page
 // added.
-func generateKBInstructions(kbName, kbRoot, toolPrefix string) string {
+func generateKBInstructions(kbName, kbRoot, toolPrefix string, routed bool) string {
 	var sb strings.Builder
 	tool := func(base string) string { return qualifyToolName(toolPrefix, base) }
 
 	fmt.Fprintf(&sb, "The %q KB is served via MCP by the \"cartographer\" server.", kbName)
+	if routed {
+		// D187: one endpoint, one copy of the tools, the KB as an argument.
+		// The tool names are bare (a routed mount refuses tool_prefix), so the
+		// only thing the model must be told is the value to pass.
+		fmt.Fprintf(&sb, " Every tool call to it must carry `kb: %q` — that server serves several KBs through one set of tools and never infers which one you mean.", kbName)
+	}
 
 	archives := kbArchives(kbRoot)
 	if len(archives) == 0 {

--- a/internal/provisioning/provisioning_instructions_test.go
+++ b/internal/provisioning/provisioning_instructions_test.go
@@ -1456,3 +1456,40 @@ func TestApply_Instructions_IdempotenteMultiKB(t *testing.T) {
 		t.Errorf("second Apply (in-sync, multi-KB): expected no Written, got %+v", res2.Written)
 	}
 }
+
+// TestBuildManifest_Instructions_RoutedMount: the generated block is the part
+// the model actually reads, so on a routed server it must name the bare tool
+// names — a routed mount refuses tool_prefix — and say which `kb` value to
+// pass. A wrong name here is worse than the duplication routing removes (D187).
+func TestBuildManifest_Instructions_RoutedMount(t *testing.T) {
+	kbRoot := makeKBWithArchives(t, map[string][]string{"entities": {"router.md"}})
+
+	plain, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, provisioning.BuildOptions{})
+	if err != nil {
+		t.Fatalf("BuildManifest plain: %v", err)
+	}
+	plainContent := instructionsContent(t, plain, "homelab")
+
+	routed, err := provisioning.BuildManifest(nil, map[string]string{"homelab": kbRoot}, provisioning.BuildOptions{RoutedMount: true})
+	if err != nil {
+		t.Fatalf("BuildManifest routed: %v", err)
+	}
+	got := instructionsContent(t, routed, "homelab")
+
+	if got == plainContent {
+		t.Fatal("routed instructions are identical to the per-KB ones: the kb argument is never stated")
+	}
+	if !strings.Contains(got, "`kb: \"homelab\"`") {
+		t.Errorf("routed instructions do not name the kb value to pass:\n%s", got)
+	}
+	// The tool names stay bare: a routed mount refuses a prefix, so imprinting
+	// a prefixed name would name a tool that does not exist.
+	for _, want := range []string{"`search`", "`atlas_overview`", "`concept_read`", "`concept_write`", "`log_append`"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("routed instructions do not name %s:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "__") {
+		t.Errorf("routed instructions contain a prefixed tool name:\n%s", got)
+	}
+}

--- a/test/e2e/scenarios/17_routed_multikb.sh
+++ b/test/e2e/scenarios/17_routed_multikb.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# scenarios/17_routed_multikb.sh — OPERATOR scenario: routed multi-KB mount (D187).
+#
+# A three-KB server with mcp.mount_mode: routed. The point of the mode is that a
+# client using N KBs stops paying N copies of the same tool schemas in its fixed
+# context on every model round-trip; the point of this scenario is that the flag
+# actually reaches the wire, which the unit tests cannot show.
+#
+# Verifies (operator channel only, curl + CLI — no agent/model):
+#   1. /health advertises mount_mode and routed_path, so a client can detect the
+#      topology instead of assuming it.
+#   2. /mcp/routed advertises each tool exactly once and its payload is far
+#      smaller than the per-KB mounts summed.
+#   3. A call routed with `kb` reaches that KB; a call without `kb` is refused
+#      naming the mounted KBs, and one with an unknown `kb` is refused too.
+#   4. The per-KB endpoints still answer exactly as before.
+#   5. `cartographer connect` writes ONE MCP entry, pointed at /mcp/routed.
+#
+# Expected environment variables: E2E_TMP_DIR, E2E_HTTP_PORT, REPO_ROOT.
+
+set -uo pipefail
+
+SCENARIO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_DIR="$(cd "${SCENARIO_DIR}/.." && pwd)"
+
+# shellcheck source=../lib/assert.sh
+source "${E2E_DIR}/lib/assert.sh"
+# shellcheck source=../lib/kb.sh
+source "${E2E_DIR}/lib/kb.sh"
+# shellcheck source=../lib/server.sh
+source "${E2E_DIR}/lib/server.sh"
+
+SCENARIO_NAME="17_routed_multikb"
+
+echo "=== Scenario ${SCENARIO_NAME} ==="
+
+DIR="${E2E_TMP_DIR}/${SCENARIO_NAME}"
+CONFIG="${DIR}/config.yaml"
+SANDBOX="${DIR}/home"
+BIN="${REPO_ROOT}/bin/cartographer"
+HOST="http://127.0.0.1:${E2E_HTTP_PORT}"
+SERVER_URL="${HOST}/mcp"
+ROUTED_URL="${HOST}/mcp/routed"
+
+KBS=(alpha beta gamma)
+mkdir -p "$DIR" "$SANDBOX"
+for name in "${KBS[@]}"; do kb_make "${DIR}/${name}"; done
+
+{
+    echo "http: \":${E2E_HTTP_PORT}\""
+    echo "init: true"
+    echo "mcp:"
+    echo "  mount_mode: routed"
+    echo "kbs:"
+    for name in "${KBS[@]}"; do
+        echo "  - path: ${DIR}/${name}"
+        echo "    name: ${name}"
+    done
+} > "$CONFIG"
+
+KB_CSV="$(IFS=,; echo "${KBS[*]/#/${DIR}/}")"
+E2E_CONFIG="$CONFIG" server_start "$KB_CSV"
+server_wait_health 20
+trap 'server_stop' EXIT
+
+echo ""
+echo "--- Phase 1: the topology is discoverable from /health ---"
+
+HEALTH="${DIR}/health.json"
+curl -s "${HOST}/health" -o "$HEALTH"
+assert_file_contains "$HEALTH" '"mount_mode":"routed"'
+assert_file_contains "$HEALTH" '"routed_path":"/mcp/routed"'
+
+echo ""
+echo "--- Phase 2: one copy of the tools, and a much smaller payload ---"
+
+list_body='{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+post() {
+    curl -s -X POST "$1" -H "Content-Type: application/json" \
+        -H "Accept: application/json, text/event-stream" -d "$2"
+}
+
+ROUTED_LIST="${DIR}/routed-tools.json"
+post "$ROUTED_URL" "$list_body" > "$ROUTED_LIST"
+PERKB_LIST="${DIR}/perkb-tools.json"
+post "${SERVER_URL}?kb=alpha" "$list_body" > "$PERKB_LIST"
+
+# atlas_overview must appear exactly once on the routed mount.
+OCCURRENCES="$(grep -o '"name":"atlas_overview"' "$ROUTED_LIST" | wc -l | tr -d ' ')"
+if [[ "$OCCURRENCES" == "1" ]]; then
+    _assert_pass "atlas_overview is advertised exactly once on the routed mount"
+else
+    _assert_fail "atlas_overview advertised ${OCCURRENCES} times on the routed mount, want 1"
+fi
+
+# Every tool schema carries the kb argument, required with 3 KBs routed.
+assert_file_contains "$ROUTED_LIST" '"kb"'
+
+ROUTED_BYTES="$(wc -c < "$ROUTED_LIST" | tr -d ' ')"
+PERKB_BYTES="$(wc -c < "$PERKB_LIST" | tr -d ' ')"
+THREE_MOUNTS=$((PERKB_BYTES * 3))
+echo "[info] tools/list: routed ${ROUTED_BYTES} bytes vs ${THREE_MOUNTS} for three per-KB mounts"
+if [[ "$ROUTED_BYTES" -lt $((PERKB_BYTES * 2)) ]]; then
+    _assert_pass "the routed payload is well under two copies of the per-KB one"
+else
+    _assert_fail "routed payload ${ROUTED_BYTES} is not smaller than two per-KB copies (${PERKB_BYTES} each)"
+fi
+
+echo ""
+echo "--- Phase 3: kb selects the target, and is never inferred ---"
+
+routed_call() {
+    post "$ROUTED_URL" "$1"
+}
+call_with_kb() {
+    printf '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"atlas_overview","arguments":{"kb":"%s"}}}' "$1"
+}
+
+for name in "${KBS[@]}"; do
+    assert_mcp_ok "routed call with kb=${name} succeeds" "$(routed_call "$(call_with_kb "$name")")"
+done
+
+NO_KB="$(routed_call '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"atlas_overview","arguments":{}}}')"
+if grep -q '"isError":true' <<< "$NO_KB" && grep -q 'alpha' <<< "$NO_KB" && grep -q 'gamma' <<< "$NO_KB"; then
+    _assert_pass "a routed call with no kb is refused, naming the mounted KBs"
+else
+    _assert_fail "a routed call with no kb was not refused with the KB list: ${NO_KB}"
+fi
+
+UNKNOWN_KB="$(routed_call "$(call_with_kb nope)")"
+if grep -q 'unknown kb' <<< "$UNKNOWN_KB"; then
+    _assert_pass "a routed call with an unknown kb is refused"
+else
+    _assert_fail "an unknown kb was not refused: ${UNKNOWN_KB}"
+fi
+
+# The KB travels in the arguments here: a ?kb= on this URL is a second channel.
+CONFLICT_CODE="$(curl -s -o /dev/null -w '%{http_code}' -X POST "${ROUTED_URL}?kb=alpha" \
+    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" -d "$list_body")"
+if [[ "$CONFLICT_CODE" == "400" ]]; then
+    _assert_pass "?kb= on the routed endpoint is refused with 400"
+else
+    _assert_fail "?kb= on the routed endpoint returned ${CONFLICT_CODE}, want 400"
+fi
+
+echo ""
+echo "--- Phase 4: the per-KB endpoints are untouched ---"
+
+for name in "${KBS[@]}"; do
+    assert_mcp_ok "per-KB endpoint ?kb=${name} still answers" \
+        "$(mcp_call "$SERVER_URL" "$name" "" '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"atlas_overview","arguments":{}}}')"
+done
+# The per-KB list has no kb argument: routing added an endpoint, it changed none.
+if grep -q '"kb"' "$PERKB_LIST"; then
+    _assert_fail "the per-KB tools/list gained a kb argument: the routed mount is not additive"
+else
+    _assert_pass "the per-KB tools/list is unchanged (no kb argument)"
+fi
+
+echo ""
+echo "--- Phase 5: the client writes ONE MCP entry, at the routed endpoint ---"
+
+(cd "$SANDBOX" && HOME="$SANDBOX" "$BIN" connect opencode --server-url "$SERVER_URL" --kb all --auto-trust) \
+    >"${DIR}/connect.log" 2>&1 || true
+
+OPENCODE_CFG="${SANDBOX}/.config/opencode/opencode.json"
+if [[ ! -f "$OPENCODE_CFG" ]]; then
+    OPENCODE_CFG="$(find "$SANDBOX" -name 'opencode.json' -print -quit 2>/dev/null)"
+fi
+assert_file_exists "$OPENCODE_CFG"
+assert_file_contains "$OPENCODE_CFG" "/mcp/routed"
+assert_file_not_contains "$OPENCODE_CFG" "kb=alpha"
+
+ENTRIES="$(grep -o '/mcp/routed' "$OPENCODE_CFG" | wc -l | tr -d ' ')"
+if [[ "$ENTRIES" == "1" ]]; then
+    _assert_pass "exactly one routed MCP entry was written"
+else
+    _assert_fail "${ENTRIES} routed MCP entries were written, want 1"
+fi
+
+echo ""
+if [[ "${E2E_FAILURES}" -eq 0 ]]; then
+    echo "[SCENARIO ${SCENARIO_NAME}] PASS"
+    exit 0
+else
+    echo "[SCENARIO ${SCENARIO_NAME}] FAIL (${E2E_FAILURES} assertion(s) failed)"
+    exit 1
+fi


### PR DESCRIPTION
Implements the plan in #242.

A client using N KBs paid N copies of the same tool schemas in its fixed context on **every** model round-trip — 82,341 bytes for three KBs, two thirds duplicate. The `agent` profile shrinks the set *per mount*; D102's prefix makes multi-KB *work* on a flat-namespace client. Neither removes the duplication, because the duplication is the topology.

**WP1 — routed mount** (`internal/mcpserver/routedmount.go`). `/mcp/routed` registers the union of the mounted KBs' descriptors once, injecting a `kb` property into each schema at the single point where the descriptor list is assembled. Dispatch resolves `kb`, strips it, and calls the target KB's own `Server.callTool` — so the read/write classification, the D118 policy, the audit pair naming the real KB and the git wrapper are the per-KB ones, unchanged. The routed server carries no audit log and an authorizer that defers every tool decision, so exactly one authorization and one audit record happen, at the target; the metadata gate is answered as "can reach at least one routed KB".

Edges: missing `kb` with 2+ routed → error naming them; missing with exactly 1 → accepted; unknown `kb` → error listing the KBs *and their state*; a tool not registered for the resolved KB → attributed error reusing `unknownToolMessage`'s setting lookup; `?kb=` on the routed URL → 400.

**WP2 — configuration.** `mcp.mount_mode` / `CARTOGRAPHER_MCP_MOUNT_MODE` / `--mount-mode`, flag > env > YAML > default, default `per-kb`. An explicit `kbs[].tool_prefix` on a routed KB is fatal at startup, as is a KB named `routed` (it would claim the endpoint's path).

**WP3 — client.** `/health` gains `mount_mode`/`routed_path` (emitted only when routing is on, so a per-KB and a pre-D187 server look identical to any client). `connect`/`sync` write **one** entry at that path, persist the fact in `.cartographer.yaml`, and `doctor` derives the expected entries from it offline. The generated instructions name the bare tools and the `kb` value (`Deps.RoutedMount` → `BuildOptions.RoutedMount`). The Kiro flat-namespace warning is silent — one entry cannot collide with itself. `status` reports a mode switch and names `reconnect`.

**WP4 — docs.** `transport-auth.md` §Mount modes, `deployment.md` §HTTP routing + env table, `control-plane.md` §MCP API, `configurator.md` §Routed servers, `config.example.yaml`, `testing.md`, and `D187` in `docs/decisions/transport-auth.md`.

### The E2E scenario found a real defect

`17_routed_multikb` drives a real three-KB server with `curl`. It failed on the first run: D153's **derived** `kb-name` prefix — which nobody configures explicitly — tripped the `tool_prefix` refusal and killed the server at startup, making the mode unusable out of the box. No Go test could see it; the defect was in the wiring between the config default and the mount. Resolved by distinguishing who asked: a *derived* prefix is not applied under routing (there is no flat namespace left to disambiguate), an *explicit* `kbs[].tool_prefix` still is a fatal error.

### Measured

| | per-KB × 3 | routed |
|---|---|---|
| E2E, real server | 81,633 B | **31,969 B** |
| Go fixture | 115,932 B | **46,196 B** |

Invariants pinned by tests: the per-KB endpoints' `tools/list` is byte-identical with routing on or off; their schemas gain no `kb`; `TestServer_ToolsProfile` is untouched.

`make vet && make test && make e2e` green (13/13 scenarios).

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AY3RmkHqUB1SaugB2YSGpB