### PR TITLE
feat(sync): workspace-scoped artifact projection (D193)

### DIFF
--- a/cmd/cartographer/clientsync.go
+++ b/cmd/cartographer/clientsync.go
@@ -170,6 +170,12 @@ func kbOrderForProviders(cfg *clientconfig.Config, providers []string) map[strin
 // Verification pins are applied per provider only because VerifiedManifest
 // takes a manifest — the work is over the same artifacts either way, and an
 // artifact's verification result cannot differ between providers.
+//
+// It returns the GLOBAL projection of each provider, keyed by provider name —
+// the view `status` and the TUI have always shown. A workspace-scoped provider
+// has more projections than this one; `status` reports them separately (D193),
+// and the sync path goes through manifestsForProjections instead, which is the
+// only caller that materializes.
 func manifestsForProviders(cfg *clientconfig.Config, providers []string) (map[string]provisioning.Manifest, error) {
 	out := make(map[string]provisioning.Manifest, len(providers))
 
@@ -415,41 +421,61 @@ type portabilityOptions struct {
 // binding order (D182 WP2) — omitted or nil for a provider entry means no
 // explicit binding, so its instructions block keeps the alphabetical
 // fallback. See kbOrderForProviders.
-func materializeForProviders(manifests map[string]provisioning.Manifest, providers []string, targetDir, serverVersion string, autoTrust, dryRun, noHeal bool, portability portabilityOptions, kbOrder map[string][]string, approvalHashes ...map[string]string) (map[string]provisioning.AppliedResult, error) {
+func materializeForProviders(manifests map[string]provisioning.Manifest, projections []syncProjection, targetDir, serverVersion string, autoTrust, dryRun, noHeal bool, portability portabilityOptions, kbOrder map[string][]string, approvalHashes ...map[string]string) (map[string]provisioning.AppliedResult, error) {
 	lockPath := lockFilePath(targetDir)
 	lockFile, err := provisioning.ReadLockFile(lockPath)
 	if err != nil {
 		return nil, fmt.Errorf("read lockfile: %w", err)
 	}
 
-	results := make(map[string]provisioning.AppliedResult, len(providers))
+	results := make(map[string]provisioning.AppliedResult, len(projections))
 	var approvedMCP map[string]string
 	if len(approvalHashes) > 0 {
 		approvedMCP = approvalHashes[0]
 	}
 	// Validate every authorized local command for every destination before any
-	// provider file or lockfile can change. Provider is carried into errors so
-	// a failed multi-provider sync identifies the configuration it protected.
-	baseDirs := make(map[string]string, len(providers))
-	for _, p := range providers {
-		baseDir, err := provisioning.BaseDirFor(configurator.Provider(p), targetDir)
-		if err != nil {
+	// provider file or lockfile can change, and — for a workspace projection —
+	// check the repository hygiene rules too (D193 WP5). Both refusals are free
+	// here: nothing has been written yet. The projection is carried into errors
+	// so a failed multi-projection sync identifies the configuration it
+	// protected.
+	for _, p := range projections {
+		// Preflight the projection's OWN view: validating the whole candidate
+		// set would fail a sync over a local command belonging to a KB this
+		// projection is not even bound to (D170).
+		if err := provisioning.PreflightStdioMCP(manifests[projectionKey(p)], provisioning.ApplyOptions{Provider: configurator.Provider(p.Provider), BaseDir: p.BaseDir, Scope: p.Scope, AutoTrust: autoTrust, ApprovedMCP: approvedMCP}); err != nil {
 			return nil, err
 		}
-		baseDirs[p] = baseDir
-		// Preflight the provider's OWN view: validating the whole candidate set
-		// would fail a sync over a local command belonging to a KB this
-		// provider is not even bound to (D170).
-		if err := provisioning.PreflightStdioMCP(manifests[p], provisioning.ApplyOptions{Provider: configurator.Provider(p), BaseDir: baseDir, AutoTrust: autoTrust, ApprovedMCP: approvedMCP}); err != nil {
+		if err := prepareWorkspace(p, dryRun); err != nil {
 			return nil, err
 		}
 	}
+	// A projection the lockfile still records but the configuration no longer
+	// declares — a workspace that was unbound, or a provider that left
+	// workspace scope — must have its files removed. Nothing else would ever
+	// touch them: they are outside every remaining projection, so a later sync
+	// would not see them and `doctor` would report them as residue forever.
+	// This runs before the projections are applied, so the files are gone
+	// before anything is written in their place.
+	if !dryRun {
+		orphans, err := pruneOrphanProjections(&lockFile, projections, targetDir)
+		if err != nil {
+			return nil, err
+		}
+		if len(orphans) > 0 {
+			if err := provisioning.WriteLockFile(lockPath, lockFile); err != nil {
+				return nil, fmt.Errorf("write lockfile after pruning %s: %w", strings.Join(orphans, ", "), err)
+			}
+		}
+	}
+
 	var appliedSoFar []string
-	for _, p := range providers {
-		previous := lockFile.ForProvider(p)
+	for _, p := range projections {
+		previous := lockFile.ForProjection(p.Key())
 		opts := provisioning.ApplyOptions{
-			Provider:           configurator.Provider(p),
-			BaseDir:            baseDirs[p],
+			Provider:           configurator.Provider(p.Provider),
+			BaseDir:            p.BaseDir,
+			Scope:              p.Scope,
 			DryRun:             dryRun,
 			NoHeal:             noHeal,
 			AutoTrust:          autoTrust,
@@ -460,25 +486,25 @@ func materializeForProviders(manifests map[string]provisioning.Manifest, provide
 			SearchRoots:        portability.SearchRoots,
 			SearchDepth:        portability.SearchDepth,
 			Paths:              portability.Paths,
-			KBOrder:            kbOrder[p],
+			KBOrder:            kbOrder[p.Provider],
 		}
-		// Apply only the artifacts the provider knows how to materialize:
-		// Unsupported kinds are neither drift nor pending; they
+		// Apply only the artifacts the provider knows how to materialize in
+		// this scope: unsupported kinds are neither drift nor pending, they
 		// simply don't concern it.
-		applied, err := provisioning.Apply(provisioning.FilterForProvider(manifests[p], configurator.Provider(p)), opts)
+		applied, err := provisioning.Apply(provisioning.FilterForProviderScoped(manifests[projectionKey(p)], configurator.Provider(p.Provider), p.Scope), opts)
 		if err != nil {
 			// Name what is already recorded, so a rerun is informed rather
 			// than a guess about how far the previous one got.
 			if len(appliedSoFar) > 0 {
-				return nil, fmt.Errorf("apply %s: %w (already applied and recorded: %s)", p, err, strings.Join(appliedSoFar, ", "))
+				return nil, fmt.Errorf("apply %s: %w (already applied and recorded: %s)", p.Label(), err, strings.Join(appliedSoFar, ", "))
 			}
-			return nil, fmt.Errorf("apply %s: %w", p, err)
+			return nil, fmt.Errorf("apply %s: %w", p.Label(), err)
 		}
 		// Record the base dir only when it is not the lockfile's own
 		// directory: every existing lockfile keeps its current meaning and no
-		// migration runs (D141).
-		if baseDirs[p] != targetDir {
-			applied.NewLock.BaseDir = baseDirs[p]
+		// migration runs (D141). SetProjection records it for a workspace.
+		if p.BaseDir != targetDir {
+			applied.NewLock.BaseDir = p.BaseDir
 		}
 		// An unknown live version preserves the recorded one rather than
 		// blanking it (D142).
@@ -486,8 +512,8 @@ func materializeForProviders(manifests map[string]provisioning.Manifest, provide
 		if serverVersion != "" {
 			applied.NewLock.ServerVersion = serverVersion
 		}
-		lockFile.SetProvider(p, applied.NewLock)
-		results[p] = applied
+		lockFile.SetProjection(p.Key(), applied.NewLock, p.Remote)
+		results[projectionKey(p)] = applied
 
 		// Checkpoint after every provider, not once at the end (D172). With a
 		// single trailing write, a failure on provider N left providers
@@ -497,9 +523,9 @@ func materializeForProviders(manifests map[string]provisioning.Manifest, provide
 		// provider's own partial files are still possible (D178).
 		if !dryRun {
 			if err := provisioning.WriteLockFile(lockPath, lockFile); err != nil {
-				return nil, fmt.Errorf("write lockfile after %s: %w", p, err)
+				return nil, fmt.Errorf("write lockfile after %s: %w", p.Label(), err)
 			}
-			appliedSoFar = append(appliedSoFar, p)
+			appliedSoFar = append(appliedSoFar, p.Label())
 		}
 	}
 	return results, nil

--- a/cmd/cartographer/clientsync_test.go
+++ b/cmd/cartographer/clientsync_test.go
@@ -157,7 +157,7 @@ func TestFetchMergedManifestVerifiesPinnedSignatureAndRejectsTampering(t *testin
 	}
 
 	target := t.TempDir()
-	if _, err := materializeForProviders(uniformManifests(m, []string{"claude"}), []string{"claude"}, target, "", false, false, false, portabilityOptions{}, nil); err != nil {
+	if _, err := materializeForProviders(uniformManifests(m, []string{"claude"}), globalProjections([]string{"claude"}, target), target, "", false, false, false, portabilityOptions{}, nil); err != nil {
 		t.Fatalf("materialize valid manifest: %v", err)
 	}
 	lockPath := filepath.Join(target, provisioning.LockFileName)
@@ -193,7 +193,7 @@ func TestFetchMergedManifestVerifiesPinnedSignatureAndRejectsTampering(t *testin
 			fetched, fetchErr := fetchMergedManifest(cfg)
 			srv.Close()
 			if fetchErr == nil {
-				_, fetchErr = materializeForProviders(uniformManifests(fetched, []string{"claude"}), []string{"claude"}, target, "", false, false, false, portabilityOptions{}, nil)
+				_, fetchErr = materializeForProviders(uniformManifests(fetched, []string{"claude"}), globalProjections([]string{"claude"}, target), target, "", false, false, false, portabilityOptions{}, nil)
 			}
 			if fetchErr == nil {
 				t.Fatal("tampered sync unexpectedly succeeded")
@@ -284,7 +284,7 @@ func TestAuthorizationDoesNotSetSigned(t *testing.T) {
 	if m.Artifacts[0].Signed {
 		t.Fatal("test fixture must be unsigned")
 	}
-	if _, err := materializeForProviders(uniformManifests(m, []string{"claude"}), []string{"claude"}, t.TempDir(), "", true, true, false, portabilityOptions{}, nil); err != nil {
+	if _, err := materializeForProviders(uniformManifests(m, []string{"claude"}), globalProjections([]string{"claude"}, t.TempDir()), t.TempDir(), "", true, true, false, portabilityOptions{}, nil); err != nil {
 		t.Fatal(err)
 	}
 	if m.Artifacts[0].Signed {
@@ -296,7 +296,7 @@ func TestMaterializeForProviders_TrustAvoidsNeedsApproval(t *testing.T) {
 	dir := t.TempDir()
 	m := kbSkillManifest()
 
-	results, err := materializeForProviders(uniformManifests(m, []string{"claude"}), []string{"claude"}, dir, "", true, true /* dryRun */, false, portabilityOptions{}, nil)
+	results, err := materializeForProviders(uniformManifests(m, []string{"claude"}), globalProjections([]string{"claude"}, dir), dir, "", true, true /* dryRun */, false, portabilityOptions{}, nil)
 	if err != nil {
 		t.Fatalf("materializeForProviders: %v", err)
 	}
@@ -313,7 +313,7 @@ func TestMaterializeForProviders_NoTrustNeedsApproval(t *testing.T) {
 	dir := t.TempDir()
 	m := kbSkillManifest()
 
-	results, err := materializeForProviders(uniformManifests(m, []string{"claude"}), []string{"claude"}, dir, "", false, true /* dryRun */, false, portabilityOptions{}, nil)
+	results, err := materializeForProviders(uniformManifests(m, []string{"claude"}), globalProjections([]string{"claude"}, dir), dir, "", false, true /* dryRun */, false, portabilityOptions{}, nil)
 	if err != nil {
 		t.Fatalf("materializeForProviders: %v", err)
 	}
@@ -354,7 +354,7 @@ func TestMaterializeForProviders_Instructions_ClaudeEKiro(t *testing.T) {
 	dir := t.TempDir()
 	m := instructionsManifest("homelab", "Contenuto di imprinting per homelab.\n")
 
-	results, err := materializeForProviders(uniformManifests(m, []string{"claude", "kiro"}), []string{"claude", "kiro"}, dir, "", true, false /* dryRun */, false, portabilityOptions{}, nil)
+	results, err := materializeForProviders(uniformManifests(m, []string{"claude", "kiro"}), globalProjections([]string{"claude", "kiro"}, dir), dir, "", true, false /* dryRun */, false, portabilityOptions{}, nil)
 	if err != nil {
 		t.Fatalf("materializeForProviders: %v", err)
 	}
@@ -477,7 +477,7 @@ func TestMaterializeForProviders_StdioPreflightIsAtomic(t *testing.T) {
 		Kind: "mcp", Name: "missing", Source: "kb:kb", Signed: true,
 		ContentHash: provisioning.ContentHashFiles([]provisioning.ArtifactFile{file}), Files: []provisioning.ArtifactFile{file},
 	}}}
-	_, err := materializeForProviders(uniformManifests(m, []string{"claude", "codex"}), []string{"claude", "codex"}, dir, "", false, false, false, portabilityOptions{}, nil)
+	_, err := materializeForProviders(uniformManifests(m, []string{"claude", "codex"}), globalProjections([]string{"claude", "codex"}, dir), dir, "", false, false, false, portabilityOptions{}, nil)
 	if err == nil || !strings.Contains(err.Error(), "not found on PATH") || !strings.Contains(err.Error(), "for claude") {
 		t.Fatalf("preflight error = %v", err)
 	}
@@ -499,7 +499,7 @@ func TestMaterializeForProviders_PerProviderBaseDir(t *testing.T) {
 	t.Setenv("HERMES_HOME", hermesHome)
 
 	m := kbSkillManifest()
-	if _, err := materializeForProviders(uniformManifests(m, []string{"claude", "hermes"}), []string{"claude", "hermes"}, dir, "", true, false /* dryRun */, false, portabilityOptions{}, nil); err != nil {
+	if _, err := materializeForProviders(uniformManifests(m, []string{"claude", "hermes"}), globalProjections([]string{"claude", "hermes"}, dir), dir, "", true, false /* dryRun */, false, portabilityOptions{}, nil); err != nil {
 		t.Fatalf("materializeForProviders: %v", err)
 	}
 
@@ -545,11 +545,15 @@ func TestMaterializeForProviders_PerProviderBaseDir(t *testing.T) {
 
 // $HERMES_HOME unset is a failure that names the variable, not a silent
 // fallback to the home directory (D141).
+// A provider whose base dir cannot be resolved fails before anything is
+// written, naming the variable that would fix it. Since D193 the resolution
+// happens while the projections are built — one per provider in the default
+// scope — which is the first thing both `sync` and `connect` do.
 func TestMaterializeForProviders_MissingProviderBaseDir(t *testing.T) {
 	t.Setenv("HERMES_HOME", "")
-	_, err := materializeForProviders(uniformManifests(kbSkillManifest(), []string{"hermes"}), []string{"hermes"}, t.TempDir(), "", true, false, false, portabilityOptions{}, nil)
+	_, err := allProjections(&clientconfig.Config{}, []string{"hermes"}, t.TempDir())
 	if err == nil {
-		t.Fatal("materializeForProviders succeeded with $HERMES_HOME unset")
+		t.Fatal("projections resolved with $HERMES_HOME unset")
 	}
 	if !strings.Contains(err.Error(), "HERMES_HOME") {
 		t.Errorf("error %q does not name the variable", err)
@@ -848,7 +852,7 @@ func TestUnbindingRemovesItsArtifacts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("manifestsForProviders: %v", err)
 	}
-	if _, err := materializeForProviders(both, cfg.Agents, dir, "", true, false, false, portabilityOptions{}, nil); err != nil {
+	if _, err := materializeForProviders(both, globalProjections(cfg.Agents, dir), dir, "", true, false, false, portabilityOptions{}, nil); err != nil {
 		t.Fatalf("materialize: %v", err)
 	}
 	twoPath := filepath.Join(dir, ".claude", "skills", "skill-two", "SKILL.md")
@@ -864,7 +868,7 @@ func TestUnbindingRemovesItsArtifacts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("manifestsForProviders (narrowed): %v", err)
 	}
-	if _, err := materializeForProviders(narrowed, cfg.Agents, dir, "", true, false, false, portabilityOptions{}, nil); err != nil {
+	if _, err := materializeForProviders(narrowed, globalProjections(cfg.Agents, dir), dir, "", true, false, false, portabilityOptions{}, nil); err != nil {
 		t.Fatalf("materialize (narrowed): %v", err)
 	}
 	if _, err := os.Stat(twoPath); !os.IsNotExist(err) {
@@ -942,7 +946,7 @@ func TestPrintSyncRevisions_UnsupportedKindReportsRecordedRevision(t *testing.T)
 		t.Fatal("test fixture is broken: filtering the agent out must change the revision")
 	}
 
-	results, err := materializeForProviders(uniformManifests(m, []string{"hermes"}), []string{"hermes"}, t.TempDir(), "", true, false, false, portabilityOptions{}, nil)
+	results, err := materializeForProviders(uniformManifests(m, []string{"hermes"}), globalProjections([]string{"hermes"}, t.TempDir()), t.TempDir(), "", true, false, false, portabilityOptions{}, nil)
 	if err != nil {
 		t.Fatalf("materializeForProviders: %v", err)
 	}
@@ -969,7 +973,7 @@ func TestPrintSyncRevisions_DryRunMatchesReal(t *testing.T) {
 	m := skillAndAgentManifest()
 	filtered := provisioning.FilterForProvider(m, configurator.ProviderHermes)
 
-	results, err := materializeForProviders(uniformManifests(m, []string{"hermes"}), []string{"hermes"}, t.TempDir(), "", true, true /* dryRun */, false, portabilityOptions{}, nil)
+	results, err := materializeForProviders(uniformManifests(m, []string{"hermes"}), globalProjections([]string{"hermes"}, t.TempDir()), t.TempDir(), "", true, true /* dryRun */, false, portabilityOptions{}, nil)
 	if err != nil {
 		t.Fatalf("materializeForProviders (dry-run): %v", err)
 	}
@@ -994,7 +998,7 @@ func TestPrintSyncRevisions_MultiProviderDivergence(t *testing.T) {
 		t.Fatal("test fixture is broken: claude and hermes must diverge")
 	}
 
-	results, err := materializeForProviders(uniformManifests(m, []string{"claude", "hermes"}), []string{"claude", "hermes"}, t.TempDir(), "", true, false, false, portabilityOptions{}, nil)
+	results, err := materializeForProviders(uniformManifests(m, []string{"claude", "hermes"}), globalProjections([]string{"claude", "hermes"}, t.TempDir()), t.TempDir(), "", true, false, false, portabilityOptions{}, nil)
 	if err != nil {
 		t.Fatalf("materializeForProviders: %v", err)
 	}
@@ -1107,7 +1111,7 @@ func TestMaterializeCheckpointsPerProvider(t *testing.T) {
 	// Learn where opencode materializes, by letting it succeed once in a
 	// throwaway directory, then sabotage that exact path in the real one.
 	probe := t.TempDir()
-	if _, err := materializeForProviders(map[string]provisioning.Manifest{"opencode": agentManifest}, []string{"opencode"}, probe, "", true, false, false, portabilityOptions{}, nil); err != nil {
+	if _, err := materializeForProviders(map[string]provisioning.Manifest{"opencode": agentManifest}, globalProjections([]string{"opencode"}, probe), probe, "", true, false, false, portabilityOptions{}, nil); err != nil {
 		t.Fatalf("probe run: %v", err)
 	}
 	probeLock, err := provisioning.ReadLockFile(lockFilePath(probe))
@@ -1125,7 +1129,7 @@ func TestMaterializeCheckpointsPerProvider(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = materializeForProviders(manifests, providers, dir, "", true, false, false, portabilityOptions{}, nil)
+	_, err = materializeForProviders(manifests, globalProjections(providers, dir), dir, "", true, false, false, portabilityOptions{}, nil)
 	if err == nil {
 		t.Fatal("materialize should fail: opencode's destination file is a directory")
 	}
@@ -1200,4 +1204,21 @@ func TestDryRunPlanCoversRemovalsAndKnownKBs(t *testing.T) {
 			t.Errorf("a dry run modified %s", name)
 		}
 	}
+}
+
+// globalProjections is the test helper for the shape every caller had before
+// D193: one global projection per provider, materializing into baseDir.
+// It resolves each provider's own base dir exactly as allProjections does, so
+// a provider that materializes outside the shared client dir (hermes under
+// $HERMES_HOME, D141) is not silently redirected into it by the helper.
+func globalProjections(providers []string, baseDir string) []syncProjection {
+	out := make([]syncProjection, 0, len(providers))
+	for _, p := range providers {
+		resolved, err := provisioning.BaseDirFor(configurator.Provider(p), baseDir)
+		if err != nil {
+			resolved = baseDir
+		}
+		out = append(out, globalProjection(p, resolved, nil))
+	}
+	return out
 }

--- a/cmd/cartographer/connect.go
+++ b/cmd/cartographer/connect.go
@@ -330,6 +330,7 @@ func cmdConnect(args []string) int {
 	agentsCSV := fs.String("agents", "", "Comma-separated agent subset: claude,codex")
 	var kbSel repeatedString
 	fs.Var(&kbSel, "kb", "KB this client may receive (repeatable, or comma-separated; 'all' for every mounted KB)")
+	workspaceFlag := fs.String("workspace", "", "Project the selected KBs into this repository instead of the global catalogue (D193)")
 	fs.Parse(rest)
 
 	interactive := wantsConnectForm(fs, *noInput)
@@ -374,6 +375,7 @@ func cmdConnect(args []string) int {
 		Trust:     settings.Trust,
 		PinKeys:   pinKeys,
 		KBs:       splitCommaList(kbSel),
+		Workspace: *workspaceFlag,
 	}
 
 	if interactive {
@@ -607,6 +609,14 @@ type connectOptions struct {
 	// mounted KB and is recorded as an explicit binding to their names, which
 	// is what stops a KB mounted later from widening this client.
 	KBs []string
+	// Workspace, when set, makes this connect a WORKSPACE binding rather than
+	// a provider-global one (D193): the selected KBs are projected into that
+	// repository's own project-local directories and nothing KB-sourced is
+	// written to the global catalogue. It is offered at connect because the
+	// choice between the two has to be made *before the first write*: a
+	// provider-global connect materializes every selected KB's artifacts into
+	// $HOME, and moving them afterwards is a migration rather than a choice.
+	Workspace string
 }
 
 // connectResult is the outcome of doConnect: which providers were connected, the
@@ -687,6 +697,30 @@ func doConnect(opts connectOptions) (connectResult, error) {
 			}
 		}
 	}
+	// D193: --workspace turns the selection into a workspace binding instead of
+	// a global one. It is decided here, before step 3 writes anything, because
+	// a provider-global connect materializes every selected KB into $HOME and
+	// undoing that afterwards is a migration, not a choice.
+	if opts.Workspace != "" {
+		for _, provider := range opts.Providers {
+			p := configurator.Provider(provider)
+			if !provisioning.SupportsProjectScope(p) {
+				return connectResult{}, fmt.Errorf("%s cannot be scoped to a workspace: %s",
+					provider, provisioning.ProjectScopeUnsupportedReason(p))
+			}
+			if err := existing.BindWorkspace(provider, opts.Workspace, selected); err != nil {
+				return connectResult{}, err
+			}
+			if err := existing.SetWorkspaceScope(provider, clientconfig.ScopeWorkspace); err != nil {
+				return connectResult{}, err
+			}
+		}
+	} else if len(selected) > 0 && len(kbs) > 1 && !opts.DryRun {
+		// Name the alternative once, where the operator is deciding. Silence
+		// here is how a machine-wide catalogue becomes the default nobody chose.
+		fmt.Println("note: these KBs will be readable from every directory on this machine.")
+		fmt.Println("      pass --workspace <repo> to confine them to one repository instead (docs/sync.md §Workspace scope).")
+	}
 
 	// entryKBs stays the server's full mount list: it tells entriesForKBs that
 	// the endpoint must be scoped with ?kb= at all. Which of them this provider
@@ -756,11 +790,15 @@ func doConnect(opts connectOptions) (connectResult, error) {
 		mcpEntries = nil
 	}
 	res := connectResult{Providers: opts.Providers, ConfigsWritten: configsWritten, MCPEntries: mcpEntries, Warnings: configWarnings}
-	if manifests, err := manifestsForProviders(pullCfg, opts.Providers); err != nil {
+	projections, projErr := allProjections(pullCfg, opts.Providers, opts.Dir)
+	if projErr != nil {
+		return connectResult{}, projErr
+	}
+	if manifests, err := manifestsForProjections(pullCfg, projections); err != nil {
 		res.Deferred = true
 		res.DeferredErr = err
 	} else {
-		applied, err := materializeForProviders(manifests, opts.Providers, opts.Dir, facts.Version, opts.Trust || opts.AutoTrust, opts.DryRun, false /* noHeal */, portabilityOptions{SearchRoots: existing.SearchRoots, SearchDepth: existing.SearchDepth, Paths: existing.Paths}, kbOrderForProviders(pullCfg, opts.Providers), existing.ApprovedMCPHashes())
+		applied, err := materializeForProviders(manifests, projections, opts.Dir, facts.Version, opts.Trust || opts.AutoTrust, opts.DryRun, false /* noHeal */, portabilityOptions{SearchRoots: existing.SearchRoots, SearchDepth: existing.SearchDepth, Paths: existing.Paths}, kbOrderForProviders(pullCfg, opts.Providers), existing.ApprovedMCPHashes())
 		if err != nil {
 			return connectResult{}, err
 		}

--- a/cmd/cartographer/doctor.go
+++ b/cmd/cartographer/doctor.go
@@ -194,6 +194,7 @@ func runDoctor(dir, only string) doctorReport {
 		findings = append(findings, checkSymlinkedDestinations(dir, providers)...)
 		findings = append(findings, checkCapabilities(dir, cfg)...)
 		findings = append(findings, checkKBCollisions(dir, cfg, providers)...)
+		findings = append(findings, checkWorkspaceProjections(dir, cfg, providers)...)
 		if lockErr == nil {
 			findings = append(findings, checkUnboundResidues(dir, cfg, providers, lockFile)...)
 		}

--- a/cmd/cartographer/main.go
+++ b/cmd/cartographer/main.go
@@ -31,6 +31,7 @@ var subcommands = []subcommand{
 	{"Client", "reconnect", "Rebuild an agent client's configuration from scratch"},
 	{"Client", "approve", "Approve or revoke a third-party MCP descriptor"},
 	{"Client", "client", "Manage which KBs each agent client receives"},
+	{"Client", "workspace", "Bind a repository to the KBs a client receives there"},
 	{"Server", "serve", "Run the MCP server"},
 	{"Server", "service", "Manage the native server service"},
 	{"Server", "upgrade-repair", "Repair the native service and provider sync after an upgrade"},
@@ -66,6 +67,7 @@ var (
 	reindexFn       = cmdReindex
 	auditFn         = cmdAudit
 	clientFn        = cmdClient
+	workspaceFn     = cmdWorkspace
 )
 
 func main() {
@@ -129,6 +131,8 @@ func run(args []string) int {
 		return reindexFn(rest)
 	case "client":
 		return clientFn(rest)
+	case "workspace":
+		return workspaceFn(rest)
 	default:
 		fmt.Fprintf(os.Stderr, "Error: unknown command %q", cmd)
 		if suggestion := commandSuggestion(cmd); suggestion != "" {

--- a/cmd/cartographer/reconnect_test.go
+++ b/cmd/cartographer/reconnect_test.go
@@ -195,7 +195,7 @@ func TestMaterializeForProviders_RecordsServerVersion(t *testing.T) {
 	dir := t.TempDir()
 	m := kbSkillManifest()
 
-	if _, err := materializeForProviders(uniformManifests(m, []string{"claude"}), []string{"claude"}, dir, "1.4.0", true, false, false, portabilityOptions{}, nil); err != nil {
+	if _, err := materializeForProviders(uniformManifests(m, []string{"claude"}), globalProjections([]string{"claude"}, dir), dir, "1.4.0", true, false, false, portabilityOptions{}, nil); err != nil {
 		t.Fatalf("materializeForProviders: %v", err)
 	}
 	lockFile, err := provisioning.ReadLockFile(lockFilePath(dir))
@@ -207,7 +207,7 @@ func TestMaterializeForProviders_RecordsServerVersion(t *testing.T) {
 	}
 
 	// An offline sync (empty version) must not erase the knowledge.
-	if _, err := materializeForProviders(uniformManifests(m, []string{"claude"}), []string{"claude"}, dir, "", true, false, false, portabilityOptions{}, nil); err != nil {
+	if _, err := materializeForProviders(uniformManifests(m, []string{"claude"}), globalProjections([]string{"claude"}, dir), dir, "", true, false, false, portabilityOptions{}, nil); err != nil {
 		t.Fatalf("materializeForProviders offline: %v", err)
 	}
 	lockFile, err = provisioning.ReadLockFile(lockFilePath(dir))

--- a/cmd/cartographer/status.go
+++ b/cmd/cartographer/status.go
@@ -103,6 +103,7 @@ func renderStatus(output string, s statusSnapshot, code int) int {
 		if p.State == "in_sync" {
 			fmt.Printf("[%s] in-sync (revision %s)\n", p.Name, p.Revision)
 			printBindingLine(p)
+			printWorkspaceLines(p.Workspaces)
 			if p.Kinds != "" {
 				fmt.Printf("  %s\n", p.Kinds)
 			}
@@ -115,6 +116,7 @@ func renderStatus(output string, s statusSnapshot, code int) int {
 		}
 		fmt.Printf("[%s] drift (manifest %s, lock %s)\n", p.Name, p.Revision, p.LockRevision)
 		printBindingLine(p)
+		printWorkspaceLines(p.Workspaces)
 		if p.Kinds != "" {
 			fmt.Printf("  %s\n", p.Kinds)
 		}

--- a/cmd/cartographer/status_snapshot.go
+++ b/cmd/cartographer/status_snapshot.go
@@ -60,6 +60,25 @@ type providerStatus struct {
 	// the lockfile's per-file Source (D170). Empty for a lockfile written
 	// before that field existed: unknown, not zero.
 	KBCounts map[string]int `json:"kb_counts,omitempty"`
+	// Workspaces reports this provider's workspace projections (D193), empty
+	// for a provider in the default scope. A workspace-scoped provider's own
+	// counts above describe its bundle-only global projection, which is
+	// deliberately not the interesting part: the KB artifacts live here.
+	Workspaces []workspaceStatus `json:"workspaces,omitempty"`
+}
+
+// workspaceStatus is one workspace projection's state, as `status` reports it.
+type workspaceStatus struct {
+	Path string   `json:"path"`
+	KBs  []string `json:"kbs,omitempty"`
+	// State is "ok", "gone" (the bound directory is not there any more),
+	// "moved" (its git remote is not the one it was bound to) or "inactive"
+	// (the files are correct but the client will not read them — a Codex
+	// project that is not trusted). Each is reported, none is healed: a
+	// projection that silently fell back to the global catalogue is the
+	// exposure this whole scope exists to prevent.
+	State  string `json:"state"`
+	Detail string `json:"detail,omitempty"`
 }
 
 type statusArtifact struct {
@@ -331,6 +350,12 @@ func providerStatuses(cfg *clientconfig.Config) []providerStatus {
 			state = "unknown"
 		}
 		out[i] = providerStatus{Name: string(a.Provider), Installed: a.Installed, Connected: connected[string(a.Provider)], State: state}
+		if cfg != nil && connected[string(a.Provider)] {
+			base, err := clientconfig.TargetDir()
+			if err == nil {
+				out[i].Workspaces = workspaceStatuses(cfg, string(a.Provider), base)
+			}
+		}
 	}
 	return out
 }

--- a/cmd/cartographer/sync.go
+++ b/cmd/cartographer/sync.go
@@ -148,7 +148,15 @@ func runSync(dir string, cfg *clientconfig.Config, opts syncOptions) (syncResult
 		cfg.KnownKBs = kbs
 	}
 
-	manifests, err := manifestsForProviders(cfg, targets)
+	// D193: one applied state per projection. A provider in the default scope
+	// has exactly one — the global catalogue, byte-identical to before — and a
+	// workspace-scoped one has a bundle-only global projection plus one per
+	// bound workspace.
+	projections, err := allProjections(cfg, targets, dir)
+	if err != nil {
+		return syncResult{}, fmt.Errorf("%w (no configuration was modified)", err)
+	}
+	manifests, err := manifestsForProjections(cfg, projections)
 	if err != nil {
 		return syncResult{}, fmt.Errorf("%w (no configuration was modified)", err)
 	}
@@ -193,7 +201,7 @@ func runSync(dir string, cfg *clientconfig.Config, opts syncOptions) (syncResult
 		}
 	}
 
-	results, err := materializeForProviders(manifests, targets, dir, facts.Version, cfg.Trust || opts.AutoTrust, opts.DryRun, opts.NoHeal, portabilityOptions{SearchRoots: cfg.SearchRoots, SearchDepth: cfg.SearchDepth, Paths: cfg.Paths}, kbOrderForProviders(cfg, targets), cfg.ApprovedMCPHashes())
+	results, err := materializeForProviders(manifests, projections, dir, facts.Version, cfg.Trust || opts.AutoTrust, opts.DryRun, opts.NoHeal, portabilityOptions{SearchRoots: cfg.SearchRoots, SearchDepth: cfg.SearchDepth, Paths: cfg.Paths}, kbOrderForProviders(cfg, targets), cfg.ApprovedMCPHashes())
 	if err != nil {
 		return syncResult{}, err
 	}

--- a/cmd/cartographer/tui.go
+++ b/cmd/cartographer/tui.go
@@ -520,7 +520,11 @@ func syncOneProvider(provider, dir string) syncDoneMsg {
 	if err != nil {
 		return syncDoneMsg{provider: provider, err: err}
 	}
-	manifests, err := manifestsForProviders(cfg, []string{provider})
+	projections, err := allProjections(cfg, []string{provider}, dir)
+	if err != nil {
+		return syncDoneMsg{provider: provider, err: err}
+	}
+	manifests, err := manifestsForProjections(cfg, projections)
 	if err != nil {
 		return syncDoneMsg{provider: provider, err: err}
 	}
@@ -528,10 +532,12 @@ func syncOneProvider(provider, dir string) syncDoneMsg {
 	// leaves it empty, which preserves the previously recorded value
 	// instead of erasing it.
 	facts, _ := enumerateKBs(cfg.ServerURL, cfg.Auth, cfg.TokenEnv)
-	applied, err := materializeForProviders(manifests, []string{provider}, dir, facts.Version, cfg.Trust, false, false /* noHeal */, portabilityOptions{SearchRoots: cfg.SearchRoots, SearchDepth: cfg.SearchDepth, Paths: cfg.Paths}, kbOrderForProviders(cfg, []string{provider}), cfg.ApprovedMCPHashes())
+	applied, err := materializeForProviders(manifests, projections, dir, facts.Version, cfg.Trust, false, false /* noHeal */, portabilityOptions{SearchRoots: cfg.SearchRoots, SearchDepth: cfg.SearchDepth, Paths: cfg.Paths}, kbOrderForProviders(cfg, []string{provider}), cfg.ApprovedMCPHashes())
 	if err != nil {
 		return syncDoneMsg{provider: provider, err: err}
 	}
+	// The dashboard shows one card per provider: report its global projection,
+	// which is the one the card's counts describe.
 	return syncDoneMsg{provider: provider, applied: applied[provider]}
 }
 

--- a/cmd/cartographer/workspace.go
+++ b/cmd/cartographer/workspace.go
@@ -1,0 +1,720 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/BeppeTemp/cartographer/internal/clientconfig"
+	"github.com/BeppeTemp/cartographer/internal/configurator"
+	"github.com/BeppeTemp/cartographer/internal/provisioning"
+)
+
+// workspace.go (D193) — resolving a provider's projections, and the
+// `cartographer workspace` subcommand.
+//
+// A provider in the default scope has exactly one projection: the global
+// catalogue under $HOME, which is what every release before D193 had. A
+// provider in workspace scope has one projection per bound workspace, plus a
+// global one that carries **only** Cartographer's own transversal bundled
+// skills — never a KB's content (decisions 4 and 5).
+
+// syncProjection is one applied state to compute and materialize: a provider,
+// where it writes, and which KBs it may receive there.
+type syncProjection struct {
+	Provider string
+	// Workspace is the canonical path of the bound workspace, empty for the
+	// global projection.
+	Workspace string
+	// BaseDir is where artifacts are materialized: the client base dir for the
+	// global projection, the workspace path otherwise.
+	BaseDir string
+	// Remote is the workspace's recorded git remote guard, empty when there is
+	// none or for the global projection.
+	Remote string
+	// KBs are the KBs this projection may receive. Empty is a legal, explicit
+	// state and never means "every KB".
+	KBs []string
+	// BundleOnly marks the residual global projection of a workspace-scoped
+	// provider: it carries the transversal bundled skills and nothing
+	// KB-sourced. This is decision 5 made into a flag rather than a convention.
+	BundleOnly bool
+	// Scope is the destination matrix half this projection writes through.
+	Scope provisioning.Scope
+}
+
+// Key is the lockfile projection this state is recorded under.
+func (p syncProjection) Key() provisioning.Projection {
+	return provisioning.Projection{Provider: p.Provider, Workspace: p.Workspace}
+}
+
+// Label names the projection for a user-facing line.
+func (p syncProjection) Label() string {
+	if p.Workspace == "" {
+		return p.Provider
+	}
+	return p.Provider + " [" + p.Workspace + "]"
+}
+
+// projectionsFor resolves every projection a provider currently has.
+//
+// In the default scope this is exactly one entry, identical in every respect to
+// what the code did before workspaces existed. In workspace scope it is one
+// entry per bound workspace plus the bundle-only global one; a provider that
+// cannot project into a workspace at all is an error naming the reason, never a
+// silent fall back to the global catalogue — falling back is the exposure this
+// plan closes.
+func projectionsFor(cfg *clientconfig.Config, provider, clientBaseDir string) ([]syncProjection, error) {
+	if cfg.WorkspaceScope(provider) != clientconfig.ScopeWorkspace {
+		bound, _ := cfg.BoundKBs(provider)
+		return []syncProjection{{
+			Provider: provider,
+			BaseDir:  clientBaseDir,
+			KBs:      bound,
+			Scope:    provisioning.ScopeGlobal,
+		}}, nil
+	}
+
+	p := configurator.Provider(provider)
+	if !provisioning.SupportsProjectScope(p) {
+		return nil, fmt.Errorf("%s cannot be scoped to a workspace: %s — leave it in the default scope, or run it under a separate profile",
+			provider, provisioning.ProjectScopeUnsupportedReason(p))
+	}
+
+	// The residual global projection: transversal bundle only. It exists so an
+	// upgrade to workspace scope does not take `cartographer-ops` and its
+	// siblings away from a session that is not in any bound workspace.
+	out := []syncProjection{{
+		Provider:   provider,
+		BaseDir:    clientBaseDir,
+		BundleOnly: true,
+		Scope:      provisioning.ScopeGlobal,
+	}}
+
+	bindings := cfg.WorkspaceBindings(provider)
+	sort.Slice(bindings, func(i, j int) bool { return bindings[i].Path < bindings[j].Path })
+	for _, w := range bindings {
+		if info, err := os.Stat(w.Path); err != nil || !info.IsDir() {
+			return nil, fmt.Errorf("%s: bound workspace %s is gone — rebind it, or remove the binding with `cartographer workspace unbind %s %s`",
+				provider, w.Path, provider, w.Path)
+		}
+		out = append(out, syncProjection{
+			Provider:  provider,
+			Workspace: w.Path,
+			BaseDir:   w.Path,
+			Remote:    w.Remote,
+			KBs:       w.KBs,
+			Scope:     provisioning.ScopeProject,
+		})
+	}
+	return out, nil
+}
+
+// artifactsForProjection narrows the fetched candidates to what one projection
+// may receive. This is WP4's scoping: the strict collision check downstream then
+// answers "do two KBs collide **here**", which is the only place a collision can
+// actually confuse an agent. Two KBs owning a same-named skill in two different
+// workspaces is legal; the same two bound to one workspace is not.
+func (cs candidateSet) forProjection(cfg *clientconfig.Config, p syncProjection) []provisioning.Artifact {
+	if p.BundleOnly {
+		out := make([]provisioning.Artifact, 0, len(cs.Bare))
+		for _, a := range cs.all() {
+			if a.Source == "bundle" {
+				out = append(out, a)
+			}
+		}
+		return out
+	}
+	if p.Workspace == "" {
+		return cs.forProvider(cfg, p.Provider)
+	}
+	if cs.HasBare {
+		// No KB names to match: a workspace binding cannot be expressed against
+		// a server that does not identify its KBs, so the projection receives
+		// nothing rather than everything. Fail closed (decision 8).
+		return nil
+	}
+	// KB artifacts only. Cartographer's own transversal bundled skills belong
+	// to no perimeter and stay in the global catalogue (decision 4); copying
+	// them into every workspace would multiply them by the number of bindings
+	// and put `cartographer-ops` inside a repository that has nothing to do
+	// with it.
+	permitted := make(map[string]bool, len(p.KBs))
+	for _, kb := range p.KBs {
+		permitted["kb:"+kb] = true
+	}
+	var out []provisioning.Artifact
+	for _, a := range cs.forKBs(p.KBs) {
+		if permitted[a.Source] {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+// workspaceKBUnion is boundKBUnion's workspace half: every KB any bound
+// workspace of any listed provider asks for. A KB no workspace is bound to is
+// never fetched.
+func workspaceKBUnion(cfg *clientconfig.Config, providers []string) []string {
+	seen := map[string]bool{}
+	var names []string
+	for _, provider := range providers {
+		if cfg.WorkspaceScope(provider) != clientconfig.ScopeWorkspace {
+			continue
+		}
+		for _, w := range cfg.WorkspaceBindings(provider) {
+			for _, kb := range w.KBs {
+				if !seen[kb] {
+					seen[kb] = true
+					names = append(names, kb)
+				}
+			}
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// --- `cartographer workspace` ---
+
+func cmdWorkspace(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, workspaceUsage)
+		return 2
+	}
+	sub, rest := args[0], args[1:]
+	switch sub {
+	case "bind":
+		return cmdWorkspaceBind(rest)
+	case "unbind":
+		return cmdWorkspaceUnbind(rest)
+	case "list":
+		return cmdWorkspaceList(rest)
+	default:
+		fmt.Fprintln(os.Stderr, workspaceUsage)
+		return 2
+	}
+}
+
+const workspaceUsage = `usage: cartographer workspace bind <provider> <path> --kb <name>[,<name>...]
+       cartographer workspace bind <provider> <path> --no-kb
+       cartographer workspace unbind <provider> <path>
+       cartographer workspace list [provider]`
+
+// loadWorkspaceConfig is the shared prologue: the config dir and the config.
+func loadWorkspaceConfig() (string, *clientconfig.Config, error) {
+	dir, err := clientconfig.TargetDir()
+	if err != nil {
+		return "", nil, err
+	}
+	cfg, err := clientconfig.Load(dir)
+	if err != nil {
+		return "", nil, fmt.Errorf("no client config found in %s (run `cartographer connect` first): %w", dir, err)
+	}
+	return dir, cfg, nil
+}
+
+func cmdWorkspaceBind(args []string) int {
+	var provider, path string
+	var kbs []string
+	noKB := false
+	positional := make([]string, 0, 2)
+	for i := 0; i < len(args); i++ {
+		switch {
+		case args[i] == "--no-kb":
+			noKB = true
+		case args[i] == "--kb" && i+1 < len(args):
+			i++
+			kbs = append(kbs, splitCommaList([]string{args[i]})...)
+		case strings.HasPrefix(args[i], "--kb="):
+			kbs = append(kbs, splitCommaList([]string{strings.TrimPrefix(args[i], "--kb=")})...)
+		case strings.HasPrefix(args[i], "-"):
+			fmt.Fprintf(os.Stderr, "Error: unknown flag %q\n%s\n", args[i], workspaceUsage)
+			return 2
+		default:
+			positional = append(positional, args[i])
+		}
+	}
+	if len(positional) != 2 {
+		fmt.Fprintln(os.Stderr, workspaceUsage)
+		return 2
+	}
+	provider, path = positional[0], positional[1]
+	kbs = nonEmpty(kbs)
+	if len(kbs) == 0 && !noKB {
+		// Silence here would mean "every KB", which is precisely what a
+		// workspace binding exists to stop. Make the empty case explicit.
+		fmt.Fprintf(os.Stderr, "Error: say which KBs this workspace receives with --kb, or --no-kb for none.\n"+
+			"A workspace binding is never implicitly 'every KB' — that is the exposure it exists to prevent.\n")
+		return 2
+	}
+	if noKB && len(kbs) > 0 {
+		fmt.Fprintln(os.Stderr, "Error: --no-kb and --kb are mutually exclusive")
+		return 2
+	}
+
+	dir, cfg, err := loadWorkspaceConfig()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		return 2
+	}
+	p := configurator.Provider(provider)
+	if _, ok := configurator.Lookup(p); !ok {
+		fmt.Fprintf(os.Stderr, "Error: unknown provider %q\n", provider)
+		return 2
+	}
+	if !provisioning.SupportsProjectScope(p) {
+		fmt.Fprintf(os.Stderr, "Error: %s cannot be scoped to a workspace: %s\n",
+			provider, provisioning.ProjectScopeUnsupportedReason(p))
+		return 2
+	}
+	if err := cfg.BindWorkspace(provider, path, kbs); err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		return 2
+	}
+	switched := cfg.WorkspaceScope(provider) != clientconfig.ScopeWorkspace
+	if switched {
+		if err := cfg.SetWorkspaceScope(provider, clientconfig.ScopeWorkspace); err != nil {
+			fmt.Fprintln(os.Stderr, "Error:", err)
+			return 2
+		}
+	}
+	if err := clientconfig.Save(dir, cfg); err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		return 2
+	}
+
+	canonical, _ := clientconfig.CanonicalWorkspacePath(path)
+	if len(kbs) == 0 {
+		fmt.Printf("bound %s in %s to no KBs\n", provider, canonical)
+	} else {
+		fmt.Printf("bound %s in %s to %s\n", provider, canonical, strings.Join(kbs, ", "))
+	}
+	if switched {
+		fmt.Printf("%s switched to workspace scope: its KB artifacts now live in each bound workspace, not in your home.\n", provider)
+		fmt.Println("run `cartographer sync` to move them — the previous global copies are pruned as part of it.")
+	} else {
+		fmt.Println("run `cartographer sync` to project it")
+	}
+	return 0
+}
+
+func cmdWorkspaceUnbind(args []string) int {
+	if len(args) != 2 {
+		fmt.Fprintln(os.Stderr, workspaceUsage)
+		return 2
+	}
+	provider, path := args[0], args[1]
+	dir, cfg, err := loadWorkspaceConfig()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		return 2
+	}
+	if err := cfg.UnbindWorkspace(provider, path); err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		return 2
+	}
+	if len(cfg.WorkspaceBindings(provider)) == 0 {
+		// The last workspace: the provider goes back to the global catalogue,
+		// which is the only other state that exists. Leaving it in workspace
+		// scope with no bindings would silently deliver nothing.
+		if err := cfg.SetWorkspaceScope(provider, clientconfig.ScopeProvider); err != nil {
+			fmt.Fprintln(os.Stderr, "Error:", err)
+			return 2
+		}
+		fmt.Printf("%s has no bound workspace left: it returns to the global scope.\n", provider)
+	}
+	if err := clientconfig.Save(dir, cfg); err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		return 2
+	}
+	fmt.Printf("unbound %s from %s\n", provider, path)
+	fmt.Println("run `cartographer sync` to remove what was projected there")
+	return 0
+}
+
+func cmdWorkspaceList(args []string) int {
+	if len(args) > 1 {
+		fmt.Fprintln(os.Stderr, workspaceUsage)
+		return 2
+	}
+	_, cfg, err := loadWorkspaceConfig()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		return 2
+	}
+	providers := cfg.Agents
+	if len(args) == 1 {
+		providers = []string{args[0]}
+	}
+	sort.Strings(providers)
+
+	any := false
+	for _, provider := range providers {
+		if cfg.WorkspaceScope(provider) != clientconfig.ScopeWorkspace {
+			continue
+		}
+		any = true
+		fmt.Printf("%s  (workspace scope)\n", provider)
+		for _, w := range cfg.WorkspaceBindings(provider) {
+			state := ""
+			if info, err := os.Stat(w.Path); err != nil || !info.IsDir() {
+				state = "  [gone]"
+			}
+			kbs := "no KBs"
+			if len(w.KBs) > 0 {
+				kbs = strings.Join(w.KBs, ", ")
+			}
+			fmt.Printf("  %s  →  %s%s\n", w.Path, kbs, state)
+			if w.Remote != "" {
+				fmt.Printf("      remote %s\n", w.Remote)
+			}
+		}
+	}
+	if !any {
+		fmt.Println("no provider is in workspace scope (bind one with `cartographer workspace bind`)")
+	}
+	return 0
+}
+
+// workspaceRelPath renders a managed path for a message: relative to the
+// workspace when it is inside one, absolute otherwise.
+func workspaceRelPath(base, path string) string {
+	if rel, err := filepath.Rel(base, path); err == nil && !strings.HasPrefix(rel, "..") {
+		return rel
+	}
+	return path
+}
+
+// nonEmpty drops the empty elements splitCommaList preserves. It preserves them
+// so a caller can reject `--kb ""`; here the rejection is the same message as
+// giving no --kb at all, so dropping them first keeps one error path.
+func nonEmpty(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// --- Manifests and apply, per projection (D193) ---
+
+// projectionKey is the map key a projection's manifest and result are stored
+// under. Provider alone was the key before D193, which is exactly one
+// projection per provider; a workspace-scoped provider has several, and they
+// must not share a slot.
+// The global projection keys on the bare provider name, which is what the map
+// was keyed by before D193: every caller that has only ever had one projection
+// per provider keeps working with no translation.
+func projectionKey(p syncProjection) string {
+	if p.Workspace == "" {
+		return p.Provider
+	}
+	return p.Provider + "\x00" + p.Workspace
+}
+
+// globalProjection is the single projection a default-scoped provider has. It
+// is the shape every caller had before workspaces existed.
+func globalProjection(provider, baseDir string, kbs []string) syncProjection {
+	return syncProjection{Provider: provider, BaseDir: baseDir, KBs: kbs, Scope: provisioning.ScopeGlobal}
+}
+
+// allProjections resolves every projection of every listed provider, in a
+// deterministic order.
+func allProjections(cfg *clientconfig.Config, providers []string, clientBaseDir string) ([]syncProjection, error) {
+	var out []syncProjection
+	sorted := append([]string(nil), providers...)
+	sort.Strings(sorted)
+	for _, provider := range sorted {
+		base, err := provisioning.BaseDirFor(configurator.Provider(provider), clientBaseDir)
+		if err != nil {
+			return nil, err
+		}
+		ps, err := projectionsFor(cfg, provider, base)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, ps...)
+	}
+	return out, nil
+}
+
+// manifestsForProjections is manifestsForProviders with the workspace axis: one
+// manifest per projection, each merged strictly over **that projection's** KBs.
+//
+// That narrowing is WP4's whole content. The strict merge (D171) then answers
+// "do two KBs collide here", which is the only place a collision can actually
+// confuse an agent: two KBs owning a same-named skill in two different
+// workspaces is legal and must stay legal, while the same two bound to one
+// workspace is still refused.
+func manifestsForProjections(cfg *clientconfig.Config, projections []syncProjection) (map[string]provisioning.Manifest, error) {
+	out := make(map[string]provisioning.Manifest, len(projections))
+
+	// Every KB any projection asks for, pulled once.
+	seen := map[string]bool{}
+	var union []string
+	anyDefault := false
+	requiredBy := map[string][]string{}
+	for _, p := range projections {
+		if p.BundleOnly {
+			continue
+		}
+		if p.Workspace == "" {
+			if _, explicit := cfg.BoundKBs(p.Provider); !explicit {
+				anyDefault = true
+			}
+		}
+		for _, kb := range p.KBs {
+			if !seen[kb] {
+				seen[kb] = true
+				union = append(union, kb)
+			}
+			requiredBy[kb] = append(requiredBy[kb], p.Label())
+		}
+	}
+	sort.Strings(union)
+
+	if len(union) == 0 && !anyDefault {
+		for _, p := range projections {
+			out[projectionKey(p)] = provisioning.MergeArtifacts(nil)
+		}
+		// A bundle-only projection still needs the bundle, which lives on the
+		// server side of a sync_pull: with no KB to pull it from there is
+		// nothing to fetch, and an empty manifest is the honest answer.
+		return out, nil
+	}
+
+	cs, err := fetchCandidates(cfg, union)
+	if err != nil {
+		return nil, annotateStaleBinding(err, requiredBy)
+	}
+	if cs.HasBare {
+		fmt.Fprintln(os.Stderr, "warning: the server does not identify its KBs by name, so per-client KB bindings cannot be applied; every connected client receives everything it serves")
+	}
+	pins, err := pinnedPublicKeys(cfg)
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range projections {
+		merged, err := provisioning.MergeArtifactsStrict(cs.forProjection(cfg, p))
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", p.Label(), err)
+		}
+		verified, err := provisioning.VerifiedManifest(merged, pins)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", p.Label(), err)
+		}
+		out[projectionKey(p)] = verified
+	}
+	return out, nil
+}
+
+// prepareWorkspace runs the repository-hygiene checks and exclusions for one
+// project-scoped projection, before anything is written there (WP5). A refusal
+// here costs nothing: no file has been touched yet.
+func prepareWorkspace(p syncProjection, dryRun bool) error {
+	if p.Scope != provisioning.ScopeProject {
+		return nil
+	}
+	provider := configurator.Provider(p.Provider)
+	owned := provisioning.ProjectOwnedPaths(provider)
+	// The files Cartographer writes a marker-delimited *block* into are the
+	// user's own; a repository legitimately tracks them, and they are neither
+	// refused nor excluded.
+	var blocks []string
+	for _, kind := range []string{"instructions"} {
+		if rel := provisioning.ProjectDestination(kind, "", provider); rel != "" {
+			blocks = append(blocks, rel)
+		}
+	}
+	if err := provisioning.CheckWorkspaceHygiene(p.Provider, p.Workspace, owned, blocks); err != nil {
+		return err
+	}
+	if dryRun {
+		return nil
+	}
+	// Decision 10: exclude Cartographer's OWN untracked paths. A shared file
+	// the repository already tracks (a CLAUDE.md the team wrote) is the user's:
+	// Cartographer writes a marker-delimited block in it and must not tell git
+	// to ignore their own file. One it created itself, because the repository
+	// had none, is untracked and is ours to exclude — otherwise every sync
+	// leaves the working tree dirty.
+	tracked, err := provisioning.TrackedPaths(p.Workspace)
+	if err != nil {
+		return err
+	}
+	var excluded []string
+	for _, o := range owned {
+		isBlock := false
+		for _, b := range blocks {
+			if o == b {
+				isBlock = true
+			}
+		}
+		if isBlock && tracked[filepath.ToSlash(o)] {
+			continue
+		}
+		excluded = append(excluded, o)
+	}
+	return provisioning.EnsureWorkspaceExcluded(p.Workspace, excluded)
+}
+
+// workspaceStatuses reports one provider's workspace projections for `status`
+// and `doctor` (D193 WP7).
+//
+// Every state it can report is a fact it checked, and none of them is healed
+// here: a bound directory that is gone, one whose git remote has changed, and a
+// Codex project that is not trusted are three different problems with three
+// different fixes, and a projection that silently fell back to the global
+// catalogue is exactly the exposure the scope exists to prevent.
+func workspaceStatuses(cfg *clientconfig.Config, provider, clientBaseDir string) []workspaceStatus {
+	if cfg.WorkspaceScope(provider) != clientconfig.ScopeWorkspace {
+		return nil
+	}
+	bindings := cfg.WorkspaceBindings(provider)
+	sort.Slice(bindings, func(i, j int) bool { return bindings[i].Path < bindings[j].Path })
+
+	out := make([]workspaceStatus, 0, len(bindings))
+	for _, w := range bindings {
+		st := workspaceStatus{Path: w.Path, KBs: w.KBs, State: "ok"}
+		if info, err := os.Stat(w.Path); err != nil || !info.IsDir() {
+			st.State, st.Detail = "gone", "the bound directory is not there any more"
+			out = append(out, st)
+			continue
+		}
+		if _, _, err := cfg.ResolveWorkspace(provider, w.Path); err != nil {
+			st.State, st.Detail = "moved", err.Error()
+			out = append(out, st)
+			continue
+		}
+		// Codex ignores a project's .codex/ layer entirely unless the project
+		// is trusted, so the files can be correct and the projection still
+		// inactive. Saying "installed" there is the false-positive class D189
+		// exists to eliminate.
+		if provider == string(configurator.ProviderCodex) &&
+			!provisioning.CodexProjectTrusted(provisioning.CodexConfigPath(clientBaseDir), w.Path) {
+			st.State = "inactive"
+			st.Detail = "codex does not trust this project, so it ignores its .codex/ layer — trust it from a codex session in this directory"
+		}
+		out = append(out, st)
+	}
+	return out
+}
+
+// printWorkspaceLines renders workspaceStatuses under a provider's status card.
+func printWorkspaceLines(ws []workspaceStatus) {
+	for _, w := range ws {
+		kbs := "no KBs"
+		if len(w.KBs) > 0 {
+			kbs = strings.Join(w.KBs, ", ")
+		}
+		suffix := ""
+		if w.State != "ok" {
+			suffix = "  [" + w.State + "]"
+		}
+		fmt.Printf("  workspace %s → %s%s\n", w.Path, kbs, suffix)
+		if w.Detail != "" {
+			fmt.Printf("    %s\n", w.Detail)
+		}
+	}
+}
+
+// checkWorkspaceProjections is `doctor`'s view of the workspace bindings
+// (D193 WP7). Each state reported here has a distinct fix, and none of them is
+// healed on the spot.
+func checkWorkspaceProjections(dir string, cfg *clientconfig.Config, providers []string) []doctorFinding {
+	var out []doctorFinding
+	for _, provider := range providers {
+		if cfg.WorkspaceScope(provider) != clientconfig.ScopeWorkspace {
+			continue
+		}
+		if !provisioning.SupportsProjectScope(configurator.Provider(provider)) {
+			out = append(out, doctorFinding{
+				Check: "workspace", Severity: doctorError, Path: filepath.Join(dir, clientconfig.FileName),
+				Message: fmt.Sprintf("%s is in workspace scope but cannot project: %s",
+					provider, provisioning.ProjectScopeUnsupportedReason(configurator.Provider(provider))),
+				Fix: "cartographer workspace unbind " + provider + " <path>",
+			})
+			continue
+		}
+		for _, w := range workspaceStatuses(cfg, provider, dir) {
+			switch w.State {
+			case "gone":
+				out = append(out, doctorFinding{
+					Check: "workspace", Severity: doctorError, Path: w.Path,
+					Message: fmt.Sprintf("%s: the bound workspace is not there any more", provider),
+					Fix:     fmt.Sprintf("cartographer workspace unbind %s %s", provider, w.Path),
+				})
+			case "moved":
+				out = append(out, doctorFinding{
+					Check: "workspace", Severity: doctorError, Path: w.Path,
+					Message: fmt.Sprintf("%s: %s", provider, w.Detail),
+					Fix:     fmt.Sprintf("cartographer workspace bind %s %s --kb <name>", provider, w.Path),
+				})
+			case "inactive":
+				// A warning, not an error: nothing is broken, the projection is
+				// simply not being read yet, and the fix is the user's to make
+				// in their own client.
+				out = append(out, doctorFinding{
+					Check: "workspace", Severity: doctorWarning, Path: w.Path,
+					Message: fmt.Sprintf("%s: %s", provider, w.Detail),
+					Fix:     "trust the project from a codex session in that directory",
+				})
+			}
+		}
+	}
+	return out
+}
+
+// pruneOrphanProjections removes the files of every projection the lockfile
+// still records but the configuration no longer declares, and drops its lock
+// entry. It returns the labels of what it pruned.
+//
+// This is the other half of `workspace unbind`. Unbinding removes the
+// declaration; without this, the files it had projected would stay in the
+// repository forever, because every later sync iterates the *declared*
+// projections and so would never look at them again.
+//
+// Only WORKSPACE projections are considered. A provider's global projection is
+// removed by `disconnect`, which owns that decision — reaching it from here
+// would delete a connected provider's catalogue because it was absent from one
+// `sync --client` invocation.
+func pruneOrphanProjections(lockFile *provisioning.LockFile, declared []syncProjection, clientBaseDir string) ([]string, error) {
+	wanted := map[string]bool{}
+	providersInPlay := map[string]bool{}
+	for _, p := range declared {
+		wanted[p.Provider+"\x00"+p.Workspace] = true
+		providersInPlay[p.Provider] = true
+	}
+
+	var pruned []string
+	for _, key := range lockFile.Projections() {
+		if key.Global() || !providersInPlay[key.Provider] {
+			// Not a workspace projection, or a provider this run is not
+			// touching at all (`sync --client` names a subset): leaving it
+			// alone is the only safe answer.
+			continue
+		}
+		if wanted[key.Provider+"\x00"+key.Workspace] {
+			continue
+		}
+		lock := lockFile.ForProjection(key)
+		base := provisioning.LockBaseDir(lock, clientBaseDir)
+		if _, err := provisioning.PruneManaged(lock.Managed, base, false); err != nil {
+			return nil, fmt.Errorf("prune %s: %w", key.String(), err)
+		}
+		// The exclusions go with the files: leaving the block behind would keep
+		// git ignoring paths nothing writes any more.
+		if err := provisioning.RemoveWorkspaceExclusions(key.Workspace); err != nil {
+			return nil, fmt.Errorf("prune %s: %w", key.String(), err)
+		}
+		lockFile.RemoveProjection(key)
+		pruned = append(pruned, key.String())
+		fmt.Printf("[%s] pruned the projection in %s\n", key.Provider, key.Workspace)
+	}
+	return pruned, nil
+}

--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -115,6 +115,18 @@ In an interactive terminal the same choice is offered as a list after the connec
 narrowest selection that does the job, and verify the result with `cartographer status`: the bound
 KBs are printed per provider, with `explicit` next to them.
 
+A KB bound this way is readable from **every** directory on the machine. If the user works in two
+separate perimeters with the same client, offer the alternative before the first sync, because it
+is free only now (D193):
+
+```bash
+cartographer connect --agents codex --kb <name> --workspace <repository path>
+```
+
+That confines those KBs to one repository instead — their skills, subagents and hooks are
+materialized into that repository's own configuration and nowhere else. `cartographer workspace
+bind/unbind/list` manages it afterwards.
+
 ## 5. Verify the installation
 
 ```bash

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -66,6 +66,20 @@ rename on one-to-many transitions. If the server cannot be reached, it leaves
 the MCP entries and `known_kbs` untouched and warns; run `sync` again once it is
 up.
 
+**Workspace scope (D193).** `cartographer workspace bind <provider> <path> --kb <name>…` moves a
+provider from one machine-wide catalogue to one projection per bound repository: the KBs land in
+that repository's own project-local directories and nothing KB-sourced is written under `$HOME` any
+more. `connect --workspace <repo>` makes the same choice at connect time, which is the only moment
+it is free — a provider-global connect materializes every selected KB into `$HOME` first, and moving
+them afterwards is a migration. `workspace unbind` removes the declaration and the next `sync`
+prunes what was projected there. `workspace list` shows the bindings, with `[gone]` next to a
+directory that is not there any more.
+
+Existing configurations are untouched: the scope is per provider, absent means the historical global
+catalogue, and no upgrade changes it. Full rules, the project-local destination matrix, the
+repository-hygiene guarantees and the providers that cannot be scoped at all → `sync.md`
+§Workspace scope.
+
 **Routed servers (D187).** When `/health` reports `mount_mode: routed`, the KB is no longer part of
 the URL: the client writes **one** entry, `<server_name>`, pointed at the path the server names in
 `routed_path` (`/mcp/routed`), whatever the provider is bound to. The binding still decides which

--- a/docs/decisions/sync-provisioning.md
+++ b/docs/decisions/sync-provisioning.md
@@ -1293,3 +1293,95 @@ outcome), on the very provider D147's own writeup already names.
 **Consequences.** `fix:` — output only; no configuration, CLI or MCP surface
 change. A provider with unsupported kinds now prints the same revision
 `status` reports for it.
+
+---
+
+<a id="d193"></a>
+## D193 — Workspace-scoped artifact projection: one provider, different KBs per repository
+
+**Status: implemented.** Closes #247.
+
+**Context.** A session working in the HomeLab perimeter activated `new-microservice`, a skill
+belonging to `dante-kb` and specific to DANTE/ADMS. Cartographer tracked the source KB correctly
+everywhere it records provenance — the manifest, the lockfile's `source` (D170), the materialized
+footer — but the provider chooses a skill from **name and description alone**, and the provenance
+block is in the body, read only *after* activation. The description was generic and did not name
+DANTE.
+
+D169/D170's per-provider binding closes this for a provider dedicated to one perimeter. What it
+cannot close is the case that produced the incident: the binding is **static per provider** and does
+not depend on the current directory. `.cartographer.yaml` is machine-wide by design, every provider
+destination is under `$HOME`, there is no notion of an active workspace, and two concurrent sessions
+of the same provider in two perimeters share one global catalogue.
+
+The audit verified that every supported provider *does* have a project-local scope — Claude Code
+`.claude/`, Kiro `.kiro/`, OpenCode `.opencode/`, Codex `.agents/skills` and `.codex/` along
+cwd→repository root — and that this holds for instructions, agents, hooks and MCP descriptors, not
+only skills. Sources are recorded in `docs/interoperability.md` §Project-local scopes.
+
+**Decisions.**
+
+- **An explicit binding between workspace and KBs, per provider**, with the scope selected per
+  provider. Absent means the historical global catalogue, so no existing installation changes on
+  upgrade; migration is a deliberate `workspace bind` or a `connect --workspace`.
+- **The bind takes a path, resolves it once, and persists the canonical form.** For a git repository
+  it also records the normalized remote as a **guard** against moves and accidental reuse — never as
+  a selector, because one remote has many clones and worktrees and choosing between them by remote
+  would pick the wrong one. A bound path that is gone, or whose remote has changed, is an **error**.
+- **Fail closed, everywhere.** An unbound workspace receives the transversal bundle and no KB
+  artifact. "No KBs" and "several KBs" are distinct explicit states and neither is ever "every KB" —
+  `workspace bind` requires `--kb` or an explicit `--no-kb` rather than defaulting. A provider with
+  no project-local scope (hermes, antigravity) **cannot** be bound and is refused with the reason,
+  never degraded to the global catalogue: degrading is precisely the exposure this closes.
+- **Only Cartographer's own transversal bundled skills stay global.** `cartographer-ops`,
+  `kb-create` and their siblings belong to no perimeter, and a session outside every bound workspace
+  still needs them. Nothing KB-sourced is materialized globally under workspace scope, and nothing
+  bundled is copied into a workspace — the E2E scenario caught the first implementation doing
+  exactly that, which would have multiplied `cartographer-ops` by the number of bindings.
+- **The lockfile gets a separate namespace, not an extended key space.** Prune deletes every managed
+  file its lock names, so a key that *could* resolve to the wrong projection deletes another
+  workspace's files. Two maps — `providers` and `workspaces` — make that mistake unrepresentable
+  rather than merely unlikely. Each workspace lock carries its `base_dir` and a `project_scope` flag,
+  the latter persisted rather than derived because verifying or pruning through the wrong matrix
+  looks for the wrong paths entirely.
+- **Unbinding prunes.** The declaration and the files are two different things: a later sync only
+  iterates the *declared* projections, so without an explicit orphan pass the files of an unbound
+  workspace would stay in that repository forever. The pass considers workspace projections only —
+  a provider's global catalogue is `disconnect`'s decision, and reaching it from here would delete a
+  connected provider's artifacts because it was absent from one `sync --client`.
+- **Collision detection is scoped to the projection, not weakened.** Two KBs owning a same-named
+  skill in two different workspaces is legal and now works; the same two bound to **one** workspace
+  is still refused by the strict merge (D171), because that is the only place a collision can
+  actually confuse an agent.
+- **Repository hygiene is two rules with teeth.** Cartographer excludes only its **own untracked**
+  paths, only in `.git/info/exclude`, inside a marker block — never `.gitignore`, which is shared
+  with everyone who clones the repository. A shared file the repository already tracks is the
+  user's: the block goes inside it and it is not excluded; one Cartographer created itself is
+  untracked and is excluded, or every sync would leave the working tree dirty. A path Cartographer
+  would own **entirely** that git already tracks is a refusal, before anything is written.
+- **Honest reporting where correct files are not enough.** Codex ignores a project's `.codex/` layer
+  unless the project is trusted, so `status` and `doctor` report such a projection as `inactive` and
+  name the fix. Reporting it as installed is the false-positive class D189 exists to eliminate.
+- **Kiro keeps its unsupported agent and hook cells in the project scope**, for the same D140 reason
+  as globally. #248 tracks whether Kiro 3.0 changes that and is blocked on an empirical
+  verification; giving it a cell here would be shipping that finding without its evidence.
+
+**Invariants kept.** D169's statement that a projection is **not an authorization boundary** — a
+process running as the same user can read any file on the machine; what this prevents is accidental
+exposure and activation, and that is all it claims. The signature and trust chain applies per
+projection unchanged, the `safepath.go` symlink refusals hold for project-local destinations, and
+the bundled transversal skills keep working with no workspace binding at all. A provider in the
+default scope resolves to exactly one projection whose behaviour is byte-identical to before.
+
+**Consequences.** New opt-in scope; existing installations are unchanged until someone binds a
+workspace. The lockfile gains a `workspaces` key, absent in every file written before this and
+therefore needing no migration. Release-note the `workspace` subcommand and `connect --workspace`.
+
+**What the acceptance scenario found.** `18_workspace_projection` is the mandatory E2E from the
+plan, and it failed on its first run with three defects no unit test could see: the bundled skills
+were being copied into every workspace, a `CLAUDE.md` Cartographer created itself was left untracked
+and dirtying the repository, and unbinding a workspace left its projected files behind. All three
+lived in the wiring between components, which is exactly what the scenario exists to exercise.
+
+Details: `docs/sync.md` §Workspace scope, `docs/configurator.md`, `docs/interoperability.md`
+§Project-local scopes, `docs/testing.md`.

--- a/docs/interoperability.md
+++ b/docs/interoperability.md
@@ -69,14 +69,41 @@ client installed (and skips where it does not).
 | `agent` × opencode | `~/.opencode/agent/<name>.md` | `.opencode/agents` ([source](https://opencode.ai/docs/agents)) | client 1.18.20 |
 
 Neither is moved here: a destination change is a migration (prune the old
-files, re-key the lockfile), and for Codex the right target is the *repository*
-path, which only exists once a workspace scope does (D193). Moving it now would
-mean doing the migration twice. What was missing was the alarm, not the move.
+files, re-key the lockfile), and what was missing was the alarm, not the move.
+The Codex case is now half-resolved: the workspace scope (D193) does use the
+repository path the vendor documents, `.agents/skills/<name>/`, because that
+scope is new and has no installed base to migrate. The **global** cell stays at
+`~/.codex/skills/` for the reason above.
 
 Current limitations are documented once in the relevant table/section rather
 than repeated here. In particular, Kiro's flat MCP tool namespace may require
 the server's per-KB tool prefix, and provider translations intentionally drop
 fields that cannot be represented safely.
+
+### Project-local scopes as an external contract (D193)
+
+The workspace scope writes into each provider's **project-local** configuration,
+which is a second set of external contracts, verified during the D193 audit and
+changing outside this project's release cycle. Re-verify before changing a cell;
+the citation lives next to it in `internal/provisioning/workspacescope.go`.
+
+| Provider | Project-local scope | Source |
+|---|---|---|
+| Claude Code | `.claude/skills/`, `.claude/agents/`, `.claude/hooks/`, `.mcp.json`, `./CLAUDE.md` | [skills](https://code.claude.com/docs/en/skills), [memory](https://code.claude.com/docs/en/memory), [sub-agents](https://code.claude.com/docs/en/sub-agents), [hooks](https://code.claude.com/docs/en/hooks), [mcp](https://code.claude.com/docs/en/mcp) |
+| Codex | `.agents/skills`, `.codex/agents`, `.codex/hooks`, `.codex/config.toml`, `AGENTS.md` | [skills](https://developers.openai.com/codex/skills), [subagents](https://developers.openai.com/codex/subagents), [hooks](https://developers.openai.com/codex/hooks), [mcp](https://developers.openai.com/codex/mcp) |
+| Kiro | `.kiro/skills/`, `.kiro/steering/`, `.kiro/settings/mcp.json` | [skills](https://kiro.dev/docs/skills/) |
+| OpenCode | `.opencode/skills`, `.opencode/agent`, `.opencode/hooks`, `opencode.json`, `AGENTS.md` | [skills](https://opencode.ai/docs/skills), [rules](https://opencode.ai/docs/rules), [agents](https://opencode.ai/docs/agents), [plugins](https://opencode.ai/docs/plugins) |
+| Hermes | **none** | its configuration is rendered by its own Ansible role and skills go to one inbox (D141) |
+| Antigravity | **none** | only a global configuration root is documented (D194) |
+
+Two consequences are worth stating plainly. Kiro keeps `unsupported` agent and
+hook cells in the project scope too, for the same D140 reason as globally —
+[#248](https://github.com/BeppeTemp/cartographer/issues/248) tracks whether Kiro
+3.0 changes it and is blocked on an empirical verification, so giving it a cell
+here would be shipping that finding without its evidence. And Codex ignores a
+project's `.codex/` layer unless the project is **trusted**, which is the one
+case where writing the files correctly is not the same as the projection being
+active: `status` and `doctor` report it as `inactive` rather than installed.
 
 ### Instruction slots Cartographer deliberately does not write
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -355,6 +355,83 @@ while the rest of the sync completes.
 Hermes has no session hook, so its trigger is the scheduled timer (`cartographer service sync-timer
 install`, D140).
 
+## Workspace scope (D193)
+
+By default a provider has **one** catalogue, under the user's home, shared by every session of
+that provider on the machine. A provider that works in two perimeters therefore sees both
+perimeters' skills everywhere, and chooses between them from name and description alone — the
+provenance footer is in the body, read only *after* activation. That is how a DANTE skill got
+activated in a HomeLab session.
+
+`cartographer workspace bind <provider> <path> --kb <name>…` switches that provider to **workspace
+scope**: each bound directory receives its own KBs, in that directory's own project-local
+configuration, and **nothing KB-sourced is written globally** any more.
+
+| | provider scope (default) | workspace scope |
+|---|---|---|
+| Where KB artifacts land | the client base dir (`$HOME`) | each bound workspace |
+| Who sees them | every session of that provider | only sessions in that workspace |
+| The binding | one per provider (D169/D170) | one per provider **and** workspace |
+| Lockfile key | provider | provider + workspace, in its own namespace |
+
+**Cartographer's own bundled skills stay global.** `cartographer-ops`, `kb-create` and their
+siblings belong to no perimeter, and a session outside every bound workspace still needs them. They
+are the only thing the global catalogue of a workspace-scoped provider holds.
+
+**An unbound workspace is fail-closed.** It receives the transversal bundle and no KB artifact at
+all. "No KBs" and "several KBs" are distinct explicit states; neither is ever "every KB", and a
+bound path that is gone or whose git remote has changed is an **error**, never a fall-back — falling
+back is the exposure the scope exists to close.
+
+**A projection is not an authorization boundary.** A process running as the same user can read any
+file on the machine ([D169](decisions/sync-provisioning.md#d169)). What this prevents is accidental
+exposure and activation, and that is all it claims.
+
+### Project-local destinations
+
+| Kind | claude | opencode | codex | kiro | hermes | antigravity |
+|---|---|---|---|---|---|---|
+| `skill` | `.claude/skills/<name>/` | `.opencode/skills/<name>/` | `.agents/skills/<name>/` | `.kiro/skills/<name>/` | unsupported | unsupported |
+| `agent` | `.claude/agents/<name>.md` | `.opencode/agent/<name>.md` | `.codex/agents/<name>.toml` | unsupported | unsupported | unsupported |
+| `hook` | `.claude/hooks/<name>/` | `.opencode/hooks/<name>/` | `.codex/hooks/<name>/` | unsupported | unsupported | unsupported |
+| `instructions` | block in `./CLAUDE.md` | block in `./AGENTS.md` | block in `./AGENTS.md` | `.kiro/steering/cartographer.md` | unsupported | unsupported |
+| `mcp` | `.mcp.json` | `opencode.json` | `.codex/config.toml` | `.kiro/settings/mcp.json` | unsupported | unsupported |
+
+Paths are relative to the **workspace**. The matrix is data, like the global one, and is held to the
+same completeness rule: every kind × provider cell either names a destination or is explicitly
+unsupported. `hermes` and `antigravity` have no project-local scope at all — the first renders its
+configuration from an Ansible role and delivers skills to one inbox, the second documents only a
+global configuration root — so they **cannot be bound to a workspace**, and `workspace bind` refuses
+them with that reason rather than degrading to the global catalogue.
+
+Codex is the one provider where correct files are not the whole story: it ignores a project's
+`.codex/` layer unless the project is **trusted**. `status` and `doctor` report such a projection as
+`inactive` and name the fix, because reporting it as installed is the false-positive class
+[D189](decisions/client-configurator.md#d189) exists to eliminate.
+
+### Repository hygiene
+
+A projection writes into a directory the user version-controls, so two rules hold:
+
+- Cartographer excludes **only its own untracked paths**, and only in `.git/info/exclude`, inside a
+  marker-delimited block. It **never** edits `.gitignore`: that file is the repository's, shared
+  with everyone who clones it. A shared file the repository already tracks — a `CLAUDE.md` the team
+  wrote — is the user's: Cartographer writes its block inside it and does not exclude it.
+- A path Cartographer would own **entirely** that git already tracks is a **refusal**, before
+  anything is written. Overwriting a versioned file destroys work under version control, and there
+  is no safe silent answer.
+
+`git status` is clean after a sync. That is asserted end-to-end by the `18_workspace_projection`
+E2E scenario, along with the rest of this section.
+
+### Unbinding
+
+`cartographer workspace unbind <provider> <path>` removes the declaration; the next `sync` prunes
+what was projected there and removes the exclusion block. Unbinding the last workspace returns the
+provider to the global scope — the only other state there is. Neither ever touches another
+workspace's files: the lockfile keys workspace projections in a separate namespace, so a prune
+cannot reach past its own projection.
+
 ## Agents and hooks
 
 - **KB layout** (optional/backward-compatible): `agents/<name>.md` (Claude subagent: frontmatter + body) and `hooks/<name>/` (script + `hook.json` with `event`/`matcher`/`command`). `BuildManifest` scans these (KB only, the bundle remains skill-only).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -127,6 +127,24 @@ prefix, which nobody configures explicitly, was making the routed mode fail at
 startup out of the box. No Go test could see it, because the defect lived in the
 wiring between the config default and the mount, not in either.
 
+**The workspace scope is asserted on real repositories.** `18_workspace_projection`
+is D193's mandatory acceptance criterion, and it is a scenario that **cannot
+pass** before the scope exists: two KBs holding a skill with the *same name*,
+two git repositories, one provider bound to a different KB in each. It asserts
+that each workspace receives its own perimeter — comparing the *bodies*, not
+just the paths, because reaching the wrong KB also produces a readable file —
+that no KB artifact is left in the global catalogue while Cartographer's own
+transversal bundled skills stay there, that an unbound workspace receives
+nothing, that `git status` is clean and `.gitignore` untouched, that unbinding
+one workspace prunes only its files, and that one workspace bound to *both* KBs
+is still refused as a collision.
+
+It earned its keep on the first run, finding three defects no unit test could
+see: the bundled skills were being copied into every workspace, a `CLAUDE.md`
+Cartographer created itself was left untracked and dirtying the repository, and
+unbinding a workspace left its projected files behind forever because every
+later sync only iterates the *declared* projections.
+
 ### Packaging (`install.sh` and the generated Cask)
 
 `make test-install` runs the network-free suite under `test/install/` plus

--- a/internal/clientconfig/clientconfig.go
+++ b/internal/clientconfig/clientconfig.go
@@ -54,6 +54,22 @@ type Config struct {
 	// names are three distinct states, and a nil slice never means "every KB".
 	Clients map[string]ClientBinding `yaml:"clients,omitempty"`
 
+	// Scopes is the per-provider projection scope (D193): absent or "provider"
+	// means the historical global catalogue under $HOME, "workspace" means each
+	// bound workspace receives its own KBs in its own project-local
+	// directories and nothing KB-sourced is written globally. USER-owned.
+	// Always read it through WorkspaceScope: an absent entry is the default,
+	// and the default must never change under an existing installation.
+	Scopes map[string]string `yaml:"scopes,omitempty"`
+
+	// Workspaces is the per-provider workspace↔KB binding (D193): which KBs a
+	// provider receives while working in a given directory. USER-owned. Read it
+	// through WorkspaceBindings/ResolveWorkspace, never directly: an unbound
+	// workspace is fail-closed (it gets only the transversal bundle) and a
+	// bound one holding no KBs is an explicit declaration — two states an
+	// emptiness test cannot tell apart.
+	Workspaces map[string][]WorkspaceBinding `yaml:"workspaces,omitempty"`
+
 	// Trust records the persistent, per-server decision made at connect time:
 	// when true, kb:-sourced provisioning artifacts (skill/agent/hook/instructions)
 	// are treated as trusted at every sync, without needing the one-time
@@ -128,6 +144,8 @@ type yamlConfig struct {
 	ServerMountMode  string                            `yaml:"server_mount_mode,omitempty"`
 	ServerRoutedPath string                            `yaml:"server_routed_path,omitempty"`
 	Clients          map[string]ClientBinding          `yaml:"clients,omitempty"`
+	Scopes           map[string]string                 `yaml:"scopes,omitempty"`
+	Workspaces       map[string][]WorkspaceBinding     `yaml:"workspaces,omitempty"`
 	Trust            *bool                             `yaml:"trust,omitempty"`
 	SearchRoots      []string                          `yaml:"search_roots,omitempty"`
 	SearchDepth      int                               `yaml:"search_depth,omitempty"`
@@ -199,6 +217,8 @@ func Load(dir string) (*Config, error) {
 		ServerMountMode:  y.ServerMountMode,
 		ServerRoutedPath: y.ServerRoutedPath,
 		Clients:          y.Clients,
+		Scopes:           y.Scopes,
+		Workspaces:       y.Workspaces,
 		Trust:            true, // absent `trust` key defaults to true, see yamlConfig doc
 		SearchRoots:      y.SearchRoots,
 		SearchDepth:      y.SearchDepth,
@@ -238,6 +258,8 @@ func Save(dir string, cfg *Config) error {
 		ServerMountMode:  cfg.ServerMountMode,
 		ServerRoutedPath: cfg.ServerRoutedPath,
 		Clients:          cfg.Clients,
+		Scopes:           cfg.Scopes,
+		Workspaces:       cfg.Workspaces,
 		Trust:            &cfg.Trust,
 		SearchRoots:      cfg.SearchRoots,
 		SearchDepth:      cfg.SearchDepth,

--- a/internal/clientconfig/workspace.go
+++ b/internal/clientconfig/workspace.go
@@ -1,0 +1,312 @@
+package clientconfig
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// workspace.go (D193) — the workspace↔KB↔provider binding.
+//
+// D169's per-provider binding is static: it does not depend on the directory a
+// session is running in. That closed the originating incident for a provider
+// dedicated to one perimeter, and could not close it for a provider used in
+// two: one global catalogue, two perimeters, and a skill belonging to one of
+// them offered in the other.
+//
+// A workspace binding is a *projection*, not an authorization boundary (D169):
+// a process running as the same user can read any file on the machine. What it
+// prevents is accidental exposure and activation. Do not promise more.
+
+// ProjectionScope selects where a provider's KB artifacts are materialized.
+const (
+	// ScopeProvider is the historical behaviour: one global catalogue under the
+	// user's home, shared by every session of that provider.
+	ScopeProvider = "provider"
+	// ScopeWorkspace materializes each workspace's KBs into that workspace's
+	// own project-local directories, and materializes nothing KB-sourced
+	// globally.
+	ScopeWorkspace = "workspace"
+)
+
+// WorkspaceBinding binds one directory to the KBs a provider may receive while
+// working in it.
+//
+// Path is canonical and absolute: it is resolved once, at bind time, and
+// persisted. Remote is the normalized git remote of the repository at that path
+// when there is one, recorded as a **guard** against moves and accidental
+// reuse — never as a selector, because one remote has many clones and
+// worktrees and choosing between them by remote would pick the wrong one.
+//
+// KBs is explicit and may be empty: "this workspace receives no KB artifacts"
+// is a declaration, distinct from "this workspace is not bound", which is the
+// absence of the entry. Neither ever means "every KB" — that is what
+// fail-closed means here (decision 8).
+type WorkspaceBinding struct {
+	Path   string   `yaml:"path"`
+	Remote string   `yaml:"remote,omitempty"`
+	KBs    []string `yaml:"kbs"`
+}
+
+// gitRemoteFn is indirected for tests: a bind must work in a temp dir with no
+// git at all, and a test must be able to fake a remote without a real clone.
+var gitRemoteFn = gitRemoteOrigin
+
+// gitRemoteOrigin returns the normalized `origin` URL of the repository
+// containing dir, or "" when dir is not in a git repository (which is a legal
+// workspace: a plain directory binds fine, it simply carries no guard).
+func gitRemoteOrigin(dir string) string {
+	cmd := exec.Command("git", "-C", dir, "remote", "get-url", "origin")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return NormalizeRemote(string(out))
+}
+
+// NormalizeRemote reduces a git remote URL to a comparable form: trimmed,
+// lowercased, without a trailing ".git" or "/", and with the scp-like SSH
+// syntax rewritten to a path. It exists so `git@host:owner/repo.git` and
+// `https://host/owner/repo` compare equal — the same repository reached two
+// ways must not read as a moved workspace.
+func NormalizeRemote(raw string) string {
+	s := strings.ToLower(strings.TrimSpace(raw))
+	if s == "" {
+		return ""
+	}
+	if i := strings.Index(s, "://"); i >= 0 {
+		s = s[i+3:]
+		if at := strings.Index(s, "@"); at >= 0 && at < strings.Index(s+"/", "/") {
+			s = s[at+1:]
+		}
+	} else if at := strings.Index(s, "@"); at >= 0 {
+		// scp-like: user@host:owner/repo.git
+		s = strings.Replace(s[at+1:], ":", "/", 1)
+	}
+	// Trailing "/" first, then ".git": a URL copied from a browser can carry
+	// both ("…/repo.git/"), and trimming in the other order leaves the ".git".
+	s = strings.TrimRight(s, "/")
+	s = strings.TrimSuffix(s, ".git")
+	return strings.TrimRight(s, "/")
+}
+
+// CanonicalWorkspacePath resolves dir to the absolute, symlink-free path that
+// is persisted and compared. Resolving once at bind time is what makes the
+// later comparison a string comparison rather than a filesystem walk.
+func CanonicalWorkspacePath(dir string) (string, error) {
+	if strings.TrimSpace(dir) == "" {
+		return "", fmt.Errorf("clientconfig: empty workspace path")
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", fmt.Errorf("clientconfig: resolve workspace path %q: %w", dir, err)
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		// The path must exist to be bound: binding a directory that is not
+		// there records a guard nothing can ever check.
+		return "", fmt.Errorf("clientconfig: workspace path %q: %w", dir, err)
+	}
+	return resolved, nil
+}
+
+// WorkspaceScope reports the projection scope configured for provider.
+// The zero value is ScopeProvider, so every existing configuration keeps the
+// global catalogue it has: a new scope must never switch under anyone
+// (decision: migration is explicit).
+func (c *Config) WorkspaceScope(provider string) string {
+	if c.Scopes == nil {
+		return ScopeProvider
+	}
+	if s, ok := c.Scopes[provider]; ok && s == ScopeWorkspace {
+		return ScopeWorkspace
+	}
+	return ScopeProvider
+}
+
+// SetWorkspaceScope records provider's projection scope. Setting it to
+// ScopeProvider removes the entry, so the file does not accumulate keys that
+// restate the default.
+func (c *Config) SetWorkspaceScope(provider, scope string) error {
+	switch scope {
+	case ScopeProvider:
+		delete(c.Scopes, provider)
+		return nil
+	case ScopeWorkspace:
+		if c.Scopes == nil {
+			c.Scopes = map[string]string{}
+		}
+		c.Scopes[provider] = ScopeWorkspace
+		return nil
+	default:
+		return fmt.Errorf("clientconfig: unknown projection scope %q (want %q or %q)", scope, ScopeProvider, ScopeWorkspace)
+	}
+}
+
+// WorkspaceBindings returns provider's workspace bindings, as a copy.
+func (c *Config) WorkspaceBindings(provider string) []WorkspaceBinding {
+	out := make([]WorkspaceBinding, 0, len(c.Workspaces[provider]))
+	for _, w := range c.Workspaces[provider] {
+		w.KBs = append([]string(nil), w.KBs...)
+		out = append(out, w)
+	}
+	return out
+}
+
+// BindWorkspace binds dir to kbs for provider, replacing any existing binding
+// for the same canonical path. kbs may be empty — an explicit "no KB artifacts
+// here" — but never nil-means-all.
+//
+// The git remote is recorded when dir is in a repository. It is a guard: a
+// later sync that finds a different remote at the same path refuses rather than
+// projecting one perimeter's artifacts into another's checkout.
+func (c *Config) BindWorkspace(provider, dir string, kbs []string) error {
+	if provider == "" || provider != strings.TrimSpace(provider) {
+		return fmt.Errorf("clientconfig: invalid provider name %q", provider)
+	}
+	path, err := CanonicalWorkspacePath(dir)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return fmt.Errorf("clientconfig: workspace %q is not a directory", dir)
+	}
+	for _, kb := range kbs {
+		if kb == "" || kb != strings.TrimSpace(kb) {
+			return fmt.Errorf("clientconfig: invalid KB name %q", kb)
+		}
+	}
+	if c.Workspaces == nil {
+		c.Workspaces = map[string][]WorkspaceBinding{}
+	}
+	binding := WorkspaceBinding{
+		Path:   path,
+		Remote: gitRemoteFn(path),
+		KBs:    append([]string{}, kbs...),
+	}
+	list := c.Workspaces[provider]
+	for i := range list {
+		if list[i].Path == path {
+			list[i] = binding
+			c.Workspaces[provider] = list
+			return nil
+		}
+	}
+	c.Workspaces[provider] = append(list, binding)
+	return nil
+}
+
+// UnbindWorkspace removes provider's binding for dir. Unbinding a path that is
+// not bound is a silent no-op, matching Unbind. The path is canonicalized when
+// it still exists and compared verbatim when it does not, so a workspace whose
+// directory was deleted can still be removed from the config.
+func (c *Config) UnbindWorkspace(provider, dir string) error {
+	if provider == "" {
+		return fmt.Errorf("clientconfig: invalid provider name %q", provider)
+	}
+	path, err := CanonicalWorkspacePath(dir)
+	if err != nil {
+		abs, absErr := filepath.Abs(dir)
+		if absErr != nil {
+			return err
+		}
+		path = abs
+	}
+	list := c.Workspaces[provider]
+	kept := make([]WorkspaceBinding, 0, len(list))
+	for _, w := range list {
+		if w.Path != path {
+			kept = append(kept, w)
+		}
+	}
+	if len(kept) == 0 {
+		delete(c.Workspaces, provider)
+		return nil
+	}
+	c.Workspaces[provider] = kept
+	return nil
+}
+
+// WorkspaceLookupError distinguishes the ways a bound workspace can fail to
+// resolve. Each is an error, never a fallback to "every KB": falling back is
+// how a perimeter's artifacts end up in another's checkout.
+type WorkspaceLookupError struct {
+	Path   string
+	Reason string
+	Detail string
+}
+
+func (e *WorkspaceLookupError) Error() string {
+	return fmt.Sprintf("workspace %s: %s (%s)", e.Path, e.Reason, e.Detail)
+}
+
+// ResolveWorkspace returns provider's binding for the workspace containing dir.
+//
+// The match is the **longest** bound path that is dir or a parent of it, so a
+// repository bound inside another bound directory wins over the outer one. A
+// dir under no bound path returns ok=false with no error: that is an unbound
+// workspace, which is fail-closed for KB artifacts and receives only the
+// transversal bundle — a legal state, not a failure.
+//
+// A bound path that no longer exists, or whose git remote no longer matches the
+// one recorded at bind time, returns an error. Both mean the binding describes
+// something that is not there any more, and continuing would project a
+// perimeter's artifacts into a checkout nobody bound.
+func (c *Config) ResolveWorkspace(provider, dir string) (WorkspaceBinding, bool, error) {
+	list := c.Workspaces[provider]
+	if len(list) == 0 {
+		return WorkspaceBinding{}, false, nil
+	}
+	target, err := CanonicalWorkspacePath(dir)
+	if err != nil {
+		return WorkspaceBinding{}, false, err
+	}
+
+	best := -1
+	for i, w := range list {
+		if !pathWithin(target, w.Path) {
+			continue
+		}
+		if best < 0 || len(w.Path) > len(list[best].Path) {
+			best = i
+		}
+	}
+	if best < 0 {
+		return WorkspaceBinding{}, false, nil
+	}
+	w := list[best]
+
+	if info, err := os.Stat(w.Path); err != nil || !info.IsDir() {
+		return WorkspaceBinding{}, false, &WorkspaceLookupError{
+			Path: w.Path, Reason: "bound directory is gone",
+			Detail: "rebind it with `cartographer workspace bind`, or remove the binding with `workspace unbind`",
+		}
+	}
+	if w.Remote != "" {
+		if got := gitRemoteFn(w.Path); got != w.Remote {
+			return WorkspaceBinding{}, false, &WorkspaceLookupError{
+				Path: w.Path, Reason: "git remote changed since it was bound",
+				Detail: fmt.Sprintf("bound to %s, found %q — rebind deliberately rather than projecting another perimeter's artifacts here", w.Remote, got),
+			}
+		}
+	}
+	w.KBs = append([]string(nil), w.KBs...)
+	return w, true, nil
+}
+
+// pathWithin reports whether target is root or a descendant of it. It compares
+// canonical paths textually, which is what makes the check cheap enough to run
+// on every sync.
+func pathWithin(target, root string) bool {
+	if target == root {
+		return true
+	}
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}

--- a/internal/clientconfig/workspace_test.go
+++ b/internal/clientconfig/workspace_test.go
@@ -1,0 +1,322 @@
+package clientconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func withFakeRemote(t *testing.T, remotes map[string]string) {
+	t.Helper()
+	prev := gitRemoteFn
+	gitRemoteFn = func(dir string) string { return remotes[dir] }
+	t.Cleanup(func() { gitRemoteFn = prev })
+}
+
+// TestWorkspaceScope_DefaultsToProvider is D193's migration promise: a
+// configuration written before workspaces existed keeps the global catalogue it
+// has. A new scope that switched under an existing installation would move every
+// artifact on the next sync.
+func TestWorkspaceScope_DefaultsToProvider(t *testing.T) {
+	cfg := &Config{}
+	if got := cfg.WorkspaceScope("claude"); got != ScopeProvider {
+		t.Errorf("default scope = %q, want %q", got, ScopeProvider)
+	}
+	if err := cfg.SetWorkspaceScope("claude", ScopeWorkspace); err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.WorkspaceScope("claude"); got != ScopeWorkspace {
+		t.Errorf("scope = %q, want %q", got, ScopeWorkspace)
+	}
+	// Other providers are unaffected: the scope is per provider.
+	if got := cfg.WorkspaceScope("codex"); got != ScopeProvider {
+		t.Errorf("codex scope = %q, want %q", got, ScopeProvider)
+	}
+	// Setting it back removes the key rather than restating the default.
+	if err := cfg.SetWorkspaceScope("claude", ScopeProvider); err != nil {
+		t.Fatal(err)
+	}
+	if _, present := cfg.Scopes["claude"]; present {
+		t.Error("setting the default scope left a key behind")
+	}
+	if err := cfg.SetWorkspaceScope("claude", "sideways"); err == nil {
+		t.Error("an unknown scope was accepted")
+	}
+}
+
+// TestBindWorkspace_CanonicalizesAndGuards: the path is resolved once, at bind
+// time, and the remote is recorded as a guard beside it.
+func TestBindWorkspace_CanonicalizesAndGuards(t *testing.T) {
+	root := t.TempDir()
+	ws := filepath.Join(root, "repo")
+	if err := os.MkdirAll(ws, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	canonical, err := CanonicalWorkspacePath(ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withFakeRemote(t, map[string]string{canonical: "git.example.com/team/repo"})
+
+	cfg := &Config{}
+	if err := cfg.BindWorkspace("claude", ws, []string{"homelab-kb"}); err != nil {
+		t.Fatal(err)
+	}
+	bindings := cfg.WorkspaceBindings("claude")
+	if len(bindings) != 1 {
+		t.Fatalf("bindings = %+v, want 1", bindings)
+	}
+	if bindings[0].Path != canonical {
+		t.Errorf("path = %q, want the canonical %q", bindings[0].Path, canonical)
+	}
+	if bindings[0].Remote != "git.example.com/team/repo" {
+		t.Errorf("remote guard = %q", bindings[0].Remote)
+	}
+
+	// Re-binding the same path replaces rather than duplicating.
+	if err := cfg.BindWorkspace("claude", ws, []string{"other-kb"}); err != nil {
+		t.Fatal(err)
+	}
+	if bindings := cfg.WorkspaceBindings("claude"); len(bindings) != 1 || bindings[0].KBs[0] != "other-kb" {
+		t.Errorf("rebind produced %+v", bindings)
+	}
+
+	// A path that does not exist cannot be bound: the guard would be
+	// uncheckable from the moment it was written.
+	if err := cfg.BindWorkspace("claude", filepath.Join(root, "nope"), nil); err == nil {
+		t.Error("a non-existent directory was bound")
+	}
+}
+
+// TestBindWorkspace_EmptyKBsIsADeclaration: decision 8 — zero KBs and several
+// KBs are distinct explicit states, and neither is "every KB".
+func TestBindWorkspace_EmptyKBsIsADeclaration(t *testing.T) {
+	ws := t.TempDir()
+	withFakeRemote(t, nil)
+	cfg := &Config{KnownKBs: []string{"a", "b", "c"}}
+	if err := cfg.BindWorkspace("claude", ws, nil); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := cfg.ResolveWorkspace("claude", ws)
+	if err != nil || !ok {
+		t.Fatalf("resolve: ok=%v err=%v", ok, err)
+	}
+	if len(got.KBs) != 0 {
+		t.Errorf("a workspace bound to no KBs resolved to %v — an empty binding must never mean 'every KB'", got.KBs)
+	}
+}
+
+// TestResolveWorkspace_LongestMatchWins: a repository bound inside another
+// bound directory is its own perimeter, not the outer one's.
+func TestResolveWorkspace_LongestMatchWins(t *testing.T) {
+	root := t.TempDir()
+	outer := filepath.Join(root, "work")
+	inner := filepath.Join(outer, "dante")
+	if err := os.MkdirAll(inner, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	withFakeRemote(t, nil)
+	cfg := &Config{}
+	if err := cfg.BindWorkspace("claude", outer, []string{"general-kb"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.BindWorkspace("claude", inner, []string{"dante-kb"}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok, err := cfg.ResolveWorkspace("claude", inner)
+	if err != nil || !ok {
+		t.Fatalf("resolve inner: ok=%v err=%v", ok, err)
+	}
+	if len(got.KBs) != 1 || got.KBs[0] != "dante-kb" {
+		t.Errorf("inner workspace resolved to %v, want the inner binding", got.KBs)
+	}
+
+	got, ok, err = cfg.ResolveWorkspace("claude", outer)
+	if err != nil || !ok {
+		t.Fatalf("resolve outer: ok=%v err=%v", ok, err)
+	}
+	if got.KBs[0] != "general-kb" {
+		t.Errorf("outer workspace resolved to %v", got.KBs)
+	}
+}
+
+// TestResolveWorkspace_UnboundIsNotAnError: an unbound directory is a legal,
+// fail-closed state — it receives only the transversal bundle.
+func TestResolveWorkspace_UnboundIsNotAnError(t *testing.T) {
+	root := t.TempDir()
+	bound := filepath.Join(root, "bound")
+	elsewhere := filepath.Join(root, "elsewhere")
+	for _, d := range []string{bound, elsewhere} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	withFakeRemote(t, nil)
+	cfg := &Config{}
+	if err := cfg.BindWorkspace("claude", bound, []string{"kb"}); err != nil {
+		t.Fatal(err)
+	}
+	_, ok, err := cfg.ResolveWorkspace("claude", elsewhere)
+	if err != nil {
+		t.Fatalf("an unbound workspace is not an error: %v", err)
+	}
+	if ok {
+		t.Error("an unbound directory resolved to a binding")
+	}
+}
+
+// TestResolveWorkspace_RemoteGuardRefuses: the remote is a guard against
+// accidental reuse of a path, and a mismatch is an error — never a fallback.
+func TestResolveWorkspace_RemoteGuardRefuses(t *testing.T) {
+	ws := t.TempDir()
+	canonical, err := CanonicalWorkspacePath(ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+	remotes := map[string]string{canonical: "git.example.com/team/dante"}
+	withFakeRemote(t, remotes)
+
+	cfg := &Config{}
+	if err := cfg.BindWorkspace("claude", ws, []string{"dante-kb"}); err != nil {
+		t.Fatal(err)
+	}
+	// The directory is now a different repository.
+	remotes[canonical] = "git.example.com/team/homelab"
+
+	_, ok, err := cfg.ResolveWorkspace("claude", ws)
+	if err == nil {
+		t.Fatal("a changed remote resolved successfully")
+	}
+	if ok {
+		t.Error("ok was true alongside an error")
+	}
+	var lookupErr *WorkspaceLookupError
+	if !asWorkspaceLookupError(err, &lookupErr) {
+		t.Fatalf("error is not a WorkspaceLookupError: %T", err)
+	}
+}
+
+func asWorkspaceLookupError(err error, target **WorkspaceLookupError) bool {
+	if e, ok := err.(*WorkspaceLookupError); ok {
+		*target = e
+		return true
+	}
+	return false
+}
+
+// TestResolveWorkspace_GoneDirectoryRefuses: a binding whose directory is no
+// longer there describes something that does not exist.
+func TestResolveWorkspace_GoneDirectoryRefuses(t *testing.T) {
+	root := t.TempDir()
+	ws := filepath.Join(root, "repo")
+	if err := os.MkdirAll(ws, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	withFakeRemote(t, nil)
+	cfg := &Config{}
+	if err := cfg.BindWorkspace("claude", ws, []string{"kb"}); err != nil {
+		t.Fatal(err)
+	}
+	// Resolving from a path that still exists, for a binding that does not.
+	canonical := cfg.WorkspaceBindings("claude")[0].Path
+	if err := os.RemoveAll(ws); err != nil {
+		t.Fatal(err)
+	}
+	cfg.Workspaces["claude"][0].Path = canonical
+	if _, _, err := cfg.ResolveWorkspace("claude", canonical); err == nil {
+		t.Error("a binding whose directory is gone resolved successfully")
+	}
+}
+
+func TestUnbindWorkspace(t *testing.T) {
+	root := t.TempDir()
+	a := filepath.Join(root, "a")
+	b := filepath.Join(root, "b")
+	for _, d := range []string{a, b} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	withFakeRemote(t, nil)
+	cfg := &Config{}
+	if err := cfg.BindWorkspace("claude", a, []string{"ka"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.BindWorkspace("claude", b, []string{"kb"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.UnbindWorkspace("claude", a); err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.WorkspaceBindings("claude"); len(got) != 1 || got[0].KBs[0] != "kb" {
+		t.Errorf("after unbind: %+v", got)
+	}
+	// Unbinding what is not bound is a silent no-op.
+	if err := cfg.UnbindWorkspace("claude", a); err != nil {
+		t.Errorf("unbinding an unbound path errored: %v", err)
+	}
+	// The last one removes the provider entry entirely.
+	if err := cfg.UnbindWorkspace("claude", b); err != nil {
+		t.Fatal(err)
+	}
+	if _, present := cfg.Workspaces["claude"]; present {
+		t.Error("the provider entry survived its last binding")
+	}
+}
+
+func TestNormalizeRemote(t *testing.T) {
+	same := []string{
+		"git@git.example.com:team/repo.git",
+		"https://git.example.com/team/repo",
+		"https://git.example.com/team/repo.git/",
+		"ssh://git@git.example.com/team/repo.git",
+		"  HTTPS://Git.Example.com/Team/Repo.git  ",
+	}
+	want := NormalizeRemote(same[0])
+	if want == "" {
+		t.Fatal("normalization produced an empty guard")
+	}
+	for _, raw := range same[1:] {
+		if got := NormalizeRemote(raw); got != want {
+			t.Errorf("NormalizeRemote(%q) = %q, want %q — the same repository reached two ways must not read as a move", raw, got, want)
+		}
+	}
+	if NormalizeRemote("") != "" {
+		t.Error("an empty remote must normalize to empty, not to a guard")
+	}
+}
+
+// TestWorkspacesRoundTrip: the bindings survive a Save/Load cycle, which is
+// what makes them usable by a later `sync` in a different process.
+func TestWorkspacesRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	ws := filepath.Join(dir, "repo")
+	if err := os.MkdirAll(ws, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	canonical, _ := CanonicalWorkspacePath(ws)
+	withFakeRemote(t, map[string]string{canonical: "git.example.com/team/repo"})
+
+	cfg := Default()
+	if err := cfg.SetWorkspaceScope("claude", ScopeWorkspace); err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.BindWorkspace("claude", ws, []string{"homelab-kb"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Save(dir, cfg); err != nil {
+		t.Fatal(err)
+	}
+	reloaded, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.WorkspaceScope("claude") != ScopeWorkspace {
+		t.Error("the scope did not survive a round trip")
+	}
+	got := reloaded.WorkspaceBindings("claude")
+	if len(got) != 1 || got[0].Path != canonical || got[0].Remote != "git.example.com/team/repo" || got[0].KBs[0] != "homelab-kb" {
+		t.Errorf("bindings did not survive a round trip: %+v", got)
+	}
+}

--- a/internal/provisioning/codextrust.go
+++ b/internal/provisioning/codextrust.go
@@ -1,0 +1,75 @@
+package provisioning
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// codextrust.go (D193) — Codex ignores a project's `.codex/` layer unless the
+// project is trusted.
+//
+// That makes a Codex workspace projection the one case where writing the files
+// correctly is not the same as the projection being active. Reporting it as
+// installed would be the false-positive class D189 exists to eliminate, so the
+// projection reports itself **inactive** and says what would activate it.
+//
+// The trust record lives in the user's own `~/.codex/config.toml`, under a
+// `[projects."<path>"]` table with a `trust_level` key. Cartographer only reads
+// it: trusting a project is the user's decision and `codex` has its own prompt
+// for it.
+
+// CodexProjectTrusted reports whether codexConfigPath records workspaceDir as a
+// trusted project. A missing or unreadable config is "not trusted": absence of
+// evidence is never evidence of trust.
+//
+// The parse is deliberately narrow — it looks for the project's own table
+// header and the first trust_level in it — because this is a read of someone
+// else's file format and a full TOML parse would fail on syntax Cartographer
+// has no business rejecting.
+func CodexProjectTrusted(codexConfigPath, workspaceDir string) bool {
+	f, err := os.Open(codexConfigPath)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	want := filepath.Clean(workspaceDir)
+	inProject := false
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if strings.HasPrefix(line, "[") {
+			inProject = isCodexProjectHeader(line, want)
+			continue
+		}
+		if !inProject {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(key) != "trust_level" {
+			continue
+		}
+		v := strings.Trim(strings.TrimSpace(value), `"'`)
+		return strings.EqualFold(v, "trusted")
+	}
+	return false
+}
+
+// isCodexProjectHeader reports whether a TOML table header names this project.
+func isCodexProjectHeader(line, want string) bool {
+	inner := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
+	rest, ok := strings.CutPrefix(inner, "projects.")
+	if !ok {
+		return false
+	}
+	return filepath.Clean(strings.Trim(strings.TrimSpace(rest), `"'`)) == want
+}
+
+// CodexConfigPath is where the trust record is read from, given the client base
+// dir. It is the same file the global MCP cell writes into.
+func CodexConfigPath(baseDir string) string {
+	return filepath.Join(baseDir, ".codex", "config.toml")
+}

--- a/internal/provisioning/codextrust_test.go
+++ b/internal/provisioning/codextrust_test.go
@@ -1,0 +1,47 @@
+package provisioning
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCodexProjectTrusted: a Codex workspace projection is only active when the
+// project is trusted, and absence of evidence is never evidence of trust.
+func TestCodexProjectTrusted(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.toml")
+	ws := "/Users/someone/work/dante"
+	other := "/Users/someone/work/homelab"
+
+	// No config at all.
+	if CodexProjectTrusted(cfg, ws) {
+		t.Error("a missing config reported the project as trusted")
+	}
+
+	content := `
+model = "o3"
+
+[projects."/Users/someone/work/dante"]
+trust_level = "trusted"
+
+[projects."/Users/someone/work/homelab"]
+trust_level = "untrusted"
+`
+	if err := os.WriteFile(cfg, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !CodexProjectTrusted(cfg, ws) {
+		t.Error("a trusted project was reported as untrusted")
+	}
+	if CodexProjectTrusted(cfg, other) {
+		t.Error("an explicitly untrusted project was reported as trusted")
+	}
+	if CodexProjectTrusted(cfg, "/Users/someone/work/absent") {
+		t.Error("a project with no record was reported as trusted")
+	}
+	// A trailing separator names the same directory.
+	if !CodexProjectTrusted(cfg, ws+"/") {
+		t.Error("a trailing separator changed the answer")
+	}
+}

--- a/internal/provisioning/provisioning.go
+++ b/internal/provisioning/provisioning.go
@@ -156,6 +156,23 @@ type Lock struct {
 	// never triggers the "the server changed" report: the first sync after an
 	// upgrade must not tell every user something it cannot actually know.
 	ServerVersion string `json:"server_version,omitempty"`
+	// ProjectScope marks a lock whose managed paths were resolved through the
+	// project-local half of the destination matrix (D193). Absent — every
+	// lockfile written before D193, and every global projection — means the
+	// global half. It is persisted rather than derived, because verifying or
+	// pruning through the wrong matrix looks for the wrong paths: it would
+	// report a correctly materialized workspace as missing, and leave real
+	// files behind on a prune.
+	ProjectScope bool `json:"project_scope,omitempty"`
+}
+
+// Scope returns the destination-matrix half this lock's paths were resolved
+// through.
+func (l Lock) ScopeOf() Scope {
+	if l.ProjectScope {
+		return ScopeProject
+	}
+	return ScopeGlobal
 }
 
 // LockBaseDir returns the directory lock's managed paths are relative to:
@@ -202,6 +219,14 @@ type ApplyOptions struct {
 	// It is authorization, not verification; Signed is never mutated by it.
 	ApprovedMCP map[string]string
 	Lock        Lock // current lockfile
+
+	// Scope selects which half of the destination matrix this apply writes
+	// through (D193). The zero value is ScopeGlobal, so every existing caller
+	// keeps the destinations it had; ScopeProject materializes into a bound
+	// workspace's own project-local directories, with BaseDir set to that
+	// workspace. Nothing else about Apply changes: the diff, the trust chain,
+	// the placeholder expansion and the safepath refusals are the same.
+	Scope Scope
 
 	// SkipLockWrite, if true, computes AppliedResult.NewLock but does not persist
 	// it to <BaseDir>/LockFileName. Used by the multi-provider clients
@@ -1256,6 +1281,14 @@ func WriteLock(path string, lock Lock) error {
 // field) are automatically migrated on read by ReadLockFile.
 type LockFile struct {
 	Providers map[string]Lock `json:"providers"`
+	// Workspaces holds the per-workspace applied state (D193), keyed by the
+	// workspace's canonical path. It is a SEPARATE namespace from Providers on
+	// purpose: prune deletes every managed file its lock names, so a key that
+	// could resolve to the wrong projection would delete another workspace's
+	// files. Two maps make that mistake unrepresentable rather than unlikely.
+	// Absent — every lockfile written before D193 — means "no workspace
+	// projection", and the global one is untouched.
+	Workspaces map[string]WorkspaceLocks `json:"workspaces,omitempty"`
 }
 
 // ReadLockFile reads the multi-provider lockfile at the given path. If the file
@@ -1634,7 +1667,7 @@ func Apply(m Manifest, opts ApplyOptions) (AppliedResult, error) {
 		// doesn't support this kind — no approval unblocks it, so it goes to
 		// Unsupported (not NeedsApproval). Support is determined by destDir:
 		// add a case there for a new kind×provider.
-		destRel := destDir(a.Kind, a.Name, opts.Provider)
+		destRel := destDirScoped(a.Kind, a.Name, opts.Provider, opts.Scope)
 		if destRel == "" {
 			result.Unsupported = append(result.Unsupported, a)
 			continue
@@ -1965,7 +1998,7 @@ func wrapKBSection(name, content string) string {
 // provider's shared file, so KindCounts reports "instructions n/n" instead of
 // counting a single physical file.
 func applyInstructionsGroup(m Manifest, diff Diff, opts ApplyOptions, tracker *expansionTracker, result *AppliedResult, newManaged *[]ManagedFile, force bool) error {
-	destRel := destDir("instructions", "", opts.Provider)
+	destRel := destDirScoped("instructions", "", opts.Provider, opts.Scope)
 	if destRel == "" {
 		// Provider with no known destination for instructions: keep this handled
 		// consistently with the other kinds' unsupported/needs_approval schema,
@@ -2231,7 +2264,7 @@ func installedSubagentSentence(m Manifest, opts ApplyOptions) string {
 		if a.Kind != "agent" || !strings.HasPrefix(a.Source, "kb:") {
 			continue
 		}
-		if destDir("agent", a.Name, opts.Provider) == "" {
+		if destDirScoped("agent", a.Name, opts.Provider, opts.Scope) == "" {
 			continue
 		}
 		if !artifactAuthorized(a, opts) {

--- a/internal/provisioning/repohygiene.go
+++ b/internal/provisioning/repohygiene.go
@@ -1,0 +1,235 @@
+package provisioning
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// repohygiene.go (D193 WP5) — generated files must not dirty the repository.
+//
+// A workspace projection writes into a directory the user version-controls. Two
+// rules follow, and neither is negotiable:
+//
+//  1. Cartographer excludes **only its own untracked paths**, and it does so in
+//     `.git/info/exclude` — the per-clone, unversioned ignore file. It never
+//     edits `.gitignore`: that file is the repository's, shared with everyone
+//     who clones it, and a tool that writes there commits an opinion on behalf
+//     of a team.
+//  2. If a path Cartographer would own is already **tracked**, the sync
+//     **refuses** with an attributed error. Overwriting a tracked file destroys
+//     work that is under version control, and there is no safe silent answer.
+
+// excludeMarkerBegin/End delimit Cartographer's block in .git/info/exclude, so
+// the block can be rewritten and removed without touching anything else in a
+// file the user also writes by hand.
+const (
+	excludeMarkerBegin = "# >>> cartographer (managed) >>>"
+	excludeMarkerEnd   = "# <<< cartographer (managed) <<<"
+)
+
+// gitTrackedFn is indirected for tests: the hygiene rules must be testable in a
+// temp dir without constructing a real repository for every case.
+var gitTrackedFn = gitTrackedPaths
+
+// gitTrackedPaths returns the set of repository-relative paths git tracks under
+// dir. A directory that is not a git repository returns an empty set and no
+// error: binding a plain directory is legal, it simply has no hygiene to keep.
+func gitTrackedPaths(dir string) (map[string]bool, error) {
+	if _, err := os.Stat(filepath.Join(dir, ".git")); err != nil {
+		return map[string]bool{}, nil
+	}
+	out, err := exec.Command("git", "-C", dir, "ls-files", "-z").Output()
+	if err != nil {
+		return nil, fmt.Errorf("provisioning: list tracked files in %s: %w", dir, err)
+	}
+	tracked := map[string]bool{}
+	for _, p := range strings.Split(string(out), "\x00") {
+		if p != "" {
+			tracked[filepath.ToSlash(p)] = true
+		}
+	}
+	return tracked, nil
+}
+
+// TrackedCollisionError is the refusal of rule 2: a path the projection owns is
+// already under version control.
+type TrackedCollisionError struct {
+	Workspace string
+	Provider  string
+	Paths     []string
+}
+
+func (e *TrackedCollisionError) Error() string {
+	return fmt.Sprintf("workspace %s: %s would write to %s, which git already tracks — "+
+		"Cartographer never overwrites a versioned file. Remove or relocate it, or bind this provider to a different workspace",
+		e.Workspace, e.Provider, strings.Join(e.Paths, ", "))
+}
+
+// CheckWorkspaceHygiene reports whether any path the provider's projection owns
+// in workspaceDir is already tracked by git. It is called **before** anything is
+// written, so a refusal costs nothing.
+//
+// A shared-file destination (CLAUDE.md, AGENTS.md, opencode.json) that is
+// tracked is deliberately NOT a refusal: those are user-owned files that a
+// repository legitimately has, and Cartographer writes a marker-delimited block
+// inside them rather than owning the file — the same D57 mechanism it uses for
+// a user's settings.json. Only a path Cartographer would own **entirely** — its
+// own directories, and .mcp.json, which it writes whole — can collide.
+func CheckWorkspaceHygiene(provider, workspaceDir string, ownedPaths, blockPaths []string) error {
+	tracked, err := gitTrackedFn(workspaceDir)
+	if err != nil {
+		return err
+	}
+	if len(tracked) == 0 {
+		return nil
+	}
+	shared := map[string]bool{}
+	for _, p := range blockPaths {
+		shared[filepath.ToSlash(p)] = true
+	}
+
+	var hits []string
+	for _, owned := range ownedPaths {
+		slash := filepath.ToSlash(owned)
+		if shared[slash] {
+			continue
+		}
+		if tracked[slash] {
+			hits = append(hits, slash)
+			continue
+		}
+		// A directory Cartographer owns: any tracked file beneath it is a
+		// collision, because pruning the directory would delete it.
+		prefix := slash + "/"
+		for t := range tracked {
+			if strings.HasPrefix(t, prefix) {
+				hits = append(hits, t)
+			}
+		}
+	}
+	if len(hits) == 0 {
+		return nil
+	}
+	sort.Strings(hits)
+	return &TrackedCollisionError{Workspace: workspaceDir, Provider: provider, Paths: dedupe(hits)}
+}
+
+// EnsureWorkspaceExcluded writes Cartographer's owned paths into
+// `<workspaceDir>/.git/info/exclude`, inside its own marker block.
+//
+// It is idempotent, it never touches a line outside the block, and it never
+// touches `.gitignore`. A workspaceDir that is not a git repository is a no-op:
+// there is nothing to keep clean.
+//
+// Only paths Cartographer owns entirely are excluded. A block it writes inside
+// a user-owned file (CLAUDE.md, AGENTS.md) must NOT be excluded — that file is
+// the user's, and telling git to ignore it would hide their own edits.
+func EnsureWorkspaceExcluded(workspaceDir string, ownedPaths []string) error {
+	infoDir := filepath.Join(workspaceDir, ".git", "info")
+	if _, err := os.Stat(filepath.Join(workspaceDir, ".git")); err != nil {
+		return nil
+	}
+	if err := os.MkdirAll(infoDir, 0o755); err != nil {
+		return fmt.Errorf("provisioning: mkdir %s: %w", infoDir, err)
+	}
+	path := filepath.Join(infoDir, "exclude")
+
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("provisioning: read %s: %w", path, err)
+	}
+	kept := stripExcludeBlock(string(existing))
+
+	if len(ownedPaths) == 0 {
+		return writeExclude(path, kept, nil)
+	}
+	lines := make([]string, 0, len(ownedPaths))
+	for _, p := range ownedPaths {
+		lines = append(lines, "/"+strings.TrimPrefix(filepath.ToSlash(p), "/"))
+	}
+	sort.Strings(lines)
+	return writeExclude(path, kept, dedupe(lines))
+}
+
+// RemoveWorkspaceExclusions drops Cartographer's block entirely, for an unbind
+// or a disconnect. The rest of the file is preserved verbatim.
+func RemoveWorkspaceExclusions(workspaceDir string) error {
+	return EnsureWorkspaceExcluded(workspaceDir, nil)
+}
+
+func writeExclude(path, kept string, lines []string) error {
+	var b strings.Builder
+	b.WriteString(kept)
+	if len(lines) > 0 {
+		if kept != "" && !strings.HasSuffix(kept, "\n") {
+			b.WriteString("\n")
+		}
+		b.WriteString(excludeMarkerBegin + "\n")
+		b.WriteString("# Written by `cartographer sync`. Paths this workspace's projection owns.\n")
+		b.WriteString("# Remove the block, not the file: `cartographer workspace unbind` does it for you.\n")
+		for _, l := range lines {
+			b.WriteString(l + "\n")
+		}
+		b.WriteString(excludeMarkerEnd + "\n")
+	}
+	out := b.String()
+	if strings.TrimSpace(out) == "" {
+		// Nothing of ours and nothing of theirs: leave the file as it was
+		// rather than creating an empty one.
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return nil
+		}
+	}
+	return writeFileNoFollow(path, []byte(out), 0o644)
+}
+
+// stripExcludeBlock returns content with Cartographer's block removed, and
+// everything else byte-identical.
+func stripExcludeBlock(content string) string {
+	if !strings.Contains(content, excludeMarkerBegin) {
+		return content
+	}
+	var out []string
+	inBlock := false
+	sc := bufio.NewScanner(strings.NewReader(content))
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		switch {
+		case strings.TrimSpace(line) == excludeMarkerBegin:
+			inBlock = true
+		case strings.TrimSpace(line) == excludeMarkerEnd:
+			inBlock = false
+		case !inBlock:
+			out = append(out, line)
+		}
+	}
+	joined := strings.Join(out, "\n")
+	joined = strings.TrimRight(joined, "\n")
+	if joined == "" {
+		return ""
+	}
+	return joined + "\n"
+}
+
+func dedupe(in []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if !seen[v] {
+			seen[v] = true
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// TrackedPaths exposes the tracked-file set to the client, which needs it to
+// tell a shared file the repository owns from one Cartographer created itself:
+// the first must not be excluded, the second must.
+func TrackedPaths(dir string) (map[string]bool, error) { return gitTrackedFn(dir) }

--- a/internal/provisioning/repohygiene_test.go
+++ b/internal/provisioning/repohygiene_test.go
@@ -1,0 +1,156 @@
+package provisioning
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func withTracked(t *testing.T, tracked map[string]bool) {
+	t.Helper()
+	prev := gitTrackedFn
+	gitTrackedFn = func(string) (map[string]bool, error) { return tracked, nil }
+	t.Cleanup(func() { gitTrackedFn = prev })
+}
+
+func gitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".git", "info"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// TestEnsureWorkspaceExcluded_OwnsOnlyItsBlock: the user's own exclude lines
+// survive verbatim, the block is idempotent, and removing it leaves them.
+func TestEnsureWorkspaceExcluded_OwnsOnlyItsBlock(t *testing.T) {
+	dir := gitRepo(t)
+	path := filepath.Join(dir, ".git", "info", "exclude")
+	userLines := "# my own rules\n*.swp\nbuild/\n"
+	if err := os.WriteFile(path, []byte(userLines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	owned := []string{".claude/skills", ".claude/agents", ".mcp.json"}
+	if err := EnsureWorkspaceExcluded(dir, owned); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, path)
+	if !strings.Contains(got, "*.swp") || !strings.Contains(got, "build/") {
+		t.Errorf("the user's own exclude lines were lost:\n%s", got)
+	}
+	for _, p := range owned {
+		if !strings.Contains(got, "/"+p) {
+			t.Errorf("owned path %q was not excluded:\n%s", p, got)
+		}
+	}
+
+	// Idempotent: a second run must not stack a second block.
+	if err := EnsureWorkspaceExcluded(dir, owned); err != nil {
+		t.Fatal(err)
+	}
+	if n := strings.Count(readFile(t, path), excludeMarkerBegin); n != 1 {
+		t.Errorf("the block appears %d times after two runs, want 1", n)
+	}
+
+	// Removal takes the block and nothing else.
+	if err := RemoveWorkspaceExclusions(dir); err != nil {
+		t.Fatal(err)
+	}
+	after := readFile(t, path)
+	if strings.Contains(after, excludeMarkerBegin) || strings.Contains(after, ".claude/skills") {
+		t.Errorf("the block survived removal:\n%s", after)
+	}
+	if !strings.Contains(after, "*.swp") || !strings.Contains(after, "build/") {
+		t.Errorf("removal took the user's lines with it:\n%s", after)
+	}
+}
+
+// TestEnsureWorkspaceExcluded_NeverTouchesGitignore is the rule with the most
+// consequence: .gitignore is shared with everyone who clones the repository.
+func TestEnsureWorkspaceExcluded_NeverTouchesGitignore(t *testing.T) {
+	dir := gitRepo(t)
+	gitignore := filepath.Join(dir, ".gitignore")
+	before := "node_modules/\n"
+	if err := os.WriteFile(gitignore, []byte(before), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureWorkspaceExcluded(dir, []string{".claude/skills"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := readFile(t, gitignore); got != before {
+		t.Errorf(".gitignore was modified:\n%s", got)
+	}
+}
+
+// TestEnsureWorkspaceExcluded_NotARepoIsANoOp: a plain directory is a legal
+// workspace; it simply has no hygiene to keep.
+func TestEnsureWorkspaceExcluded_NotARepoIsANoOp(t *testing.T) {
+	dir := t.TempDir()
+	if err := EnsureWorkspaceExcluded(dir, []string{".claude/skills"}); err != nil {
+		t.Fatalf("a non-repository workspace errored: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".git")); !os.IsNotExist(err) {
+		t.Error("a .git directory was created in a plain directory")
+	}
+}
+
+// TestCheckWorkspaceHygiene_RefusesTrackedPaths: overwriting a versioned file
+// destroys work under version control, so the sync refuses instead.
+func TestCheckWorkspaceHygiene_RefusesTrackedPaths(t *testing.T) {
+	dir := t.TempDir()
+	owned := []string{".claude/skills", ".claude/agents", ".mcp.json", "CLAUDE.md"}
+	shared := []string{"CLAUDE.md"}
+
+	// Nothing tracked: nothing to refuse.
+	withTracked(t, map[string]bool{"README.md": true, "src/main.go": true})
+	if err := CheckWorkspaceHygiene("claude", dir, owned, shared); err != nil {
+		t.Fatalf("unrelated tracked files caused a refusal: %v", err)
+	}
+
+	// A file inside a directory Cartographer owns: pruning would delete it.
+	withTracked(t, map[string]bool{".claude/skills/mine/SKILL.md": true})
+	err := CheckWorkspaceHygiene("claude", dir, owned, shared)
+	if err == nil {
+		t.Fatal("a tracked file under an owned directory was accepted")
+	}
+	var collision *TrackedCollisionError
+	if !asTracked(err, &collision) {
+		t.Fatalf("error is not a TrackedCollisionError: %T", err)
+	}
+	if !strings.Contains(err.Error(), ".claude/skills/mine/SKILL.md") {
+		t.Errorf("the refusal does not name the file: %v", err)
+	}
+
+	// A whole file Cartographer owns.
+	withTracked(t, map[string]bool{".mcp.json": true})
+	if err := CheckWorkspaceHygiene("claude", dir, owned, shared); err == nil {
+		t.Error("a tracked .mcp.json was accepted")
+	}
+
+	// A user-owned file Cartographer writes a *block* into is NOT a collision:
+	// a repository legitimately has a CLAUDE.md, and the block coexists.
+	withTracked(t, map[string]bool{"CLAUDE.md": true})
+	if err := CheckWorkspaceHygiene("claude", dir, owned, shared); err != nil {
+		t.Errorf("a tracked CLAUDE.md was refused, but Cartographer only writes a block in it: %v", err)
+	}
+}
+
+func asTracked(err error, target **TrackedCollisionError) bool {
+	e, ok := err.(*TrackedCollisionError)
+	if ok {
+		*target = e
+	}
+	return ok
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}

--- a/internal/provisioning/verify.go
+++ b/internal/provisioning/verify.go
@@ -104,7 +104,7 @@ func RepairManagedHashes(lock Lock, provider configurator.Provider, baseDir stri
 		if mf.MaterializedHash != "" {
 			continue
 		}
-		rel, full, ok := managedDest(mf, provider, baseDir)
+		rel, full, ok := managedDest(mf, provider, baseDir, lock.ScopeOf())
 		if !ok {
 			// The provider does not support this kind: nothing to hash, and not
 			// an error.
@@ -191,14 +191,14 @@ func VerifyManaged(lock Lock, provider configurator.Provider, baseDir string) []
 			continue
 		}
 		seen[key] = true
-		if f, ok := verifyArtifact(mf, provider, baseDir); ok {
+		if f, ok := verifyArtifact(mf, provider, baseDir, lock.ScopeOf()); ok {
 			findings = append(findings, f)
 		}
 	}
 	return findings
 }
 
-func verifyArtifact(mf ManagedFile, provider configurator.Provider, baseDir string) (DriftFinding, bool) {
+func verifyArtifact(mf ManagedFile, provider configurator.Provider, baseDir string, scope Scope) (DriftFinding, bool) {
 	finding := DriftFinding{Kind: mf.Kind, Name: mf.Name, Path: mf.Path}
 
 	switch mf.Kind {
@@ -215,7 +215,7 @@ func verifyArtifact(mf ManagedFile, provider configurator.Provider, baseDir stri
 		return finding, true
 	}
 
-	destRel, full, ok := managedDest(mf, provider, baseDir)
+	destRel, full, ok := managedDest(mf, provider, baseDir, scope)
 	if !ok {
 		return DriftFinding{}, false
 	}
@@ -275,11 +275,11 @@ func verifyArtifact(mf ManagedFile, provider configurator.Provider, baseDir stri
 // the path relative to baseDir and the absolute one. ok is false when the
 // artifact has no destination for this provider: an unsupported kind is not
 // drift, it simply does not concern it.
-func managedDest(mf ManagedFile, provider configurator.Provider, baseDir string) (rel, full string, ok bool) {
+func managedDest(mf ManagedFile, provider configurator.Provider, baseDir string, scope Scope) (rel, full string, ok bool) {
 	rel = mf.Path
 	if mf.Kind != "agent" {
 		// skill/hook: a directory of its own.
-		if rel = destDir(mf.Kind, mf.Name, provider); rel == "" {
+		if rel = destDirScoped(mf.Kind, mf.Name, provider, scope); rel == "" {
 			return "", "", false
 		}
 	}

--- a/internal/provisioning/workspacelock_test.go
+++ b/internal/provisioning/workspacelock_test.go
@@ -1,0 +1,154 @@
+package provisioning
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func lockWith(paths ...string) Lock {
+	managed := make([]ManagedFile, 0, len(paths))
+	for _, p := range paths {
+		managed = append(managed, ManagedFile{Kind: "skill", Name: filepath.Base(p), Path: p, Source: "kb:demo"})
+	}
+	return Lock{AppliedRevision: "r1", Managed: managed}
+}
+
+// TestProjections_GlobalAndWorkspacesAreSeparate is WP3's whole point: a
+// workspace lookup can never return the global projection's entries, and a
+// global lookup can never return a workspace's, because they are different
+// maps. Prune deletes what its lock names, so the wrong key here deletes
+// someone else's files.
+func TestProjections_GlobalAndWorkspacesAreSeparate(t *testing.T) {
+	var lf LockFile
+	lf.SetProvider("claude", lockWith("global-skill/SKILL.md"))
+	lf.SetProjection(Projection{Provider: "claude", Workspace: "/w/dante"}, lockWith("dante-skill/SKILL.md"), "git.example.com/team/dante")
+	lf.SetProjection(Projection{Provider: "claude", Workspace: "/w/homelab"}, lockWith("homelab-skill/SKILL.md"), "")
+
+	global := lf.ForProjection(Projection{Provider: "claude"})
+	if len(global.Managed) != 1 || global.Managed[0].Path != "global-skill/SKILL.md" {
+		t.Fatalf("global projection = %+v", global.Managed)
+	}
+	dante := lf.ForProjection(Projection{Provider: "claude", Workspace: "/w/dante"})
+	if len(dante.Managed) != 1 || dante.Managed[0].Path != "dante-skill/SKILL.md" {
+		t.Fatalf("dante projection = %+v", dante.Managed)
+	}
+	// The base dir is the workspace, not the lockfile's directory: pruning
+	// against the wrong base dir is how the wrong files get deleted.
+	if dante.BaseDir != "/w/dante" {
+		t.Errorf("workspace lock BaseDir = %q, want the workspace path", dante.BaseDir)
+	}
+	if LockBaseDir(dante, "/home/user") != "/w/dante" {
+		t.Error("LockBaseDir did not honour the workspace base dir")
+	}
+	// A workspace that was never written resolves empty, not to the global one.
+	if got := lf.ForProjection(Projection{Provider: "claude", Workspace: "/w/nope"}); len(got.Managed) != 0 {
+		t.Errorf("an unknown workspace resolved to %+v", got.Managed)
+	}
+	if got := lf.WorkspaceRemote("/w/dante"); got != "git.example.com/team/dante" {
+		t.Errorf("workspace remote = %q", got)
+	}
+}
+
+// TestRemoveProjection_LeavesSiblingsAlone: unbinding one workspace must not
+// touch another's applied state, nor the global one.
+func TestRemoveProjection_LeavesSiblingsAlone(t *testing.T) {
+	var lf LockFile
+	lf.SetProvider("claude", lockWith("global/SKILL.md"))
+	lf.SetProjection(Projection{Provider: "claude", Workspace: "/w/a"}, lockWith("a/SKILL.md"), "")
+	lf.SetProjection(Projection{Provider: "codex", Workspace: "/w/a"}, lockWith("a-codex/SKILL.md"), "")
+	lf.SetProjection(Projection{Provider: "claude", Workspace: "/w/b"}, lockWith("b/SKILL.md"), "")
+
+	lf.RemoveProjection(Projection{Provider: "claude", Workspace: "/w/a"})
+
+	if got := lf.ForProjection(Projection{Provider: "claude", Workspace: "/w/b"}); len(got.Managed) != 1 {
+		t.Error("removing one workspace's projection emptied another's")
+	}
+	if got := lf.ForProjection(Projection{Provider: "codex", Workspace: "/w/a"}); len(got.Managed) != 1 {
+		t.Error("removing one provider's projection emptied a sibling provider's in the same workspace")
+	}
+	if got := lf.ForProjection(Projection{Provider: "claude"}); len(got.Managed) != 1 {
+		t.Error("removing a workspace projection touched the global one")
+	}
+
+	// The last provider takes the workspace entry with it: no residue to match.
+	lf.RemoveProjection(Projection{Provider: "codex", Workspace: "/w/a"})
+	if _, present := lf.Workspaces["/w/a"]; present {
+		t.Error("the workspace entry survived its last provider")
+	}
+}
+
+// TestProjections_Deterministic: status, doctor and prune iterate this, so the
+// order must not depend on map iteration.
+func TestProjections_Deterministic(t *testing.T) {
+	var lf LockFile
+	lf.SetProvider("codex", lockWith("x"))
+	lf.SetProvider("claude", lockWith("y"))
+	lf.SetProjection(Projection{Provider: "codex", Workspace: "/w/b"}, lockWith("z"), "")
+	lf.SetProjection(Projection{Provider: "claude", Workspace: "/w/a"}, lockWith("w"), "")
+
+	want := []string{"claude (global)", "codex (global)", "claude in /w/a", "codex in /w/b"}
+	for i := 0; i < 20; i++ {
+		got := lf.Projections()
+		if len(got) != len(want) {
+			t.Fatalf("projections = %d, want %d", len(got), len(want))
+		}
+		for j, p := range got {
+			if p.String() != want[j] {
+				t.Fatalf("projection[%d] = %q, want %q", j, p.String(), want[j])
+			}
+		}
+	}
+
+	only := lf.WorkspaceProjections("/w/a")
+	if len(only) != 1 || only[0].Provider != "claude" {
+		t.Errorf("WorkspaceProjections(/w/a) = %+v, want just claude", only)
+	}
+	// A sync of one workspace may touch exactly its own projections.
+	if len(lf.WorkspaceProjections("")) != 2 {
+		t.Error("the global projections are not addressable as a workspace-scoped set")
+	}
+}
+
+// TestLockFileRoundTrip_WorkspacesSurvive, and a pre-D193 lockfile still reads
+// with no workspace projection at all.
+func TestLockFileRoundTrip_WorkspacesSurvive(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lock.json")
+
+	var lf LockFile
+	lf.SetProvider("claude", lockWith("global/SKILL.md"))
+	lf.SetProjection(Projection{Provider: "claude", Workspace: "/w/dante"}, lockWith("dante/SKILL.md"), "git.example.com/team/dante")
+	if err := WriteLockFile(path, lf); err != nil {
+		t.Fatal(err)
+	}
+	back, err := ReadLockFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := back.ForProjection(Projection{Provider: "claude", Workspace: "/w/dante"}); len(got.Managed) != 1 || got.BaseDir != "/w/dante" {
+		t.Errorf("workspace projection did not survive a round trip: %+v", got)
+	}
+	if got := back.ForProjection(Projection{Provider: "claude"}); len(got.Managed) != 1 {
+		t.Errorf("global projection did not survive a round trip: %+v", got)
+	}
+	if back.WorkspaceRemote("/w/dante") != "git.example.com/team/dante" {
+		t.Error("the workspace remote guard did not survive a round trip")
+	}
+
+	// A lockfile written before D193 has no workspaces key at all, and must
+	// read as "global projection only" rather than as anything ambiguous.
+	legacy := filepath.Join(dir, "legacy.json")
+	if err := WriteLockFile(legacy, LockFile{Providers: map[string]Lock{"claude": lockWith("old/SKILL.md")}}); err != nil {
+		t.Fatal(err)
+	}
+	old, err := ReadLockFile(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(old.Workspaces) != 0 {
+		t.Errorf("a pre-D193 lockfile produced workspace projections: %+v", old.Workspaces)
+	}
+	if len(old.Projections()) != 1 || !old.Projections()[0].Global() {
+		t.Errorf("a pre-D193 lockfile did not read as global-only: %+v", old.Projections())
+	}
+}

--- a/internal/provisioning/workspacescope.go
+++ b/internal/provisioning/workspacescope.go
@@ -1,0 +1,412 @@
+package provisioning
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	"github.com/BeppeTemp/cartographer/internal/configurator"
+)
+
+// workspacescope.go (D193) — the project-local half of the kind × provider
+// matrix.
+//
+// D137 made the destinations data; this adds the third axis. A provider in
+// workspace scope materializes a bound workspace's KB artifacts into that
+// workspace's own project-local directories, and materializes **nothing**
+// KB-sourced globally (decisions 3 and 5). Cartographer's own transversal
+// bundled skills stay global (decision 4): they are not a perimeter's content.
+//
+// Sources for each cell were verified during the D193 audit and are external
+// contracts that change outside this project's release cycle — re-verify before
+// changing one, and keep the citation next to it.
+
+// Scope selects which half of the matrix a lookup reads.
+type Scope int
+
+const (
+	// ScopeGlobal is the historical destination set, under the user's home.
+	ScopeGlobal Scope = iota
+	// ScopeProject is the per-workspace destination set, under a bound
+	// workspace's own directory.
+	ScopeProject
+)
+
+// projectDestinationMatrix is destinationMatrix's project-local counterpart.
+//
+// Sources (D193 audit):
+//   - Claude Code: .claude/skills/, .claude/agents/, .claude/settings.json,
+//     .mcp.json, ./CLAUDE.md — https://code.claude.com/docs/en/skills,
+//     /memory, /sub-agents, /hooks, /mcp.
+//   - Codex: .agents/skills and .codex/{agents,hooks.json,config.toml} along
+//     cwd→repository root — https://developers.openai.com/codex/skills,
+//     /subagents, /hooks, /mcp. The project must be *trusted* or Codex ignores
+//     the .codex/ layer entirely, which is why the projection reports itself
+//     inactive there rather than claiming success (see CodexProjectTrusted).
+//   - Kiro: .kiro/skills/ (workspace wins over global) —
+//     https://kiro.dev/docs/skills/.
+//   - OpenCode: .opencode/skills, .opencode/agent, .opencode/plugins, project
+//     opencode.json and AGENTS.md — https://opencode.ai/docs/skills, /rules,
+//     /agents, /plugins.
+//
+// Two providers have **no** project-local cells at all, and say so rather than
+// pretending (decision 11): hermes renders its configuration from an Ansible
+// role and delivers skills to an inbox with no per-directory notion, and
+// antigravity documents only a global configuration root. A provider in
+// workspace scope that cannot project is reported as
+// "strict isolation unsupported", never silently degraded to the global
+// catalogue — degrading is exactly the exposure this plan exists to prevent.
+var projectDestinationMatrix = map[string]map[configurator.Provider]destination{
+	"mcp": {
+		configurator.ProviderClaudeCode: at(".mcp.json"),
+		configurator.ProviderCodex:      at(".codex", "config.toml"),
+		configurator.ProviderOpenCode:   at("opencode.json"),
+		configurator.ProviderKiro:       at(".kiro", "settings", "mcp.json"),
+		configurator.ProviderHermes:     unsupportedDest,
+		// antigravity documents a single global configuration root
+		// (~/.gemini/config); no project-local equivalent was found in the
+		// D193 audit, so the cell fails closed rather than inventing a path.
+		configurator.ProviderAntigravity: unsupportedDest,
+	},
+	"instructions": {
+		// The project root's own CLAUDE.md is the file Claude Code reads for a
+		// project; .claude/CLAUDE.md is the alternative. The root file is
+		// chosen because it is the one a repository already has, and the block
+		// is marker-delimited so it coexists with the user's own text.
+		configurator.ProviderClaudeCode:  at("CLAUDE.md"),
+		configurator.ProviderCodex:       at("AGENTS.md"),
+		configurator.ProviderOpenCode:    at("AGENTS.md"),
+		configurator.ProviderKiro:        at(".kiro", "steering", "cartographer.md"),
+		configurator.ProviderHermes:      unsupportedDest,
+		configurator.ProviderAntigravity: unsupportedDest,
+	},
+	"agent": {
+		configurator.ProviderClaudeCode: perName(".md", ".claude", "agents"),
+		configurator.ProviderCodex:      perName(".toml", ".codex", "agents"),
+		configurator.ProviderOpenCode:   perName(".md", ".opencode", "agent"),
+		// kiro: unchanged from the global cell, and for the same reason (D140):
+		// its agents are top-level personas the user selects, not delegates a
+		// main agent invokes. Kiro 3.0 may change that — #248 tracks the work
+		// and is blocked on an empirical verification. Giving it a cell here
+		// would be shipping that finding without its evidence.
+		configurator.ProviderKiro:        unsupportedDest,
+		configurator.ProviderHermes:      unsupportedDest,
+		configurator.ProviderAntigravity: unsupportedDest,
+	},
+	"hook": {
+		configurator.ProviderClaudeCode: perName("", ".claude", "hooks"),
+		configurator.ProviderCodex:      perName("", ".codex", "hooks"),
+		configurator.ProviderOpenCode:   perName("", ".opencode", "hooks"),
+		// kiro: see the "agent" cell above — same D140 reasoning, same #248.
+		configurator.ProviderKiro:        unsupportedDest,
+		configurator.ProviderHermes:      unsupportedDest,
+		configurator.ProviderAntigravity: unsupportedDest,
+	},
+	"skill": {
+		configurator.ProviderClaudeCode: perName("", ".claude", "skills"),
+		// The repository path Codex documents for skills. The global cell still
+		// points at .codex/skills for the reason D192 records; this is the
+		// target that only became reachable once a workspace scope existed.
+		configurator.ProviderCodex:       perName("", ".agents", "skills"),
+		configurator.ProviderKiro:        perName("", ".kiro", "skills"),
+		configurator.ProviderOpenCode:    perName("", ".opencode", "skills"),
+		configurator.ProviderHermes:      unsupportedDest,
+		configurator.ProviderAntigravity: unsupportedDest,
+	},
+}
+
+// matrixFor returns the destination matrix for a scope.
+func matrixFor(scope Scope) map[string]map[configurator.Provider]destination {
+	if scope == ScopeProject {
+		return projectDestinationMatrix
+	}
+	return destinationMatrix
+}
+
+// destDirScoped is destDir with the scope axis. destDir is the ScopeGlobal
+// case and keeps its signature, because every caller that has no workspace to
+// speak of is asking exactly that question.
+func destDirScoped(kind, name string, provider configurator.Provider, scope Scope) string {
+	cell, ok := matrixFor(scope)[kind][provider]
+	if !ok || cell.unsupported {
+		return ""
+	}
+	if !cell.named {
+		return filepath.Join(cell.dir...)
+	}
+	segments := append(append([]string{}, cell.dir...), name+cell.suffix)
+	return filepath.Join(append(segments, cell.tail...)...)
+}
+
+// SupportsProjectScope reports whether provider can project any artifact kind
+// into a workspace. False is an honest answer, not a degradation: a provider
+// that cannot project must be reported as unsupported rather than quietly
+// served from the global catalogue (decision 11).
+func SupportsProjectScope(provider configurator.Provider) bool {
+	for kind := range projectDestinationMatrix {
+		if cell, ok := projectDestinationMatrix[kind][provider]; ok && !cell.unsupported {
+			return true
+		}
+	}
+	return false
+}
+
+// ProjectScopeUnsupportedReason explains, for a user, why a provider cannot be
+// bound to a workspace. Empty when it can.
+func ProjectScopeUnsupportedReason(provider configurator.Provider) string {
+	if SupportsProjectScope(provider) {
+		return ""
+	}
+	switch provider {
+	case configurator.ProviderHermes:
+		return "hermes has no per-directory configuration: its MCP endpoints and instructions are rendered by its own Ansible role, and skills are delivered to a single inbox its curator owns"
+	case configurator.ProviderAntigravity:
+		return "antigravity documents only a global configuration root (~/.gemini/config); no project-local scope was found"
+	default:
+		return "this provider declares no project-local destination"
+	}
+}
+
+// ManagedProjectRoots is ManagedDestinationRoots for the project scope: the
+// directories a workspace projection owns under workspaceDir. `doctor` checks
+// them, and the repository-hygiene pass adds them to .git/info/exclude.
+func ManagedProjectRoots(provider configurator.Provider, workspaceDir string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for kind := range projectDestinationMatrix {
+		cell, ok := projectDestinationMatrix[kind][provider]
+		if !ok || cell.unsupported {
+			continue
+		}
+		rel := filepath.Join(cell.dir...)
+		if rel == "" || rel == "." {
+			continue
+		}
+		abs := filepath.Join(workspaceDir, rel)
+		if seen[abs] {
+			continue
+		}
+		seen[abs] = true
+		out = append(out, abs)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ProjectOwnedPaths returns the workspace-relative paths a projection owns for
+// provider: the per-kind roots for directory destinations, and the exact file
+// for a shared-file destination. It is what the repository-hygiene pass (WP5)
+// writes to .git/info/exclude and what the collision check consults, so it must
+// name everything the projection can create and nothing it cannot.
+func ProjectOwnedPaths(provider configurator.Provider) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, kind := range artifactKinds {
+		cell, ok := projectDestinationMatrix[kind][provider]
+		if !ok || cell.unsupported {
+			continue
+		}
+		rel := filepath.Join(cell.dir...)
+		if rel == "" || rel == "." || seen[rel] {
+			continue
+		}
+		seen[rel] = true
+		out = append(out, rel)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// validateProjectMatrix asserts the project matrix covers every kind for every
+// provider, the same completeness rule D137 imposes on the global one: a cell
+// missing by omission is indistinguishable from one unsupported on purpose,
+// and only the second is a decision.
+func validateProjectMatrix() error {
+	for _, kind := range artifactKinds {
+		row, ok := projectDestinationMatrix[kind]
+		if !ok {
+			return fmt.Errorf("provisioning: project destination matrix has no row for kind %q", kind)
+		}
+		for _, d := range configurator.Providers() {
+			if _, ok := row[d.Provider]; !ok {
+				return fmt.Errorf("provisioning: project destination matrix has no cell for %s × %s", kind, d.Provider)
+			}
+		}
+	}
+	return nil
+}
+
+// --- Lockfile: one projection, one applied state (D193 WP3) ---
+//
+// The lockfile used to be keyed by provider alone, which is exactly one
+// projection per provider. With workspaces there are many, and the danger is
+// not subtle: prune deletes every managed file the lock names, so a key that
+// resolves to the wrong projection deletes another workspace's files.
+//
+// Workspace locks therefore live in their **own namespace**, not in an extended
+// provider key space. A workspace lookup can never return the global
+// projection's entries, and a global lookup can never return a workspace's,
+// because they are different maps — the mistake is not merely unlikely, it is
+// unrepresentable.
+
+// WorkspaceLocks is one workspace's applied state, per provider.
+type WorkspaceLocks struct {
+	// Remote is the normalized git remote recorded when the workspace was
+	// bound, carried here so a prune can refuse a directory that has become a
+	// different repository since — the same guard the binding holds, checked
+	// where the deletion actually happens.
+	Remote string `json:"remote,omitempty"`
+	// Providers is keyed by provider name, exactly as LockFile.Providers is,
+	// and every Lock in it carries BaseDir = this workspace's path.
+	Providers map[string]Lock `json:"providers"`
+}
+
+// Projection identifies one applied state: a provider, and the workspace it was
+// applied into. An empty Workspace is the global projection — the historical
+// one, and the only one a provider-scoped installation has.
+type Projection struct {
+	Provider  string
+	Workspace string
+}
+
+// Global reports whether p is the global projection.
+func (p Projection) Global() bool { return p.Workspace == "" }
+
+// String renders a projection for a user-facing message.
+func (p Projection) String() string {
+	if p.Global() {
+		return p.Provider + " (global)"
+	}
+	return p.Provider + " in " + p.Workspace
+}
+
+// ForProjection returns the Lock for one projection (zero value if absent).
+func (lf LockFile) ForProjection(p Projection) Lock {
+	if p.Global() {
+		return lf.ForProvider(p.Provider)
+	}
+	ws, ok := lf.Workspaces[p.Workspace]
+	if !ok {
+		return Lock{}
+	}
+	return ws.Providers[p.Provider]
+}
+
+// SetProjection updates (or adds) one projection's Lock. A workspace lock always
+// records BaseDir: pruning or verifying against the wrong base dir deletes the
+// wrong files, and for a workspace the base dir is never the lockfile's own
+// directory.
+func (lf *LockFile) SetProjection(p Projection, lock Lock, remote string) {
+	if p.Global() {
+		lf.SetProvider(p.Provider, lock)
+		return
+	}
+	if lf.Workspaces == nil {
+		lf.Workspaces = map[string]WorkspaceLocks{}
+	}
+	ws, ok := lf.Workspaces[p.Workspace]
+	if !ok {
+		ws = WorkspaceLocks{Providers: map[string]Lock{}}
+	}
+	if ws.Providers == nil {
+		ws.Providers = map[string]Lock{}
+	}
+	if remote != "" {
+		ws.Remote = remote
+	}
+	lock.Provider = p.Provider
+	lock.BaseDir = p.Workspace
+	lock.ProjectScope = true
+	ws.Providers[p.Provider] = lock
+	lf.Workspaces[p.Workspace] = ws
+}
+
+// RemoveProjection drops one projection's applied state, and the workspace
+// entry itself once its last provider is gone — so an unbound workspace leaves
+// no residue to be matched later.
+func (lf *LockFile) RemoveProjection(p Projection) {
+	if p.Global() {
+		delete(lf.Providers, p.Provider)
+		return
+	}
+	ws, ok := lf.Workspaces[p.Workspace]
+	if !ok {
+		return
+	}
+	delete(ws.Providers, p.Provider)
+	if len(ws.Providers) == 0 {
+		delete(lf.Workspaces, p.Workspace)
+		return
+	}
+	lf.Workspaces[p.Workspace] = ws
+}
+
+// Projections lists every applied state the lockfile holds, global first and
+// then workspaces, each in a deterministic order. `status`, `doctor` and the
+// prune path iterate this rather than reaching into either map.
+func (lf LockFile) Projections() []Projection {
+	var out []Projection
+	for provider := range lf.Providers {
+		out = append(out, Projection{Provider: provider})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Provider < out[j].Provider })
+
+	workspaces := make([]string, 0, len(lf.Workspaces))
+	for ws := range lf.Workspaces {
+		workspaces = append(workspaces, ws)
+	}
+	sort.Strings(workspaces)
+	for _, ws := range workspaces {
+		providers := make([]string, 0, len(lf.Workspaces[ws].Providers))
+		for provider := range lf.Workspaces[ws].Providers {
+			providers = append(providers, provider)
+		}
+		sort.Strings(providers)
+		for _, provider := range providers {
+			out = append(out, Projection{Provider: provider, Workspace: ws})
+		}
+	}
+	return out
+}
+
+// WorkspaceProjections lists the projections of one workspace only. This is the
+// set a sync of that workspace may touch, and nothing outside it: a prune that
+// iterated more than this is the defect WP3 exists to make impossible.
+func (lf LockFile) WorkspaceProjections(workspace string) []Projection {
+	var out []Projection
+	for _, p := range lf.Projections() {
+		if p.Workspace == workspace {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// WorkspaceRemote returns the git remote recorded for a workspace's applied
+// state, empty when there is none.
+func (lf LockFile) WorkspaceRemote(workspace string) string {
+	return lf.Workspaces[workspace].Remote
+}
+
+// ProjectDestination is destDirScoped's project half, exported for the client,
+// which needs to know which paths a projection owns before it writes any.
+func ProjectDestination(kind, name string, provider configurator.Provider) string {
+	return destDirScoped(kind, name, provider, ScopeProject)
+}
+
+// FilterForProviderScoped is FilterForProvider with the scope axis: a kind the
+// provider cannot materialize **in this scope** is not missing, it simply does
+// not apply here.
+func FilterForProviderScoped(m Manifest, provider configurator.Provider, scope Scope) Manifest {
+	if scope == ScopeGlobal {
+		return FilterForProvider(m, provider)
+	}
+	var out Manifest
+	for _, a := range m.Artifacts {
+		if destDirScoped(a.Kind, a.Name, provider, scope) != "" {
+			out.Artifacts = append(out.Artifacts, a)
+		}
+	}
+	out.Revision = computeRevision(out.Artifacts)
+	return out
+}

--- a/internal/provisioning/workspacescope_test.go
+++ b/internal/provisioning/workspacescope_test.go
@@ -1,0 +1,151 @@
+package provisioning
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/BeppeTemp/cartographer/internal/configurator"
+)
+
+// TestProjectDestinationMatrixIsComplete applies D137's completeness rule to
+// the project-local half (D193): a cell missing by omission is
+// indistinguishable from one unsupported on purpose, and only the second is a
+// decision anyone made.
+func TestProjectDestinationMatrixIsComplete(t *testing.T) {
+	if err := validateProjectMatrix(); err != nil {
+		t.Fatal(err)
+	}
+	for _, kind := range artifactKinds {
+		for provider, cell := range projectDestinationMatrix[kind] {
+			if cell.unsupported {
+				continue
+			}
+			if len(cell.dir) == 0 {
+				t.Errorf("projectDestinationMatrix[%q][%q] is supported but names no path", kind, provider)
+			}
+		}
+	}
+	for kind := range projectDestinationMatrix {
+		known := false
+		for _, k := range artifactKinds {
+			if k == kind {
+				known = true
+			}
+		}
+		if !known {
+			t.Errorf("projectDestinationMatrix has a row for unknown kind %q", kind)
+		}
+	}
+}
+
+// TestProjectDestinationsAreRelativeToTheWorkspace: every project-local path
+// must stay inside the workspace. One that escaped would write a perimeter's
+// artifacts outside the directory that was bound — the whole failure this plan
+// exists to prevent, with extra steps.
+func TestProjectDestinationsAreRelativeToTheWorkspace(t *testing.T) {
+	for _, kind := range artifactKinds {
+		for provider, cell := range projectDestinationMatrix[kind] {
+			if cell.unsupported {
+				continue
+			}
+			got := destDirScoped(kind, "demo", provider, ScopeProject)
+			if got == "" {
+				t.Errorf("%s × %s: supported cell resolved to an empty path", kind, provider)
+				continue
+			}
+			if strings.HasPrefix(got, "/") || strings.HasPrefix(got, "..") {
+				t.Errorf("%s × %s resolves outside the workspace: %q", kind, provider, got)
+			}
+		}
+	}
+}
+
+// TestDestDirScoped_GlobalIsUnchanged: the scope axis is additive. destDir and
+// the global scope must agree on every cell, or an existing installation moves
+// its files on the next sync.
+func TestDestDirScoped_GlobalIsUnchanged(t *testing.T) {
+	for _, kind := range artifactKinds {
+		for _, d := range configurator.Providers() {
+			want := destDir(kind, "demo", d.Provider)
+			got := destDirScoped(kind, "demo", d.Provider, ScopeGlobal)
+			if got != want {
+				t.Errorf("%s × %s: scoped global = %q, destDir = %q", kind, d.Provider, got, want)
+			}
+		}
+	}
+}
+
+// TestProjectScopeDivergesWhereItMust spot-checks the cells the D193 audit
+// found to differ from the global ones — these are the paths the clients
+// actually read in a project, and getting one wrong ships a silent no-op.
+func TestProjectScopeDivergesWhereItMust(t *testing.T) {
+	cases := []struct {
+		kind     string
+		provider configurator.Provider
+		want     string
+	}{
+		// Codex documents the repository skills path as .agents/skills; the
+		// global cell stays .codex/skills for the reason D192 records.
+		{"skill", configurator.ProviderCodex, ".agents/skills/demo"},
+		// A project's MCP servers live in .mcp.json, not in ~/.claude.json.
+		{"mcp", configurator.ProviderClaudeCode, ".mcp.json"},
+		// The project's own instruction file, which a repository already has.
+		{"instructions", configurator.ProviderClaudeCode, "CLAUDE.md"},
+		{"instructions", configurator.ProviderCodex, "AGENTS.md"},
+		{"instructions", configurator.ProviderOpenCode, "AGENTS.md"},
+		{"skill", configurator.ProviderClaudeCode, ".claude/skills/demo"},
+		{"skill", configurator.ProviderKiro, ".kiro/skills/demo"},
+	}
+	for _, tc := range cases {
+		if got := destDirScoped(tc.kind, "demo", tc.provider, ScopeProject); got != tc.want {
+			t.Errorf("%s × %s project destination = %q, want %q", tc.kind, tc.provider, got, tc.want)
+		}
+	}
+}
+
+// TestSupportsProjectScope_FailsClosed: a provider with no project-local scope
+// says so. Decision 11 — never a false guarantee, and never a silent
+// degradation to the global catalogue, which is the exposure this plan closes.
+func TestSupportsProjectScope_FailsClosed(t *testing.T) {
+	for _, p := range []configurator.Provider{
+		configurator.ProviderClaudeCode, configurator.ProviderCodex,
+		configurator.ProviderOpenCode, configurator.ProviderKiro,
+	} {
+		if !SupportsProjectScope(p) {
+			t.Errorf("%s should support a project scope", p)
+		}
+		if r := ProjectScopeUnsupportedReason(p); r != "" {
+			t.Errorf("%s reports an unsupported reason while supporting the scope: %s", p, r)
+		}
+	}
+	for _, p := range []configurator.Provider{configurator.ProviderHermes, configurator.ProviderAntigravity} {
+		if SupportsProjectScope(p) {
+			t.Errorf("%s claims a project scope the audit did not find", p)
+		}
+		if ProjectScopeUnsupportedReason(p) == "" {
+			t.Errorf("%s cannot project and gives no reason", p)
+		}
+	}
+}
+
+// TestProjectOwnedPaths covers what the repository-hygiene pass will exclude:
+// it must name everything a projection can create, and nothing it cannot.
+func TestProjectOwnedPaths(t *testing.T) {
+	got := ProjectOwnedPaths(configurator.ProviderClaudeCode)
+	want := map[string]bool{".mcp.json": false, "CLAUDE.md": false, ".claude/agents": false, ".claude/hooks": false, ".claude/skills": false}
+	for _, p := range got {
+		if _, ok := want[p]; !ok {
+			t.Errorf("unexpected owned path %q", p)
+			continue
+		}
+		want[p] = true
+	}
+	for p, seen := range want {
+		if !seen {
+			t.Errorf("owned path %q is missing: the hygiene pass would not exclude it", p)
+		}
+	}
+	if len(ProjectOwnedPaths(configurator.ProviderHermes)) != 0 {
+		t.Error("a provider with no project scope owns paths")
+	}
+}

--- a/test/e2e/scenarios/18_workspace_projection.sh
+++ b/test/e2e/scenarios/18_workspace_projection.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# scenarios/18_workspace_projection.sh — OPERATOR scenario: workspace-scoped
+# artifact projection (D193). This is the plan's mandatory acceptance criterion,
+# and it is a scenario that CANNOT pass before the scope exists.
+#
+# The originating incident: a session working in the HomeLab perimeter activated
+# a skill belonging to the DANTE perimeter, because the provider chooses a skill
+# from name and description alone and there was one global catalogue.
+#
+# Setup: two KBs holding a skill with the SAME NAME, two workspaces, one
+# provider bound to a different KB in each.
+#
+# Verifies (operator channel only — no agent/model):
+#   1. Each workspace receives only its own KB's skill, and the bodies differ:
+#      the projection reached the right perimeter, not merely *a* file.
+#   2. Neither skill exists in the global catalogue under $HOME — decision 5.
+#   3. Cartographer's transversal bundled skills DO stay global — decision 4.
+#   4. The two workspaces are independent: unbinding one prunes only its files.
+#   5. Generated files do not dirty the repository: .git/info/exclude carries
+#      Cartographer's block, .gitignore is untouched, `git status` is clean.
+#   6. An unbound workspace is fail-closed: it receives no KB artifact at all.
+#
+# Expected environment variables: E2E_TMP_DIR, E2E_HTTP_PORT, REPO_ROOT.
+
+set -uo pipefail
+
+SCENARIO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_DIR="$(cd "${SCENARIO_DIR}/.." && pwd)"
+
+# shellcheck source=../lib/assert.sh
+source "${E2E_DIR}/lib/assert.sh"
+# shellcheck source=../lib/kb.sh
+source "${E2E_DIR}/lib/kb.sh"
+# shellcheck source=../lib/server.sh
+source "${E2E_DIR}/lib/server.sh"
+
+SCENARIO_NAME="18_workspace_projection"
+
+echo "=== Scenario ${SCENARIO_NAME} ==="
+
+DIR="${E2E_TMP_DIR}/${SCENARIO_NAME}"
+CONFIG="${DIR}/config.yaml"
+SANDBOX="${DIR}/home"
+BIN="${REPO_ROOT}/bin/cartographer"
+SERVER_URL="http://127.0.0.1:${E2E_HTTP_PORT}/mcp"
+
+DANTE_KB="${DIR}/dante-kb"
+HOMELAB_KB="${DIR}/homelab-kb"
+WS_DANTE="${DIR}/work/dante-app"
+WS_HOMELAB="${DIR}/work/homelab-infra"
+WS_UNBOUND="${DIR}/work/scratch"
+
+mkdir -p "$DIR" "$SANDBOX" "$WS_DANTE" "$WS_HOMELAB" "$WS_UNBOUND"
+kb_make "$DANTE_KB"
+kb_make "$HOMELAB_KB"
+
+# The same skill NAME in both KBs, with bodies that name their perimeter. A
+# projection that reaches the wrong KB produces a readable file, so asserting
+# existence alone would pass on the very bug this scenario exists to catch.
+write_skill() {
+    local kb="$1" marker="$2"
+    mkdir -p "${kb}/skills/new-microservice"
+    cat > "${kb}/skills/new-microservice/SKILL.md" <<SKILL
+---
+name: new-microservice
+description: Scaffold a new microservice in this perimeter.
+---
+# New microservice
+
+PERIMETER-${marker}
+SKILL
+}
+write_skill "$DANTE_KB" "DANTE"
+write_skill "$HOMELAB_KB" "HOMELAB"
+
+# Each workspace is a git repository: rule 5 is about not dirtying one.
+for ws in "$WS_DANTE" "$WS_HOMELAB" "$WS_UNBOUND"; do
+    git -C "$ws" init -q
+    git -C "$ws" config user.email e2e@example.com
+    git -C "$ws" config user.name E2E
+    printf 'node_modules/\n' > "${ws}/.gitignore"
+    printf '# project\n' > "${ws}/README.md"
+    git -C "$ws" add -A
+    git -C "$ws" commit -q -m "initial"
+done
+
+cat > "$CONFIG" <<YAML
+http: ":${E2E_HTTP_PORT}"
+init: true
+mcp:
+  tool_prefix_mode: "off"
+kbs:
+  - path: ${DANTE_KB}
+    name: dante-kb
+  - path: ${HOMELAB_KB}
+    name: homelab-kb
+YAML
+
+E2E_CONFIG="$CONFIG" server_start "${DANTE_KB},${HOMELAB_KB}"
+server_wait_health 20
+trap 'server_stop' EXIT
+
+run_client() {
+    local out="$1"; shift
+    (cd "$SANDBOX" && HOME="$SANDBOX" "$BIN" "$@") >"$out" 2>&1
+    return $?
+}
+
+echo ""
+echo "--- Phase 1: connect, then bind each workspace to its own KB ---"
+
+# Bound to ONE KB globally: that is the pre-D193 state this plan moves away
+# from, and it is also the only global state these two KBs can be in — binding
+# a single catalogue to both is refused as a collision (D171), which is phase 7.
+run_client "${DIR}/connect.log" connect claude --server-url "$SERVER_URL" --kb dante-kb --auto-trust || true
+assert_file_exists "${SANDBOX}/.claude.json"
+
+# The global catalogue holds the DANTE skill, reachable from every directory on
+# the machine — the exposure the workspace scope exists to close.
+assert_file_exists "${SANDBOX}/.claude/skills/new-microservice/SKILL.md"
+assert_file_contains "${SANDBOX}/.claude/skills/new-microservice/SKILL.md" "PERIMETER-DANTE"
+
+if run_client "${DIR}/bind-dante.log" workspace bind claude "$WS_DANTE" --kb dante-kb; then
+    _assert_pass "workspace bind claude <dante workspace> --kb dante-kb"
+else
+    _assert_fail "workspace bind failed: $(cat "${DIR}/bind-dante.log")"
+fi
+assert_file_contains "${DIR}/bind-dante.log" "workspace scope"
+
+if run_client "${DIR}/bind-homelab.log" workspace bind claude "$WS_HOMELAB" --kb homelab-kb; then
+    _assert_pass "workspace bind claude <homelab workspace> --kb homelab-kb"
+else
+    _assert_fail "workspace bind failed: $(cat "${DIR}/bind-homelab.log")"
+fi
+
+if run_client "${DIR}/sync1.log" sync; then
+    _assert_pass "sync projects both workspaces"
+else
+    _assert_fail "sync failed: $(cat "${DIR}/sync1.log")"
+fi
+
+echo ""
+echo "--- Phase 2: each workspace sees ONLY its own perimeter ---"
+
+DANTE_SKILL="${WS_DANTE}/.claude/skills/new-microservice/SKILL.md"
+HOMELAB_SKILL="${WS_HOMELAB}/.claude/skills/new-microservice/SKILL.md"
+
+assert_file_exists "$DANTE_SKILL"
+assert_file_exists "$HOMELAB_SKILL"
+assert_file_contains "$DANTE_SKILL" "PERIMETER-DANTE"
+assert_file_not_contains "$DANTE_SKILL" "PERIMETER-HOMELAB"
+assert_file_contains "$HOMELAB_SKILL" "PERIMETER-HOMELAB"
+assert_file_not_contains "$HOMELAB_SKILL" "PERIMETER-DANTE"
+
+echo ""
+echo "--- Phase 3: no KB artifact is left in the global catalogue ---"
+
+# Decision 5: nothing KB-sourced is materialized globally under workspace scope.
+assert_file_not_exists "${SANDBOX}/.claude/skills/new-microservice/SKILL.md"
+
+# Decision 4: Cartographer's own transversal bundled skills DO stay global —
+# they belong to no perimeter, and taking them away would break every session
+# that is not inside a bound workspace.
+assert_file_exists "${SANDBOX}/.claude/skills/cartographer-ops/SKILL.md"
+assert_file_not_exists "${WS_DANTE}/.claude/skills/cartographer-ops/SKILL.md"
+
+echo ""
+echo "--- Phase 4: an unbound workspace is fail-closed ---"
+
+if [[ -d "${WS_UNBOUND}/.claude/skills" ]]; then
+    _assert_fail "an unbound workspace received artifacts: $(ls "${WS_UNBOUND}/.claude/skills")"
+else
+    _assert_pass "an unbound workspace receives no KB artifact"
+fi
+
+echo ""
+echo "--- Phase 5: the repository is not dirtied ---"
+
+for ws in "$WS_DANTE" "$WS_HOMELAB"; do
+    EXCLUDE="${ws}/.git/info/exclude"
+    assert_file_exists "$EXCLUDE"
+    assert_file_contains "$EXCLUDE" "cartographer (managed)"
+    assert_file_contains "$EXCLUDE" "/.claude/skills"
+    # .gitignore is the repository's, shared with everyone who clones it.
+    assert_file_contains "${ws}/.gitignore" "node_modules/"
+    assert_file_not_contains "${ws}/.gitignore" "cartographer"
+
+    STATUS="$(git -C "$ws" status --porcelain)"
+    if [[ -z "$STATUS" ]]; then
+        _assert_pass "$(basename "$ws"): git status is clean after the projection"
+    else
+        _assert_fail "$(basename "$ws"): the projection dirtied the repository:
+${STATUS}"
+    fi
+done
+
+echo ""
+echo "--- Phase 6: the workspaces are independent ---"
+
+# The bindings persist the CANONICAL path (symlinks resolved once, at bind
+# time), which on macOS turns /var into /private/var. Compare against that.
+CANON_DANTE="$(cd "$WS_DANTE" && pwd -P)"
+CANON_HOMELAB="$(cd "$WS_HOMELAB" && pwd -P)"
+
+run_client "${DIR}/list.log" workspace list
+assert_file_contains "${DIR}/list.log" "$CANON_DANTE"
+assert_file_contains "${DIR}/list.log" "$CANON_HOMELAB"
+assert_file_contains "${DIR}/list.log" "dante-kb"
+assert_file_contains "${DIR}/list.log" "homelab-kb"
+
+run_client "${DIR}/status.log" status || true
+assert_file_contains "${DIR}/status.log" "workspace ${CANON_DANTE}"
+
+# Unbinding one workspace prunes only its files.
+if run_client "${DIR}/unbind.log" workspace unbind claude "$WS_DANTE"; then
+    _assert_pass "workspace unbind claude <dante workspace>"
+else
+    _assert_fail "workspace unbind failed: $(cat "${DIR}/unbind.log")"
+fi
+if run_client "${DIR}/sync2.log" sync; then
+    _assert_pass "sync after unbind"
+else
+    _assert_fail "sync after unbind failed: $(cat "${DIR}/sync2.log")"
+fi
+
+assert_file_not_exists "$DANTE_SKILL"
+assert_file_exists "$HOMELAB_SKILL"
+assert_file_contains "$HOMELAB_SKILL" "PERIMETER-HOMELAB"
+
+echo ""
+echo "--- Phase 7: a collision is still refused where it can actually confuse ---"
+
+# Decision 6: the same two KBs are legal in two workspaces, and NOT legal in
+# one. The check is scoped to the projection, not weakened.
+run_client "${DIR}/bind-both.log" workspace bind claude "$WS_UNBOUND" --kb dante-kb,homelab-kb
+if run_client "${DIR}/sync3.log" sync; then
+    _assert_fail "one workspace bound to two KBs with a same-named skill synced without complaint"
+else
+    _assert_pass "one workspace bound to both KBs is refused as a collision"
+fi
+assert_file_contains "${DIR}/sync3.log" "new-microservice"
+
+# The refusal protected the configuration: the other workspace is untouched.
+assert_file_exists "$HOMELAB_SKILL"
+
+echo ""
+if [[ "${E2E_FAILURES}" -eq 0 ]]; then
+    echo "[SCENARIO ${SCENARIO_NAME}] PASS"
+    exit 0
+else
+    echo "[SCENARIO ${SCENARIO_NAME}] FAIL (${E2E_FAILURES} assertion(s) failed)"
+    exit 1
+fi


### PR DESCRIPTION
Implements the plan in #247.

A session in the HomeLab perimeter activated `new-microservice`, a skill belonging to `dante-kb`. Cartographer tracks the source KB correctly everywhere it records provenance — but the provider chooses a skill from **name and description alone**, and the provenance block is in the body, read only *after* activation. D169's per-provider binding closes this for a provider dedicated to one perimeter; it cannot close it for a provider used in two, because the binding is static per provider.

**WP1 — model and persistence** (`internal/clientconfig/workspace.go`). Per-provider scope (`provider` default / `workspace`) and the workspace↔KB binding, with the canonical path resolved once at bind time and the normalized git remote recorded as a **guard** — never as a selector, since one remote has many clones. Longest-match resolution, so a repository bound inside another bound directory wins. A bound path that is gone or whose remote changed is an **error**; an unbound directory is a legal fail-closed state.

**WP2 — project-local destinations** (`internal/provisioning/workspacescope.go`). The kind × provider matrix gains a scope axis, held to D137's completeness rule. Sources cited per cell. `hermes` and `antigravity` have no project-local scope and say so — `workspace bind` refuses them rather than degrading to the global catalogue. Kiro keeps its `unsupported` agent/hook cells for the same D140 reason; #248 is blocked on its empirical verification, so giving it a cell here would ship that finding without its evidence.

**WP3 — lockfile per projection.** A **separate `workspaces` namespace**, not an extended key space: prune deletes what its lock names, so a key that *could* resolve to the wrong projection deletes another workspace's files. Two maps make that unrepresentable. Each workspace lock carries `base_dir` and a persisted `project_scope` flag — verifying through the wrong matrix looks for the wrong paths entirely.

**WP4 — collision detection scoped.** The strict merge (D171) now answers "do two KBs collide *here*". Two KBs with a same-named skill in two workspaces is legal; the same two in one workspace is still refused.

**WP5 — repository hygiene.** Only Cartographer's **own untracked** paths, only in `.git/info/exclude`, inside a marker block. Never `.gitignore`. A shared file the repository tracks is the user's (block goes inside, not excluded); one Cartographer created itself is excluded. A path it would own entirely that git tracks is a **refusal**, before anything is written.

**WP6 — CLI.** `workspace bind/unbind/list`, and `connect --workspace <repo>` so the choice can be made *before the first write* — a provider-global connect materializes every selected KB into `$HOME` first, and undoing that is a migration.

**WP7 — reporting.** `status` and `doctor` report per projection: `ok` / `gone` / `moved` / `inactive`. The last is Codex, which ignores a project's `.codex/` layer unless the project is trusted — the one case where correct files are not the same as an active projection, and reporting it as installed is the false-positive class D189 eliminates.

### The acceptance scenario earned its keep

`18_workspace_projection` is the plan's mandatory E2E — two KBs with a **same-named** skill, two git repositories, one provider bound to a different KB in each. It **failed on its first run** with three defects no unit test could see:

1. the bundled transversal skills were being copied into every workspace, multiplying `cartographer-ops` by the number of bindings;
2. a `CLAUDE.md` Cartographer created itself was left untracked, so `git status` was dirty after every sync;
3. unbinding a workspace left its projected files there forever — a later sync only iterates the *declared* projections, so nothing would ever look at them again.

All three lived in the wiring between components. The scenario now also asserts that the bodies differ (reaching the wrong KB also produces a readable file), that the global catalogue holds no KB artifact while the bundle stays, that an unbound workspace gets nothing, that `.gitignore` is untouched and `git status` clean, and that one workspace bound to both KBs is still refused.

### Invariants

D169's statement that a projection is **not an authorization boundary** is preserved and repeated in the docs — a process running as the same user can read any file. A provider in the default scope resolves to exactly one projection, byte-identical to before. The lockfile's `workspaces` key is absent in every file written before this, so nothing migrates.

`make vet && make test && make e2e` green (14/14 scenarios).

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AY3RmkHqUB1SaugB2YSGpB